### PR TITLE
Some ReCom optimizations.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include versioneer.py
+include gerrychain/_version.py
+include LICENSE


### PR DESCRIPTION
Two main changes:
- When we recursively contract leaves of the tree, the leaves at step `n` must be a subset of the predecessors of the leaves at step `n-1`. So instead of scanning all the nodes to find the leaves at each step, we store the leaves in a `deque`, and add the predecessors to the back of the deque if their degree is 1 after contracting the nodes.
- Keep track of the degrees of the nodes in a dictionary, and update those values instead of actually calling `networkx.Graph.remove_node()`. This leaves the spanning tree graph intact, so we don't have to make a new copy every time we retry.

This seemed to speed things up a bit! I profiled the old version and this version splitting Chicago's precinct graph in half, and `contract_leaves_until_balanced_or_none` went from being by far the slowest part per-call to being faster than `random_spanning_tree`, which is now the main bottleneck. Interested to see if it makes a difference in practice.