### PR TITLE
Bring `Graph` in line with Getting started guide; Add test for `from_file()`

### DIFF
--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -114,7 +114,7 @@ we see that the value of the ``perimeter`` attribute is itself a dictionary mapp
 the perimeter of the district.
 
 Under the hood, these attributes are computed by "updater" functions. The user can pass their own
-``updaters`` dictionary when instantiating a ``Partition``, and the values will be accessible just like
-the ``perimeter`` attribute above. For more details, see :mod:`gerrychain.updaters`.
+``updaters`` dictionary when instantiating a partition, and the values will be accessible by key using the
+same syntax as the ``perimeter`` attribute above. For more details, see :mod:`gerrychain.updaters`.
 
 .. TODO: Elections

--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -65,13 +65,13 @@ Partitioning the graph with an initial districting plan
 
 Now that we have a graph, we can partition it into districts. Our shapefile has a data
 column called ``"DISTRICT"`` assigning a district ID to each node in our adjacency graph.
-We can use this assignment to instantiate a :class:`~gerrychain.Partition` object::
+We can use this assignment to instantiate a :class:`~gerrychain.GeographicPartition` object::
 
-    from gerrychain import Partition
+    from gerrychain import GeographicPartition
 
-    initial_partition = Partition(vtds_graph, assignment="DISTRICT")
+    initial_partition = GeographicPartition(vtds_graph, assignment="DISTRICT")
 
-We set ``assignment="DISTRICT"`` to tell the :class:`~gerrychain.Partition` object to use
+We set ``assignment="DISTRICT"`` to tell the :class:`~gerrychain.GeographicPartition` object to use
 the ``"DISTRICT"`` node attribute to assign nodes into districts. The ``assignment``
 parameter could also have been a dictionary from node ID to district ID. This is useful
 when your adjacency graph and districting plan data are coming from two separate sources.

--- a/gerrychain/graph/adjacency.py
+++ b/gerrychain/graph/adjacency.py
@@ -29,6 +29,9 @@ class Adjacency(enum.Enum):
     Rook = "rook"
     Queen = "queen"
 
+    def __repr__(self):
+        return "<%s.%s>" % (self.__class__.__name__, self.name)
+
 
 class UnrecognizedAdjacencyError(Exception):
     pass

--- a/gerrychain/graph/graph.py
+++ b/gerrychain/graph/graph.py
@@ -43,6 +43,7 @@ class Graph(networkx.Graph):
         df = gp.read_file(filename)
         graph = cls.from_geodataframe(df, adjacency, reproject)
         graph.add_data(df, columns=cols_to_add)
+        return graph
 
     @classmethod
     def from_geodataframe(cls, dataframe, adjacency=Adjacency.Rook, reproject=True):
@@ -108,11 +109,14 @@ class Graph(networkx.Graph):
         column_dictionaries = df.to_dict("index")
         networkx.set_node_attributes(self, column_dictionaries)
 
-    def assignment(self, node_attribute_key):
-        """Create an assignment dictionary using an attribute of the nodes
-        of the graph. For example, if you created your graph from Census data
+    def node_attribute(self, node_attribute_key):
+        """Create a dictionary of the form ``{node: <attribute value>}`` for
+        the given attribute key, over all nodes of the graph.
+
+        This is useful for creating an assignment dictionary from an attribute
+        from a source data file. For example, if you created your graph from Census data
         and each node has a `CD` attribute that gives the congressional district
-        the node belongs to, then `graph.assignment("CD")` would return the
+        the node belongs to, then `graph.node_attribute("CD")` would return the
         desired assignment of nodes to CDs.
 
         :param graph: NetworkX graph.

--- a/gerrychain/graph/graph.py
+++ b/gerrychain/graph/graph.py
@@ -30,9 +30,19 @@ class Graph(networkx.Graph):
         return cls(g)
 
     @classmethod
-    def from_file(cls, filename, adjacency=Adjacency.Rook, cols_to_add=None, reproject=True):
+    def from_file(
+        cls, filename, adjacency=Adjacency.Rook, cols_to_add=None, reproject=True
+    ):
+        """Create a :class:`Graph` from a shapefile (or GeoPackage, or GeoJSON, or
+        any other library that :mod:`geopandas` can read. See :meth:`from_geodataframe`
+        for more details.
+
+        :param cols_to_add: (optional) The names of the columns that you want to
+            add to the graph as node attributes. By default, all columns are added.
+        """
         df = gp.read_file(filename)
-        return cls.from_geodataframe(df, adjacency, cols_to_add, reproject)
+        graph = cls.from_geodataframe(df, adjacency, reproject)
+        graph.add_data(df, columns=cols_to_add)
 
     @classmethod
     def from_geodataframe(cls, dataframe, adjacency=Adjacency.Rook, reproject=True):

--- a/gerrychain/partition/partition.py
+++ b/gerrychain/partition/partition.py
@@ -1,8 +1,7 @@
 import collections
 
 from gerrychain.graph import Graph
-from gerrychain.updaters import (compute_edge_flows, cut_edges,
-                                 flows_from_changes)
+from gerrychain.updaters import compute_edge_flows, cut_edges, flows_from_changes
 
 
 class Partition:
@@ -12,10 +11,12 @@ class Partition:
     aggregations and calculations that we want to optimize.
 
     """
-    default_updaters = {'cut_edges': cut_edges}
 
-    def __init__(self, graph=None, assignment=None, updaters=None,
-                 parent=None, flips=None):
+    default_updaters = {"cut_edges": cut_edges}
+
+    def __init__(
+        self, graph=None, assignment=None, updaters=None, parent=None, flips=None
+    ):
         """
         :param graph: Underlying graph; a NetworkX object.
         :param assignment: Dictionary assigning nodes to districts. If None,
@@ -36,7 +37,7 @@ class Partition:
         self.graph = graph
 
         if isinstance(assignment, str):
-            assignment = graph.assignment(assignment)
+            assignment = graph.node_attribute(assignment)
         elif not isinstance(assignment, dict):
             raise TypeError("Assignment must be a dict or a node attribute key")
         self.assignment = assignment


### PR DESCRIPTION
Some assumptions I was making in writing the Getting started guide were not backed up by the actual `Graph` implementation. Yikes! This pull request will fix those discrepancies, both by changing implementation and by improving documentation.

I also decided to use a dictionary comprehension instead of the `networkx.get_node_attributes` method, because NetworkX method doesn't care if values are missing (and silences errors!).