### PR TITLE
Make ElectionResults.percents return a dictionary

### DIFF
--- a/gerrychain/updaters/election.py
+++ b/gerrychain/updaters/election.py
@@ -191,7 +191,7 @@ class ElectionResults:
         :return: The tuple of the percentage of votes that ``party`` received
             in each part of the partition
         """
-        return tuple(self.percents_for_party[party][race] for race in self.races)
+        return {race: self.percents_for_party[party][race] for race in self.races}
 
     def count(self, party, race=None):
         """


### PR DESCRIPTION
This makes it easier to use dataframes for election percents, since `from_dict` is now an option.