### PR TITLE
Built-in updaters

### DIFF
--- a/gerrychain/partition/partition.py
+++ b/gerrychain/partition/partition.py
@@ -49,7 +49,7 @@ class Partition:
 
         if updaters is None:
             updaters = dict()
-        
+
         self.updaters = self.default_updaters.copy()
         self.updaters.update(updaters)
 

--- a/gerrychain/partition/partition.py
+++ b/gerrychain/partition/partition.py
@@ -6,6 +6,7 @@ from ..graph import Graph
 from ..updaters import compute_edge_flows, flows_from_changes
 from .assignment import get_assignment
 from .subgraphs import SubgraphView
+from ..updaters import cut_edges
 
 
 class Partition:
@@ -15,7 +16,9 @@ class Partition:
     aggregations and calculations that we want to optimize.
     """
 
-    default_updaters = {}
+    default_updaters = {
+        "cut_edges": cut_edges
+    }
 
     def __init__(
         self, graph=None, assignment=None, updaters=None, parent=None, flips=None
@@ -46,6 +49,7 @@ class Partition:
 
         if updaters is None:
             updaters = dict()
+        
         self.updaters = self.default_updaters.copy()
         self.updaters.update(updaters)
 

--- a/tests/partition/test_partition.py
+++ b/tests/partition/test_partition.py
@@ -143,5 +143,10 @@ def test_repr(example_partition):
 def test_partition_has_default_updaters(example_partition):
     partition = example_partition
     default_updaters = partition.default_updaters
-    assert default_updaters.get("cut_edges", None) is not None
-    assert partition["cut_edges"] == cut_edges(partition)
+    should_have_updaters = {
+        "cut_edges": cut_edges
+    }
+
+    for updater in should_have_updaters:
+        assert default_updaters.get(updater, None) is not None
+        assert should_have_updaters[updater](partition) == partition[updater]

--- a/tests/partition/test_partition.py
+++ b/tests/partition/test_partition.py
@@ -137,6 +137,11 @@ def districtr_plan_file():
             json.dump(districtr_plan, f)
         yield filename
 
-
 def test_repr(example_partition):
     assert repr(example_partition) == "<Partition [2 parts]>"
+
+def test_partition_has_default_updaters(example_partition):
+    partition = example_partition
+    default_updaters = partition.default_updaters
+    assert default_updaters.get("cut_edges", None) is not None
+    assert partition["cut_edges"] == cut_edges(partition)


### PR DESCRIPTION
Adds the `cut_edges` updater to the `Partition` class by default. In addition to this being an ease-of-use feature, it fixes #314. Furthermore, this allows for us to easily add default updaters in the future.