### PR TITLE
Add Support for Multi-Member ReCom

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,7 @@ jobs:
             conda config --set always_yes yes --set auto_update_conda false
 
             # install dependencies in conda env
+            conda install python=3.8
             conda install pytest pytest-cov
             conda install codecov
             python setup.py install

--- a/gerrychain/__init__.py
+++ b/gerrychain/__init__.py
@@ -1,7 +1,7 @@
 from ._version import get_versions
 from .chain import MarkovChain
 from .graph import Graph
-from .partition import GeographicPartition, Partition
+from .partition import GeographicPartition, Partition, MultiMemberPartition
 from .updaters.election import Election
 
 __version__ = get_versions()['version']

--- a/gerrychain/constraints/__init__.py
+++ b/gerrychain/constraints/__init__.py
@@ -48,7 +48,8 @@ from .contiguity import (contiguous, contiguous_bfs, no_more_discontiguous,
                          single_flip_contiguous)
 from .validity import (Validator, districts_within_tolerance,
                        no_vanishing_districts, refuse_new_splits,
-                       within_percent_of_ideal_population)
+                       within_percent_of_ideal_population,
+                       within_percent_of_ideal_population_per_representative)
 
 __all__ = ["LowerBound", "SelfConfiguringLowerBound",
         "SelfConfiguringUpperBound", "UpperBound",
@@ -58,4 +59,5 @@ __all__ = ["LowerBound", "SelfConfiguringLowerBound",
         "no_worse_L_minus_1_polsby_popper", "contiguous", "contiguous_bfs",
         "no_more_discontiguous", "single_flip_contiguous", "Validator",
         "districts_within_tolerance", "no_vanishing_districts",
-        "refuse_new_splits", "within_percent_of_ideal_population", "Bounds"]
+        "refuse_new_splits", "within_percent_of_ideal_population",
+        "within_percent_of_ideal_population_per_representative", "Bounds"]

