### PR TITLE
Add default assignment to Partition

### DIFF
--- a/gerrychain/partition/partition.py
+++ b/gerrychain/partition/partition.py
@@ -42,6 +42,9 @@ class Partition:
     def _first_time(self, graph, assignment, updaters):
         self.graph = graph
 
+        if assignment == None:
+            assignment = {node : 0 for node in set(graph)}
+
         self.assignment = get_assignment(assignment, graph)
 
         if set(self.assignment) != set(graph):


### PR DESCRIPTION
This addresses issue #326 and assigns all nodes to district 0 if `Partition` is constructed with `assignment=None`. 