### PR TITLE
Change link to getting started guide

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,7 +40,7 @@ Getting started
 
 See our `Getting started guide`_ for the basics of using GerryChain.
 
-.. _`Getting started guide`: https://gerrychain.readthedocs.io/en/latest/quickstart
+.. _`Getting started guide`: https://gerrychain.readthedocs.io/en/latest/user/quickstart.html
 
 
 Useful links


### PR DESCRIPTION
The link that was there was broken, so I found the link I think it's supposed to point to.