--- a/gerrychain/constraints/validity.py
+++ b/gerrychain/constraints/validity.py
@@ -75,6 +75,32 @@ def within_percent_of_ideal_population(
 
     return Bounds(population, bounds=bounds)
 
+def within_percent_of_ideal_population_per_representative(
+    initial_partition, percent=0.01, pop_key="population"
+):
+    """Require that all districts are within a certain percent of "ideal" (i.e.,
+    uniform) population per representative.
+
+    Ideal population is defined as "total population / number of representatives."
+
+    :param initial_partition: Starting MultiMemberPartition from which to compute district 
+        information.
+    :param percent: (optional) Allowed percentage deviation. Default is 1%.
+    :param pop_key: (optional) The name of the population
+        :class:`Tally <gerrychain.updaters.Tally>`. Default is ``"population"``.
+    :return: A :class:`.Bounds` constraint on the population attribute identified
+        by ``pop_key``.
+    """
+
+    def population_per_rep(partition):
+        return [v / partition.magnitudes[k] for k, v in partition[pop_key].items()]
+
+    number_of_representatives = initial_partition.number_of_representatives
+    total_population = sum(initial_partition[pop_key].values())
+    ideal_population = total_population / number_of_representatives
+    bounds = ((1 - percent) * ideal_population, (1 + percent) * ideal_population)
+
+    return Bounds(population_per_rep, bounds=bounds)
 
 def deviation_from_ideal(partition, attribute="population"):
     """Computes the deviation of the given ``attribute`` from exact equality

--- a/gerrychain/constraints/validity.py
+++ b/gerrychain/constraints/validity.py
@@ -75,6 +75,7 @@ def within_percent_of_ideal_population(
 
     return Bounds(population, bounds=bounds)
 
+
 def within_percent_of_ideal_population_per_representative(
     initial_partition, percent=0.01, pop_key="population"
 ):
@@ -83,7 +84,7 @@ def within_percent_of_ideal_population_per_representative(
 
     Ideal population is defined as "total population / number of representatives."
 
-    :param initial_partition: Starting MultiMemberPartition from which to compute district 
+    :param initial_partition: Starting MultiMemberPartition from which to compute district
         information.
     :param percent: (optional) Allowed percentage deviation. Default is 1%.
     :param pop_key: (optional) The name of the population
@@ -101,6 +102,7 @@ def within_percent_of_ideal_population_per_representative(
     bounds = ((1 - percent) * ideal_population, (1 + percent) * ideal_population)
 
     return Bounds(population_per_rep, bounds=bounds)
+
 
 def deviation_from_ideal(partition, attribute="population"):
     """Computes the deviation of the given ``attribute`` from exact equality

--- a/gerrychain/partition/__init__.py
+++ b/gerrychain/partition/__init__.py
@@ -1,4 +1,5 @@
 from .partition import Partition
 from .geographic import GeographicPartition
+from .multi_member import MultiMemberPartition
 
-__all__ = ['Partition', 'GeographicPartition']
+__all__ = ['Partition', 'GeographicPartition', 'MultiMemberPartition']

--- a/gerrychain/partition/multi_member.py
+++ b/gerrychain/partition/multi_member.py
@@ -15,13 +15,14 @@ class MultiMemberPartition(Partition):
         :param updaters: Dictionary of functions to track data about the partition.
             The keys are stored as attributes on the partition class,
             which the functions compute.
-        :param magnitudes: Dictionary assigning districts to number of representatives
+        :param magnitudes (dict<Any, numeric>): Dictionary assigning districts to number of representatives
         """
         super().__init__(graph=graph, assignment=assignment, updaters=updaters, parent=parent, flips=flips)
         if parent is None:
             self._init_magnitudes(magnitudes)
         else:
             self._update_magnitudes_from_parent(magnitudes)
+        self.number_of_representatives = sum(magnitudes.values())
 
     def _init_magnitudes(self, magnitudes):
         """

--- a/gerrychain/partition/multi_member.py
+++ b/gerrychain/partition/multi_member.py
@@ -1,0 +1,36 @@
+from gerrychain.partition import Partition
+
+class MultiMemberPartition(Partition):
+    """A :class:`Partition` with district magnitude information included.
+    These additional data allows for districts of different scales (number of representatives)
+    to be properly balanced.
+    """
+
+    def __init__(self, graph=None, assignment=None, updaters=None, magnitudes=None,
+                 parent=None, flips=None):
+        """
+        :param graph: Underlying graph.
+        :param assignment: Dictionary assigning nodes to districts.
+        :param updaters: Dictionary of functions to track data about the partition.
+            The keys are stored as attributes on the partition class,
+            which the functions compute.
+        :param magnitudes: Dictionary assigning districts to number of representatives
+        """
+        super().__init__(graph=graph, assignment=assignment, updaters=updaters, parent=parent, flips=flips)
+        if parent is None:
+            self._init_magnitudes(assignment, magnitudes)
+        else:
+            self._update_magnitudes_from_parent(parent, magnitudes)
+
+    def _init_magnitudes(self, assignment, magnitudes):
+        dist_ids = assignment.parts.keys()
+        self.magnitudes = {dist_id: 1 for dist_id in dist_ids}
+        if magnitudes != None:
+            self.magnitudes = {**self.magnitudes, **magnitudes}
+
+
+    def _update_magnitudes_from_parent(self, parent, magnitudes):
+        self.magnitudes = {**parent.magnitudes, **magnitudes}
+
+    def flip(self, flips, magnitudes):
+        return self.__class__(parent=self, flips=flips, magnitudes=magnitudes)

--- a/gerrychain/partition/multi_member.py
+++ b/gerrychain/partition/multi_member.py
@@ -1,5 +1,6 @@
 from gerrychain.partition import Partition
 
+
 class MultiMemberPartition(Partition):
     """A :class:`Partition` with district magnitude information included.
     These additional data allows for districts of different scales (number of representatives)
@@ -18,18 +19,23 @@ class MultiMemberPartition(Partition):
         """
         super().__init__(graph=graph, assignment=assignment, updaters=updaters, parent=parent, flips=flips)
         if parent is None:
-            self._init_magnitudes(assignment, magnitudes)
+            self._init_magnitudes(magnitudes)
         else:
-            self._update_magnitudes_from_parent(parent, magnitudes)
+            self._update_magnitudes_from_parent(magnitudes)
 
-    def _init_magnitudes(self, assignment, magnitudes):
-        dist_ids = assignment.parts.keys()
+    def _init_magnitudes(self, magnitudes):
+        """
+        :param magnitudes: Dictionary assigning districts to number of representatives.  If None or
+            incomplete, excluded districts are assigned a magnitude of 1 representative.
+        """
+        dist_ids = self.assignment.parts.keys()
         self.magnitudes = {dist_id: 1 for dist_id in dist_ids}
         if magnitudes != None:
             self.magnitudes = {**self.magnitudes, **magnitudes}
 
 
-    def _update_magnitudes_from_parent(self, parent, magnitudes):
+    def _update_magnitudes_from_parent(self, magnitudes):
+        parent = self.parent
         self.magnitudes = {**parent.magnitudes, **magnitudes}
 
     def flip(self, flips, magnitudes):

--- a/gerrychain/partition/multi_member.py
+++ b/gerrychain/partition/multi_member.py
@@ -2,7 +2,8 @@ from gerrychain.partition import Partition
 
 
 class MultiMemberPartition(Partition):
-    """A :class:`Partition` with district magnitude information included.
+    """
+    A :class:`Partition` with district magnitude information included.
     These additional data allows for districts of different scales (number of representatives)
     to be properly balanced.
     """
@@ -15,9 +16,11 @@ class MultiMemberPartition(Partition):
         :param updaters: Dictionary of functions to track data about the partition.
             The keys are stored as attributes on the partition class,
             which the functions compute.
-        :param magnitudes (dict<Any, numeric>): Dictionary assigning districts to number of representatives
+        :param magnitudes (dict<Any, numeric>): Dictionary assigning districts to number of
+            representatives
         """
-        super().__init__(graph=graph, assignment=assignment, updaters=updaters, parent=parent, flips=flips)
+        super().__init__(graph=graph, assignment=assignment, updaters=updaters, parent=parent,
+                         flips=flips)
         if parent is None:
             self._init_magnitudes(magnitudes)
         else:
@@ -31,9 +34,8 @@ class MultiMemberPartition(Partition):
         """
         dist_ids = self.assignment.parts.keys()
         self.magnitudes = {dist_id: 1 for dist_id in dist_ids}
-        if magnitudes != None:
+        if magnitudes is not None:
             self.magnitudes = {**self.magnitudes, **magnitudes}
-
 
     def _update_magnitudes_from_parent(self, magnitudes):
         parent = self.parent

--- a/gerrychain/proposals/tree_proposals.py
+++ b/gerrychain/proposals/tree_proposals.py
@@ -9,7 +9,7 @@ from ..tree import (
 
 
 def recom(
-    partition, pop_col, pop_target, epsilon, node_repeats=1, method=bipartition_tree
+    partition, pop_col, pop_target, epsilon, node_repeats=1, method=bipartition_tree, multimember=False,
 ):
     """ReCom proposal.
 
@@ -45,7 +45,9 @@ def recom(
         partition.parts[parts_to_merge[0]] | partition.parts[parts_to_merge[1]]
     )
 
-    flips = recursive_tree_part(
+    magnitudes = partition.magnitudes if multimember else None
+
+    flips, new_magnitudes = recursive_tree_part(
         subgraph,
         parts_to_merge,
         pop_col=pop_col,
@@ -53,9 +55,10 @@ def recom(
         epsilon=epsilon,
         node_repeats=node_repeats,
         method=method,
+        magnitudes=magnitudes
     )
 
-    return partition.flip(flips)
+    return partition.flip(flips, new_magnitudes) if multimember else partition.flip(flips)
 
 
 def reversible_recom(partition, pop_col, pop_target, epsilon,

--- a/gerrychain/proposals/tree_proposals.py
+++ b/gerrychain/proposals/tree_proposals.py
@@ -9,7 +9,7 @@ from ..tree import (
 
 
 def recom(
-    partition, pop_col, pop_target, epsilon, node_repeats=1, method=bipartition_tree, 
+    partition, pop_col, pop_target, epsilon, node_repeats=1, method=bipartition_tree,
     multimember=False,
 ):
     """ReCom proposal.
@@ -139,7 +139,7 @@ class ReCom:
 
     def __call__(self, partition):
         return recom(
-            partition, self.pop_col, self.ideal_pop, self.epsilon, method=self.method, 
+            partition, self.pop_col, self.ideal_pop, self.epsilon, method=self.method,
             multimember=self.multimember
         )
 

--- a/gerrychain/proposals/tree_proposals.py
+++ b/gerrychain/proposals/tree_proposals.py
@@ -48,7 +48,7 @@ def recom(
 
     magnitudes = partition.magnitudes if multimember else None
 
-    flips, new_magnitudes = recursive_tree_part(
+    flips = recursive_tree_part(
         subgraph,
         parts_to_merge,
         pop_col=pop_col,
@@ -58,6 +58,10 @@ def recom(
         method=method,
         magnitudes=magnitudes
     )
+
+    if multimember:
+        new_magnitudes = flips[1]
+        flips = flips[0]
 
     return partition.flip(flips, new_magnitudes) if multimember else partition.flip(flips)
 

--- a/gerrychain/proposals/tree_proposals.py
+++ b/gerrychain/proposals/tree_proposals.py
@@ -9,7 +9,8 @@ from ..tree import (
 
 
 def recom(
-    partition, pop_col, pop_target, epsilon, node_repeats=1, method=bipartition_tree, multimember=False,
+    partition, pop_col, pop_target, epsilon, node_repeats=1, method=bipartition_tree, 
+    multimember=False,
 ):
     """ReCom proposal.
 
@@ -124,15 +125,18 @@ def reversible_recom(partition, pop_col, pop_target, epsilon,
 
 
 class ReCom:
-    def __init__(self, pop_col, ideal_pop, epsilon, method=bipartition_tree_random):
+    def __init__(self, pop_col, ideal_pop, epsilon, method=bipartition_tree_random,
+                 multimember=False,):
         self.pop_col = pop_col
         self.ideal_pop = ideal_pop
         self.epsilon = epsilon
         self.method = method
+        self.multimember = multimember
 
     def __call__(self, partition):
         return recom(
-            partition, self.pop_col, self.ideal_pop, self.epsilon, method=self.method
+            partition, self.pop_col, self.ideal_pop, self.epsilon, method=self.method, 
+            multimember=self.multimember
         )
 
 

--- a/gerrychain/tree.py
+++ b/gerrychain/tree.py
@@ -311,7 +311,7 @@ def recursive_tree_part(
             graph.subgraph(remaining_nodes),
             pop_col=pop_col,
             pop_target=(min_pop + max_pop) / 2,
-            epsilon=(max_pop - min_pop) / (2 * pop_target),
+            epsilon=(max_pop - min_pop) / (2 * pop_target * part_mag),
             node_repeats=node_repeats,
         )
 
@@ -322,7 +322,7 @@ def recursive_tree_part(
         for node in nodes:
             flips[node] = part
             part_pop += graph.nodes[node][pop_col]
-        debt += part_pop - pop_target
+        debt += part_pop - pop_target * part_mag
         remaining_nodes -= nodes
 
         if magnitudes != None:

--- a/gerrychain/tree.py
+++ b/gerrychain/tree.py
@@ -274,7 +274,8 @@ def bipartition_tree_random(
 
 
 def recursive_tree_part(
-    graph, parts, pop_target, pop_col, epsilon, node_repeats=1, method=bipartition_tree, magnitudes=None
+    graph, parts, pop_target, pop_col, epsilon, node_repeats=1, method=bipartition_tree,
+    magnitudes=None
 ):
     """Uses :func:`~gerrychain.tree.bipartition_tree` recursively to partition a tree into
     ``len(parts)`` parts of population ``pop_target`` (within ``epsilon``). Can be used to
@@ -304,9 +305,11 @@ def recursive_tree_part(
     debt = 0
 
     for part in parts[:-1]:
-        part_mag = 1 if magnitudes == None else magnitudes[part]
-        min_pop = max(pop_target * part_mag * (1 - epsilon), pop_target * part_mag * (1 - epsilon) - debt)
-        max_pop = min(pop_target * part_mag * (1 + epsilon), pop_target * part_mag * (1 + epsilon) - debt)
+        part_mag = 1 if magnitudes is None else magnitudes[part]
+        min_pop = max(pop_target * part_mag * (1 - epsilon),
+                      pop_target * part_mag * (1 - epsilon) - debt)
+        max_pop = min(pop_target * part_mag * (1 + epsilon),
+                      pop_target * part_mag * (1 + epsilon) - debt)
         nodes = method(
             graph.subgraph(remaining_nodes),
             pop_col=pop_col,
@@ -325,17 +328,15 @@ def recursive_tree_part(
         debt += part_pop - pop_target * part_mag
         remaining_nodes -= nodes
 
-        if magnitudes != None:
+        if magnitudes is not None:
             new_magnitudes[part] = part_mag
 
     # All of the remaining nodes go in the last part
     for node in remaining_nodes:
         flips[node] = parts[-1]
 
-    if magnitudes != None:
-            new_magnitudes[parts[-1]] = magnitudes[parts[-1]]
-
-    if magnitudes != None:
+    if magnitudes is not None:
+        new_magnitudes[parts[-1]] = magnitudes[parts[-1]]
         return flips, new_magnitudes
     else:
         return flips

--- a/gerrychain/tree.py
+++ b/gerrychain/tree.py
@@ -335,7 +335,10 @@ def recursive_tree_part(
     if magnitudes != None:
             new_magnitudes[parts[-1]] = magnitudes[parts[-1]]
 
-    return flips, new_magnitudes
+    if magnitudes != None:
+        return flips, new_magnitudes
+    else:
+        return flips
 
 
 def get_seed_chunks(


### PR DESCRIPTION
This PR introduces a new parent `Partition` class `MultiMemberPartition` which adds magnitudes for each of the districts corresponding to their number of representatives.  (by default this is set to 1).

Additional changes for computation with `MultiMemberPartititions`:
- A multimember flag is added to `recom` proposal to allow the user to indicate their use of such a partition, and that population balancing should be wrt the district magnitude (aka population per representative).
- Constraint function `within_percent_of_ideal_population_per_representative` added.