### PR TITLE
Allow NumPy booleans as constraint return values

### DIFF
--- a/gerrychain/constraints/validity.py
+++ b/gerrychain/constraints/validity.py
@@ -1,5 +1,6 @@
 from ..updaters import CountySplit
 from .bounds import Bounds
+import numpy
 
 
 class Validator:
@@ -31,6 +32,10 @@ class Validator:
         # check each constraint function and fail when a constraint test fails
         for constraint in self.constraints:
             is_valid = constraint(partition)
+            # Coerce NumPy booleans
+            if isinstance(is_valid, numpy.bool_):
+                is_valid = bool(is_valid)
+
             if is_valid is False:
                 return False
             elif is_valid is True:

--- a/tests/constraints/test_validity.py
+++ b/tests/constraints/test_validity.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock
 
 import networkx as nx
+import numpy
 import pytest
 
 from gerrychain.constraints import (SelfConfiguringLowerBound, Validator,
@@ -138,6 +139,17 @@ def test_validator_raises_TypeError_if_constraint_returns_non_boolean():
 
     with pytest.raises(TypeError):
         validator(mock_partition)
+
+
+def test_validator_accepts_numpy_booleans():
+    mock_partition = MagicMock()
+
+    mock_constraint = MagicMock()
+    mock_constraint.return_value = numpy.bool_(True)
+    mock_constraint.__name__ = "mock_constraint"
+
+    is_valid = Validator([mock_constraint])
+    assert is_valid(mock_partition)
 
 
 def test_no_vanishing_districts_works():


### PR DESCRIPTION
I've run into the following error several times over the past few weeks when trying to run a chain with the `within_percent_of_ideal_population` constraint, which returns a `Bounds` object:

```
Traceback (most recent call last):
  File "minimal_example.py", line 44, in <module>
    total_steps=100
  File "<...>/GerryChain/gerrychain/chain.py", line 37, in __init__
    if not is_valid(initial_state):
  File "<...>/GerryChain/gerrychain/constraints/validity.py", line 44, in __call__
    "Constraint {} returned a non-boolean.".format(repr(constraint))
TypeError: Constraint <gerrychain.constraints.bounds.Bounds object at 0x115c94358> returned a non-boolean.
```
This error seems to occur when the population bounds stored in the `Bounds` object are NumPy floats rather than native Python floats. This causes `Bounds.__call__` to return a `np.bool_` object rather than a native Python `bool`. This in turn breaks the constraint-checking logic in `Validator`, which verifies that the values returned by each constraint are either `True` or `False` [using the identity comparison keyword (`is`)](https://docs.python.org/3/reference/expressions.html#is-not). This is essentially a strict type-checking mechanism—rather than simply checking that the values returned by each constraint are "truthy," boolean return values are enforced. While [PEP 8 recommends against this pattern in normal circumstances](https://www.python.org/dev/peps/pep-0008/#function-annotations), such type enforcement is clearly desired here, as evidenced by a unit test that explicitly verifies this behavior. 🙂

The identity comparison pattern [breaks when a `np.bool_`, rather than a `bool`, is returned](https://github.com/numpy/numpy/issues/7913) by a constraint. The easiest way to fix this without removing the strict type-checking behavior is coercing `np.bool_` values into `bool` values. This PR implements this (unit test included).