### PR TITLE
Fix error message when id col is missing from graph

### DIFF
--- a/gerrychain/partition/partition.py
+++ b/gerrychain/partition/partition.py
@@ -168,8 +168,9 @@ class Partition:
             node_to_id = {node: str(graph.nodes[node][id_column_key]) for node in graph}
         except KeyError:
             raise TypeError(
-                "The provided graph is missing the {} column, which is "
-                "needed to match the Districtr assignment to the nodes of the graph."
+                "The provided graph is missing the {} column, which is \
+                needed to match the Districtr assignment to the nodes of the graph."
+                .format(id_column_key)
             )
 
         assignment = {node: districtr_assignment[node_to_id[node]] for node in graph}


### PR DESCRIPTION
Currently it prints out "The provided graph is missing the {} column"

I ran into this error when I uploaded a dual graph without the rest of its columns

Merged, this should print out the name of the ID column