### PR TITLE
Fix key error on contraction

### DIFF
--- a/gerrychain/tree.py
+++ b/gerrychain/tree.py
@@ -16,12 +16,19 @@ def successors(h, root):
 def random_spanning_tree(graph):
     """ Builds a spanning tree chosen by Kruskal's method using random weights.
         :param graph: Networkx Graph
+
+        Important Note:
+        The key is specifically labelled "random_weight" instead of the previously
+        used "weight". Turns out that networkx uses the "weight" keyword for other
+        operations, like when computing the laplacian or the adjacency matrix.
+        This meant that the laplacian would change for the graph step to step,
+        something that we do not intend!!
     """
     for edge in graph.edges:
-        graph.edges[edge]["weight"] = random.random()
+        graph.edges[edge]["random_weight"] = random.random()
 
     spanning_tree = tree.maximum_spanning_tree(
-        graph, algorithm="kruskal", weight="weight"
+        graph, algorithm="kruskal", weight="random_weight"
     )
     return spanning_tree
 


### PR DESCRIPTION
There is an an unknown `KeyError` bug that appears from the contraction function. The current fix is to change the default to be the memoization method of finding balanced cut edges in a spanning tree.

This isn't necessarily a hotfix, because the intention was to move to this memoization function anyway because of its faster performance. However, this bug did urge this merge in earlier than I intended it to.

Opened that bug as #352 