### PR TITLE
Missed case in assignment checking

### DIFF
--- a/gerrychain/partition/partition.py
+++ b/gerrychain/partition/partition.py
@@ -56,6 +56,9 @@ class Partition:
 
     def validate_assignment(self):
         node_names = set(self.graph.nodes)
+        if len(node_names) != sum(len(dist) for dist in self.assignment.parts.values()):
+            return False
+
         assgn_names = set(name for dist in self.assignment.parts.values() for name in dist)
         return node_names == assgn_names
 

--- a/tests/partition/test_partition.py
+++ b/tests/partition/test_partition.py
@@ -36,6 +36,12 @@ def test_Partition_unlabelled_vertices_raises_namerror():
     with pytest.raises(NameError):
         partition = Partition(graph, assignment, {"cut_edges": cut_edges})
 
+
+def test_Partition_validate_vertex_in_unique_district(example_partition):
+    example_partition.assignment.parts[1] = frozenset([0,1,2])
+    assert example_partition.validate_assignment() == False
+
+
 def test_Partition_knows_cut_edges_K3(example_partition):
     partition = example_partition
     assert (1, 2) in partition["cut_edges"] or (2, 1) in partition["cut_edges"]

--- a/tests/partition/test_partition.py
+++ b/tests/partition/test_partition.py
@@ -24,6 +24,18 @@ def test_Partition_can_be_flipped(example_partition):
     assert new_partition.assignment[1] == 2
 
 
+def test_Partition_misnamed_vertices_raises_namerror():
+    graph = networkx.complete_graph(3)
+    assignment = {'0': 1, '1': 1, '2': 2}
+    with pytest.raises(NameError):
+        partition = Partition(graph, assignment, {"cut_edges": cut_edges})
+
+def test_Partition_unlabelled_vertices_raises_namerror():
+    graph = networkx.complete_graph(3)
+    assignment = {0: 1, 2: 2}
+    with pytest.raises(NameError):
+        partition = Partition(graph, assignment, {"cut_edges": cut_edges})
+
 def test_Partition_knows_cut_edges_K3(example_partition):
     partition = example_partition
     assert (1, 2) in partition["cut_edges"] or (2, 1) in partition["cut_edges"]


### PR DESCRIPTION
The stuff I wrote yesterday doesn't handle the case where all of the unit names are correct, but the assignment has some unit in more than one district. This checks for that problem as well.