### PR TITLE
first implementation of validating node names

### DIFF
--- a/gerrychain/partition/partition.py
+++ b/gerrychain/partition/partition.py
@@ -56,7 +56,7 @@ class Partition:
         self.edge_flows = None
 
     def validate_assignment(self):
-        node_names = set(list(self.graph.nodes()))
+        node_names = set(self.graph.nodes)
         assgn_names = set([name for dist in self.assignment.parts.values() for name in dist])
         return node_names == assgn_names
 

--- a/gerrychain/partition/partition.py
+++ b/gerrychain/partition/partition.py
@@ -57,7 +57,7 @@ class Partition:
 
     def validate_assignment(self):
         node_names = set(self.graph.nodes)
-        assgn_names = set([name for dist in self.assignment.parts.values() for name in dist])
+        assgn_names = set(name for dist in self.assignment.parts.values() for name in dist)
         return node_names == assgn_names
 
     def _from_parent(self, parent, flips):

--- a/gerrychain/partition/partition.py
+++ b/gerrychain/partition/partition.py
@@ -44,7 +44,6 @@ class Partition:
         if not self.validate_assignment():
             raise NameError("Graph's nodes' names do not match the Assignment's geo units' names.")
 
-
         if updaters is None:
             updaters = dict()
         self.updaters = self.default_updaters.copy()

--- a/gerrychain/partition/partition.py
+++ b/gerrychain/partition/partition.py
@@ -41,8 +41,8 @@ class Partition:
 
         self.assignment = get_assignment(assignment, graph)
 
-         if not self.validate_assignment():
-             raise NameError("Graph's nodes' names do not match the Assignment's geo units' names.")
+        if not self.validate_assignment():
+            raise NameError("Graph's nodes' names do not match the Assignment's geo units' names.")
 
 
         if updaters is None:

--- a/gerrychain/partition/partition.py
+++ b/gerrychain/partition/partition.py
@@ -41,6 +41,10 @@ class Partition:
 
         self.assignment = get_assignment(assignment, graph)
 
+         if not self.validate_assignment():
+             raise NameError("Graph's nodes' names do not match the Assignment's geo units' names.")
+
+
         if updaters is None:
             updaters = dict()
         self.updaters = self.default_updaters.copy()
@@ -50,6 +54,11 @@ class Partition:
         self.flips = None
         self.flows = None
         self.edge_flows = None
+
+    def validate_assignment(self):
+        node_names = set(list(self.graph.nodes()))
+        assgn_names = set([name for dist in self.assignment.parts.values() for name in dist])
+        return node_names == assgn_names
 
     def _from_parent(self, parent, flips):
         self.parent = parent


### PR DESCRIPTION
Migrating discussion of Issue #280 (making sure assignments have nodes named in the same way as the graph).

Points to discuss: 

- Is the initialization of the `Partition` object the right place to do this check?
- Should the `Assignment` class implement the `collections.Mapping` stuff?
- Is `NameError` the right exception? `KeyError`? `ValueError`?