### PR TITLE
Partisan bias and partisan Gini scores

### DIFF
--- a/gerrychain/scores.py
+++ b/gerrychain/scores.py
@@ -70,9 +70,9 @@ def partisan_bias(election_results):
     :election_results: the ElectionResults to compute partisan bias against.
     :party: the party to compute partisan bias against.
     """
-    first_party  = election_results.election.parties[0]
+    first_party = election_results.election.parties[0]
     party_shares = numpy.array(election_results.percents(first_party))
-    mean_share   = numpy.mean(party_shares)
+    mean_share = numpy.mean(party_shares)
     above_mean_districts = len(party_shares[party_shares > mean_share])
     return (above_mean_districts / len(party_shares)) - 0.5
 
@@ -81,14 +81,14 @@ def partisan_gini(election_results):
     """
     Computes the partisan Gini score for the given ElectionResults.
     The partisan Gini score is defined as the area between the seats-votes
-    curve and its reflection about (.5, .5). 
+    curve and its reflection about (.5, .5).
     """
     # For two parties, the Gini score is symmetric--it does not vary by party.
     party = election_results.election.parties[0]
     
     # To find seats as a function of votes, we assume uniform partisan swing.
     # That is, if the statewide popular vote share for a party swings by some
-    # delta, the vote share for that party swings by that delta in each 
+    # delta, the vote share for that party swings by that delta in each
     # district.
     # We calculate the necessary delta to shift the district with the highest
     # vote share for the party to a vote share of 0.5.
@@ -96,16 +96,16 @@ def partisan_gini(election_results):
     # We repeat this process for the district with the second-highest vote
     # share, which gives the proportion of votes yielding 1 seat, and so on.
     overall_result = election_results.percent(party)
-    race_results   = sorted(election_results.percents(party), reverse=True)
-    seats_votes    = [overall_result - r + 0.5 for r in race_results]
+    race_results = sorted(election_results.percents(party), reverse=True)
+    seats_votes = [overall_result - r + 0.5 for r in race_results]
 
     # Apply reflection of seats-votes curve about (.5, .5)
-    reflected_sv = reversed([1-s for s in seats_votes])
+    reflected_sv = reversed([1 - s for s in seats_votes])
     # Calculate the unscaled, unsigned area between the seats-votes curve
     # and its reflection. For each possible number of seats attained, we find
     # the area of a rectangle of unit height, with a width determined by the
     # horizontal distance between the curves at that number of seats.
-    unscaled_area = sum(abs(s-r) for s,r in zip(seats_votes, reflected_sv))
+    unscaled_area = sum(abs(s - r) for s, r in zip(seats_votes, reflected_sv))
     # We divide by area by the number of seats to obtain a partisan Gini score
     # between 0 and 1.
     return unscaled_area / len(race_results)

--- a/gerrychain/scores.py
+++ b/gerrychain/scores.py
@@ -88,10 +88,12 @@ def partisan_gini(election_results):
     # delta, the vote share for that party swings by that delta in each
     # district.
     # We calculate the necessary delta to shift the district with the highest
-    # vote share for the party to a vote share of 0.5.
-    # This gives the proportion of votes yielding 0 seats to that party.
+    # vote share for the party to a vote share of 0.5. This delta, subtracted
+    # from the original popular vote share, gives the minimum popular vote
+    # share that yields 1 seat to the party.
     # We repeat this process for the district with the second-highest vote
-    # share, which gives the proportion of votes yielding 1 seat, and so on.
+    # share, which gives the minimuum popular vote share yielding 2 seats,
+    # and so on.
     overall_result = election_results.percent(party)
     race_results = sorted(election_results.percents(party), reverse=True)
     seats_votes = [overall_result - r + 0.5 for r in race_results]

--- a/gerrychain/scores.py
+++ b/gerrychain/scores.py
@@ -58,3 +58,54 @@ def wasted_votes(party1_votes, party2_votes):
         party2_waste = party2_votes - total_votes / 2
         party1_waste = party1_votes
     return party1_waste, party2_waste
+
+
+def partisan_bias(election_results):
+    """
+    Computes the partisan bias for the given ElectionResults.
+    The partisan bias is defined as the number of districts with above-mean
+    vote share by the first party divided by the total number of districts,
+    minus 1/2.
+
+    :election_results: the ElectionResults to compute partisan bias against.
+    :party: the party to compute partisan bias against.
+    """
+    first_party  = election_results.election.parties[0]
+    party_shares = numpy.array(election_results.percents(first_party))
+    mean_share   = numpy.mean(party_shares)
+    above_mean_districts = len(party_shares[party_shares > mean_share])
+    return (above_mean_districts / len(party_shares)) - 0.5
+
+
+def partisan_gini(election_results):
+    """
+    Computes the partisan Gini score for the given ElectionResults.
+    The partisan Gini score is defined as the area between the seats-votes
+    curve and its reflection about (.5, .5). 
+    """
+    # For two parties, the Gini score is symmetric--it does not vary by party.
+    party = election_results.election.parties[0]
+    
+    # To find seats as a function of votes, we assume uniform partisan swing.
+    # That is, if the statewide popular vote share for a party swings by some
+    # delta, the vote share for that party swings by that delta in each 
+    # district.
+    # We calculate the necessary delta to shift the district with the highest
+    # vote share for the party to a vote share of 0.5.
+    # This gives the proportion of votes yielding 0 seats to that party.
+    # We repeat this process for the district with the second-highest vote
+    # share, which gives the proportion of votes yielding 1 seat, and so on.
+    overall_result = election_results.percent(party)
+    race_results   = sorted(election_results.percents(party), reverse=True)
+    seats_votes    = [overall_result - r + 0.5 for r in race_results]
+
+    # Apply reflection of seats-votes curve about (.5, .5)
+    reflected_sv = reversed([1-s for s in seats_votes])
+    # Calculate the unscaled, unsigned area between the seats-votes curve
+    # and its reflection. For each possible number of seats attained, we find
+    # the area of a rectangle of unit height, with a width determined by the
+    # horizontal distance between the curves at that number of seats.
+    unscaled_area = sum(abs(s-r) for s,r in zip(seats_votes, reflected_sv))
+    # We divide by area by the number of seats to obtain a partisan Gini score
+    # between 0 and 1.
+    return unscaled_area / len(race_results)

--- a/gerrychain/scores.py
+++ b/gerrychain/scores.py
@@ -66,9 +66,6 @@ def partisan_bias(election_results):
     The partisan bias is defined as the number of districts with above-mean
     vote share by the first party divided by the total number of districts,
     minus 1/2.
-
-    :election_results: the ElectionResults to compute partisan bias against.
-    :party: the party to compute partisan bias against.
     """
     first_party = election_results.election.parties[0]
     party_shares = numpy.array(election_results.percents(first_party))

