### PR TITLE
Fix autodoc and links

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -28,7 +28,7 @@ Proposals
 ---------
 
 .. automodule:: gerrychain.proposals
-   :members:
+    :members:
 
 Binary constraints
 ------------------
@@ -37,6 +37,16 @@ Binary constraints
     :members:
 
 .. autoclass:: gerrychain.constraints.Validator
+
+.. autoclass:: gerrychain.constraints.UpperBound
+
+.. autoclass:: gerrychain.constraints.LowerBound
+
+.. autoclass:: gerrychain.constraints.SelfConfiguringLowerBound
+
+.. autoclass:: gerrychain.constraints.SelfConfiguringUpperBound
+
+.. autoclass:: gerrychain.constraints.WithinPercentRangeOfBounds
 
 Updaters
 --------

--- a/gerrychain/constraints/__init__.py
+++ b/gerrychain/constraints/__init__.py
@@ -2,30 +2,29 @@
 The :mod:`gerrychain.constraints` module provides a collection of constraint
 functions and helper classes for the validation step in GerryChain.
 
-=============================== ===============================================
+==================================== ==========================================
 Helper classes
 ===============================================================================
-``Validator``                    Collection of constraints
-``Bounds``                       Bounds on numeric constraints
-``UpperBounds``                  Upper bounds on numeric constraints
-``LowerBounds``                  Lower bounds on numeric constraints
-``SelfConfiguringUpperBound``    Automatic upper bounds on numeric constraints
-``SelfConfiguringLowerBound``    Automatic lower bounds on numeric constraints
-``WithinPercentRangeOfBounds``   Percentage bounds for numeric constraints
-===============================================================================
+:class:`Validator`                    Collection of constraints
+:class:`Bounds`                       Bounds on numeric constraints
+:class:`UpperBound`                  Upper bounds on numeric constraints
+:class:`LowerBound`                  Lower bounds on numeric constraints
+:class:`SelfConfiguringUpperBound`    Automatic upper bounds on numeric constraints
+:class:`SelfConfiguringLowerBound`    Automatic lower bounds on numeric constraints
+:class:`WithinPercentRangeOfBounds`   Percentage bounds for numeric constraints
+==================================== ==========================================
 
 |
 
-================================================== ==============================================
+=================================================== =============================================
 Binary constraint functions
 =================================================================================================
-``no_worse_L1_reciprocal_polsby_popper``            Lower bounded L1-reciprocal Polsby-Popper
-``no_worse_L_minus_1_reciprocal_polsby_popper``     Lower bounded L(-1)-reciprocal Polsby-Popper
-``contiguous``                                      Districts are contiguous (with NetworkX methods)
-``contiguous_bf``                                   Districts are contiguous (with a breadth-first search)
-``single_flip_contiguous``                          Districts are contiguous (optimized for ``propose_random_flip`` proposal)
-``no_vanishing_districts``                          No districts may be completely consumed
-================================================== ==============================================
+:meth:`no_worse_L1_reciprocal_polsby_popper`            Lower bounded L1-reciprocal Polsby-Popper
+:meth:`no_worse_L_minus_1_reciprocal_polsby_popper`     Lower bounded L(-1)-reciprocal Polsby-Popper
+:meth:`contiguous`                                      Districts are contiguous (with NetworkX methods)
+:meth:`single_flip_contiguous`                          Districts are contiguous (optimized for ``propose_random_flip`` proposal)
+:meth:`no_vanishing_districts`                          No districts may be completely consumed
+=================================================== =============================================
 
 Each new step proposed to the chain is passed off to the "validator" functions
 here to determine whether or not the step is valid. If it is invalid (breaks
@@ -40,7 +39,7 @@ examples of this.
 
 from .bounds import (LowerBound, SelfConfiguringLowerBound,
                      SelfConfiguringUpperBound, UpperBound,
-                     WithinPercentRangeOfBounds)
+                     WithinPercentRangeOfBounds, Bounds)
 from .compactness import (L1_polsby_popper, L1_reciprocal_polsby_popper,
                           L2_polsby_popper, L_minus_1_polsby_popper,
                           no_worse_L1_reciprocal_polsby_popper,
@@ -50,3 +49,13 @@ from .contiguity import (contiguous, contiguous_bfs, no_more_discontiguous,
 from .validity import (Validator, districts_within_tolerance,
                        no_vanishing_districts, refuse_new_splits,
                        within_percent_of_ideal_population)
+
+__all__ = ["LowerBound", "SelfConfiguringLowerBound",
+        "SelfConfiguringUpperBound", "UpperBound",
+        "WithinPercentRangeOfBounds", "L1_polsby_popper",
+        "L1_reciprocal_polsby_popper", "L2_polsby_popper",
+        "L_minus_1_polsby_popper", "no_worse_L1_reciprocal_polsby_popper",
+        "no_worse_L_minus_1_polsby_popper", "contiguous", "contiguous_bfs",
+        "no_more_discontiguous", "single_flip_contiguous", "Validator",
+        "districts_within_tolerance", "no_vanishing_districts",
+        "refuse_new_splits", "within_percent_of_ideal_population", "Bounds"]

--- a/gerrychain/graph/graph.py
+++ b/gerrychain/graph/graph.py
@@ -16,6 +16,7 @@ class Graph(networkx.Graph):
 
     We have added some classmethods to help construct graphs from shapefiles, and
     to save and load graphs as JSON files.
+
     """
 
     def __repr__(self):
@@ -36,12 +37,13 @@ class Graph(networkx.Graph):
 
     def to_json(self, json_file, *, include_geometries_as_geojson=False):
         """Save a graph to a JSON file in the NetworkX json_graph format.
+
         :param json_file: Path to target JSON file.
-        :param bool include_geometry_as_geojson: (optional) Whether to include any
-            :mod:`shapely` geometry objects encountered in the graph's node attributes
-            as GeoJSON. The default (``False``) behavior is to remove all geometry
-            objects because they are not serializable. Including the GeoJSON will result
-            in a much larger JSON file.
+        :param bool include_geometry_as_geojson: (optional) Whether to include
+            any :mod:`shapely` geometry objects encountered in the graph's node
+            attributes as GeoJSON. The default (``False``) behavior is to remove
+            all geometry objects because they are not serializable. Including the
+            GeoJSON will result in a much larger JSON file.
         """
         data = json_graph.adjacency_data(self)
 

--- a/gerrychain/partition/partition.py
+++ b/gerrychain/partition/partition.py
@@ -117,7 +117,7 @@ class Partition:
         :param geometries: A :class:`geopandas.GeoDataFrame` or :class:`geopandas.GeoSeries`
             holding the geometries to use for plotting. Its :class:`~pandas.Index` should match
             the node labels of the partition's underlying :class:`~gerrychain.Graph`.
-        :param **kwargs: Additional arguments to pass to :meth:`geopandas.GeoDataFrame.plot`
+        :param `**kwargs`: Additional arguments to pass to :meth:`geopandas.GeoDataFrame.plot`
             to adjust the plot.
         """
         if geometries is None:

--- a/gerrychain/proposals/__init__.py
+++ b/gerrychain/proposals/__init__.py
@@ -1,3 +1,5 @@
 from .proposals import *
 from .tree_proposals import recom
 from .spectral_proposals import spectral_recom
+
+__all__ = ["recom", "spectral_recom", "propose_chunk_flip", "propose_random_flip"]


### PR DESCRIPTION
- Add `__all__` to `gerrychain.proposals`, ensuring that autodoc actually does what it should.

- Modify "Binary constraints" section to link to relevant classes and methods.