### PR TITLE
update docs to use json - fixes errors

### DIFF
--- a/docs/user/partitions.md
+++ b/docs/user/partitions.md
@@ -10,22 +10,27 @@ GerryChain `Partition` object.
 ```
 
 We'll use our
-[Pennsylvania VTD shapefile](https://github.com/mggg-states/PA-shapefiles) to
+[Pennsylvania VTD json]( https://github.com/mggg/GerryChain/blob/master/docs/user/PA_VTDs.json) to
 create the graph we'll use in these examples.
 
+```python
+graph = Graph.from_json("./PA_VTDs.json")
+```
+
+<!--
 ```python
 >>> df = geopandas.read_file("https://github.com/mggg-states/PA-shapefiles/raw/master/PA/PA_VTD.zip")
 >>> df.set_index("GEOID10", inplace=True)
 >>> graph = Graph.from_geodataframe(df)
 >>> graph.add_data(df)
 ```
-
+-->
 ## Creating a partition
 
 Here is how you can create a Partition:
 
 ```python
->>> partition = Partition(graph, "2011_PLA_1", {"cut_edges": cut_edges})
+>>> partition = Partition(graph, "CD_2011", {"cut_edges": cut_edges})
 ```
 
 The `Partition` class takes three arguments to create a Partition:

--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -15,12 +15,12 @@ What you'll need
 Before we can start running Markov chains, you'll need to:
 
 * Install ``gerrychain`` from PyPI by running ``pip install gerrychain`` in a terminal.
-* Download and unzip MGGG's `shapefile of Pennsylvania's VTDs`_ from GitHub.
+* Download MGGG's `json of Pennsylvania's VTDs`_ from GitHub.
 * Open your preferred Python environment (e.g. JupyterLab, IPython, or a ``.py`` file
-  in your favorite editor) in the directory containing the ``PA_VTD.shp`` file
-  from the ``.zip`` that you downloaded and unzipped.
+  in your favorite editor) in the directory containing the ``PA_VTDs.json`` file
+  that you downloaded.
 
-.. _`shapefile of Pennsylvania's VTDs`: https://github.com/mggg-states/PA-shapefiles/blob/master/PA/PA_VTD.zip
+.. _`json of Pennsylvania's VTDs`: https://github.com/mggg/GerryChain/blob/master/docs/user/PA_VTDs.json
 
 .. TODO: conda instructions
 
@@ -35,24 +35,24 @@ will be the initial state of our Markov chain. ::
     from gerrychain import Graph, Partition, Election
     from gerrychain.updaters import Tally, cut_edges
 
-    graph = Graph.from_file("./PA_VTD.shp")
+    graph = Graph.from_json("./PA_VTDs.json")
 
     election = Election("SEN12", {"Dem": "USS12D", "Rep": "USS12R"})
 
     initial_partition = Partition(
         graph,
-        assignment="2011_PLA_1",
+        assignment="CD_2011",
         updaters={
             "cut_edges": cut_edges,
-            "population": Tally("TOT_POP", alias="population"),
+            "population": Tally("TOTPOP", alias="population"),
             "SEN12": election
         }
     )
 
 Here's what's happening in this code block.
 
-The :meth:`Graph.from_file() <gerrychain.Graph.from_file>` classmethod creates a
-:class:`~gerrychain.Graph` of the precincts in our shapefile. By default, this method
+The :meth:`Graph.from_json() <gerrychain.Graph.from_json>` classmethod creates a
+:class:`~gerrychain.Graph` of the precincts. By default, this method
 copies all of the data columns from the shapefile's attribute table to the ``graph`` object
 as node attributes. The contents of this particular shapefile's attribute table are
 summarized in the `mggg-states/PA-shapefiles <https://github.com/mggg-states/PA-shapefiles#metadata>`_