--- a/gerrychain/scores.py
+++ b/gerrychain/scores.py
@@ -92,7 +92,7 @@ def partisan_gini(election_results):
     # from the original popular vote share, gives the minimum popular vote
     # share that yields 1 seat to the party.
     # We repeat this process for the district with the second-highest vote
-    # share, which gives the minimuum popular vote share yielding 2 seats,
+    # share, which gives the minimum popular vote share yielding 2 seats,
     # and so on.
     overall_result = election_results.percent(party)
     race_results = sorted(election_results.percents(party), reverse=True)

--- a/gerrychain/scores.py
+++ b/gerrychain/scores.py
@@ -85,7 +85,7 @@ def partisan_gini(election_results):
     """
     # For two parties, the Gini score is symmetric--it does not vary by party.
     party = election_results.election.parties[0]
-    
+
     # To find seats as a function of votes, we assume uniform partisan swing.
     # That is, if the statewide popular vote share for a party swings by some
     # delta, the vote share for that party swings by that delta in each

--- a/tests/test_scores.py
+++ b/tests/test_scores.py
@@ -1,6 +1,7 @@
 import pytest
 from unittest.mock import MagicMock
-from gerrychain.scores import efficiency_gap, wasted_votes, mean_median
+from gerrychain.scores import (efficiency_gap, wasted_votes, mean_median,
+                               partisan_bias, partisan_gini)
 from gerrychain.updaters.election import ElectionResults
 
 
@@ -28,11 +29,12 @@ def test_wasted_votes(mock_election):
     assert result == [(45, 5), (40, 10), (25, 25), (45, 5), (45, 5)]
 
 
-def test_partisan_scores_point_the_same_way(mock_election):
+def test_signed_partisan_scores_point_the_same_way(mock_election):
     eg = efficiency_gap(mock_election)
     mm = mean_median(mock_election)
+    pb = partisan_bias(mock_election)
 
-    assert (eg > 0 and mm > 0) or (eg < 0 and mm < 0)
+    assert (eg > 0 and mm > 0 and pb > 0) or (eg < 0 and mm < 0 and pb < 0)
 
 
 def test_mean_median_has_right_value(mock_election):
@@ -41,8 +43,21 @@ def test_mean_median_has_right_value(mock_election):
     assert abs(mm - 0.15) < 0.00001
 
 
-def test_partisan_scores_are_positive_if_first_party_has_advantage(mock_election):
+def test_signed_partisan_scores_are_positive_if_first_party_has_advantage(mock_election):
     eg = efficiency_gap(mock_election)
     mm = mean_median(mock_election)
+    pb = partisan_bias(mock_election)
 
-    assert (eg > 0 and mm > 0)
+    assert (eg > 0 and mm > 0 and pb > 0)
+
+
+def test_partisan_bias_has_right_value(mock_election):
+    pb = partisan_bias(mock_election)
+
+    assert abs(pb - 0.1) < 0.00001
+
+
+def test_partisan_gini_has_right_value(mock_election):
+    pg = partisan_gini(mock_election)
+
+    assert abs(pg - 0.12) < 0.00001


### PR DESCRIPTION
This PR implements issue #241. It adds two new scores to `gerrychain.scores`:
- **Partisan bias.** The scoring function implements @mduchin's definition ("the number of districts with above-mean Republican share divided by the total number of districts, minus 1/2") but uses the first party of the given `ElectionResults` object rather than hardcoding the GOP. This follows the convention used by the other scoring functions.

- **Partisan Gini.** This score is rather esoteric—there seems to be little definitional information available other than #241. I referred to [these Tufts Math 19 lecture notes (pdf)](https://sites.tufts.edu/socialchoice/files/2018/01/partisan.pdf), which explain how to generate a seats-votes curve from a single election under the assumption of uniform partisan swing. The area between this curve and its reflection about (.5, .5) is calculated in accordance with @mduchin's definition of the metric. In this plot, the area of the yellow region gives the partisan Gini score:

![pa_seats_vs_votes](https://user-images.githubusercontent.com/1254427/50731529-31ec0100-1135-11e9-9484-afd3e847cea8.png)

Unit tests are included; some previously existing unit tests are updated to include the partisan bias metric. Unlike all other currently defined metrics, partisan Gini is unsigned, so it is not included in any of the existing tests related to directional checks.
