### PR TITLE
Fix errors in unit tests

### DIFF
--- a/gerrychain/updaters/locality_split_scores.py
+++ b/gerrychain/updaters/locality_split_scores.py
@@ -112,7 +112,7 @@ class LocalitySplits:
 
                 pop = 0
                 for n in sg.nodes():
-                    pop += sg.node[n][self.pop_col]
+                    pop += sg.nodes[n][self.pop_col]
 
                 allowed_pieces[loc] = math.ceil(pop / (totpop / num_districts))
             self.allowed_pieces = allowed_pieces

--- a/tests/partition/test_partition.py
+++ b/tests/partition/test_partition.py
@@ -47,8 +47,8 @@ def example_geographic_partition():
     graph = networkx.complete_graph(3)
     assignment = {0: 1, 1: 1, 2: 2}
     for node in graph.nodes:
-        graph.node[node]["boundary_node"] = False
-        graph.node[node]["area"] = 1
+        graph.nodes[node]["boundary_node"] = False
+        graph.nodes[node]["area"] = 1
     for edge in graph.edges:
         graph.edges[edge]["shared_perim"] = 1
     return GeographicPartition(graph, assignment, None, None, None)

--- a/tests/test_make_graph.py
+++ b/tests/test_make_graph.py
@@ -218,7 +218,7 @@ def test_graph_warns_for_islands():
 
 
 def test_graph_raises_if_crs_is_missing_when_reprojecting(geodataframe):
-    del geodataframe.crs
+    geodataframe.crs = None
 
     with pytest.raises(ValueError):
         Graph.from_geodataframe(geodataframe, reproject=True)


### PR DESCRIPTION
Addressed issues related to the 3 failing and 1 error when running unit tests.

The first major group of errors had to do with accessing the deprecated `node` property, which is now `nodes`.  The second error related to a unit test attempting to delete the `crs` property of a `geodataframe` object. This was solved by setting the property to `None` which should simulate the same failure behavior. 

Please let me know if you have any questions or recommendations on modifications to this PR. 