@@ -71,11 +71,11 @@ takes three arguments:
 :graph: A graph.
 :assignment: An assignment of the nodes of the graph into parts of the partition. This can be either
     a dictionary mapping node IDs to part IDs, or the string key of a node attribute that holds
-    each node's assignment. In this example we've written ``assignment="2011_PLA_1"`` to tell the :class:`~gerrychain.Partition`
-    to assign nodes by their ``"2011_PLA_1"`` attribute that we copied from the shapefile. This attributes holds the
+    each node's assignment. In this example we've written ``assignment="CD_2011"`` to tell the :class:`~gerrychain.Partition`
+    to assign nodes by their ``"CD_2011"`` attribute that we copied from the shapefile. This attributes holds the
     assignments of precincts to congressional districts from the 2010 redistricting cycle.
 :updaters: An optional dictionary of "updater" functions. Here we've provided an updater named ``"population"`` that
-    computes the total population of each district in the partition, based on the ``"TOT_POP"`` node attribute
+    computes the total population of each district in the partition, based on the ``"TOTPOP"`` node attribute
     from our shapefile, and a "SEN12" updater that will output the election results for the ``election`` that we
     set up. We've also provided a ``cut_edges`` updater. This returns all of the edges in the graph
     that cross from one part to another, and is used by ``propose_random_flip`` to find a random boundary node to

--- a/docs/user/recom.rst
+++ b/docs/user/recom.rst
@@ -37,9 +37,9 @@ The first step is to import everything we'll need::
 Setting up the initial districting plan
 =======================================
 
-We'll create our graph using the Pennsylvania shapefile on MGGG-States::
+We'll create our graph using the Pennsylvania shapefile from MGGG-States (download the .json `here`_ if you didn't start with the Getting started with GerryChain guide)::
 
-    graph = Graph.from_file("https://github.com/mggg-states/PA-shapefiles/blob/master/PA/PA_VTD.zip?raw=true")
+    graph = Graph.from_json("./PA_VTDs.json")
 
 We configure :class:`~gerrychain.Election` objects representing some of the election
 data from our shapefile. ::
@@ -54,6 +54,7 @@ data from our shapefile. ::
     
 
 .. _Pennsylvania shapefile: https://github.com/mggg-states/PA-shapefiles/
+.. _`here`: https://github.com/mggg/GerryChain/blob/master/docs/user/PA_VTDs.json 
 
 Configuring our updaters
 ------------------------
@@ -62,7 +63,7 @@ We want to set up updaters for everything we want to compute for each plan in th
     
     # Population updater, for computing how close to equality the district
     # populations are. "TOT_POP" is the population column from our shapefile.
-    my_updaters = {"population": updaters.Tally("TOT_POP", alias="population")}
+    my_updaters = {"population": updaters.Tally("TOTPOP", alias="population")}
     
     # Election updaters, for computing election results using the vote totals
     # from our shapefile.
@@ -75,7 +76,7 @@ Instantiating the partition
 
 We can now instantiate the initial state of our Markov chain, using the 2011 districting plan::
 
-    initial_partition = GeographicPartition(graph, assignment="2011_PLA_1", updaters=my_updaters)
+    initial_partition = GeographicPartition(graph, assignment="CD_2011", updaters=my_updaters)
     
 :class:`~gerrychain.GeographicPartition` comes with built-in ``area`` and ``perimeter`` updaters.
 We do not use them here, but they would allow us to compute compactness scores like Polsby-Popper
@@ -98,7 +99,7 @@ before we can use it as our proposal function. ::
     # We use functools.partial to bind the extra parameters (pop_col, pop_target, epsilon, node_repeats)
     # of the recom proposal.
     proposal = partial(recom,
-                       pop_col="TOT_POP",
+                       pop_col="TOTPOP",
                        pop_target=ideal_population,
                        epsilon=0.02,
                        node_repeats=2


### PR DESCRIPTION
Updates at MGGG-states caused the original quickstart doc code to fail. This replaces that shapefile with a json throughout for maintainability purposes. 