### PR TITLE
Use __slots__ in Partition

### DIFF
--- a/gerrychain/partition/partition.py
+++ b/gerrychain/partition/partition.py
@@ -16,8 +16,18 @@ class Partition:
     :ivar dict parts: Maps district IDs to the set of nodes in that district.
     :ivar dict subgraphs: Maps district IDs to the induced subgraph of that district.
     """
-
     default_updaters = {"cut_edges": cut_edges}
+    __slots__ = (
+        'graph',
+        'subgraphs',
+        'assignment',
+        'updaters',
+        'parent',
+        'flips',
+        'flows',
+        'edge_flows',
+        '_cache'
+    )
 
     def __init__(
         self, graph=None, assignment=None, updaters=None, parent=None, flips=None

--- a/tests/constraints/test_validity.py
+++ b/tests/constraints/test_validity.py
@@ -14,27 +14,35 @@ from gerrychain.partition.partition import get_assignment
 
 
 @pytest.fixture
-def contiguous_partition():
+def contiguous_partition_with_flips():
     graph = nx.Graph()
     graph.add_nodes_from(range(4))
     graph.add_edges_from([(0, 1), (1, 2), (2, 3), (3, 0)])
     partition = Partition(graph, {0: 0, 1: 1, 2: 1, 3: 0})
 
     # This flip will maintain contiguity.
-    partition.test_flips = {0: 1}
-    return partition
+    return partition, {0: 1}
 
 
 @pytest.fixture
-def discontiguous_partition():
+def discontiguous_partition_with_flips():
     graph = nx.Graph()
     graph.add_nodes_from(range(4))
     graph.add_edges_from([(0, 1), (1, 2), (2, 3)])
     partition = Partition(graph, {0: 0, 1: 1, 2: 1, 3: 0})
 
     # This flip will maintain discontiguity.
-    partition.test_flips = {1: 0}
-    return partition
+    return partition, {1: 0}
+
+
+@pytest.fixture
+def contiguous_partition(contiguous_partition_with_flips):
+    return contiguous_partition_with_flips[0]
+
+
+@pytest.fixture
+def discontiguous_partition(discontiguous_partition_with_flips):
+    return discontiguous_partition_with_flips[0]
 
 
 def test_contiguous_with_contiguity_no_flips_is_true(contiguous_partition):
@@ -43,8 +51,9 @@ def test_contiguous_with_contiguity_no_flips_is_true(contiguous_partition):
     assert contiguous_bfs(contiguous_partition)
 
 
-def test_contiguous_with_contiguity_flips_is_true(contiguous_partition):
-    contiguous_partition2 = contiguous_partition.flip(contiguous_partition.test_flips)
+def test_contiguous_with_contiguity_flips_is_true(contiguous_partition_with_flips):
+    contiguous_partition, test_flips = contiguous_partition_with_flips
+    contiguous_partition2 = contiguous_partition.flip(test_flips)
     assert contiguous(contiguous_partition2)
     assert single_flip_contiguous(contiguous_partition2)
     assert contiguous_bfs(contiguous_partition2)
@@ -64,10 +73,11 @@ def test_discontiguous_with_contiguous_bfs_no_flips_is_false(discontiguous_parti
     assert not contiguous_bfs(discontiguous_partition)
 
 
-def test_discontiguous_with_contiguous_flips_is_false(discontiguous_partition):
-    discontiguous_partition2 = discontiguous_partition.flip(
-        discontiguous_partition.test_flips
-    )
+def test_discontiguous_with_contiguous_flips_is_false(
+    discontiguous_partition_with_flips
+):
+    part, test_flips = discontiguous_partition_with_flips
+    discontiguous_partition2 = part.flip(test_flips)
     assert not contiguous(discontiguous_partition2)
 
 
@@ -76,18 +86,18 @@ def test_discontiguous_with_contiguous_flips_is_false(discontiguous_partition):
     "when the previous partition is discontiguous"
 )
 def test_discontiguous_with_single_flip_contiguous_flips_is_false(
-    discontiguous_partition
+    discontiguous_partition_with_flips
 ):
-    discontiguous_partition2 = discontiguous_partition.flip(
-        discontiguous_partition.test_flips
-    )
+    part, test_flips = discontiguous_partition_with_flips
+    discontiguous_partition2 = part.flip(test_flips)
     assert not single_flip_contiguous(discontiguous_partition2)
 
 
-def test_discontiguous_with_contiguous_bfs_flips_is_false(discontiguous_partition):
-    discontiguous_partition2 = discontiguous_partition.flip(
-        discontiguous_partition.test_flips
-    )
+def test_discontiguous_with_contiguous_bfs_flips_is_false(
+    discontiguous_partition_with_flips
+):
+    part, test_flips = discontiguous_partition_with_flips
+    discontiguous_partition2 = part.flip(test_flips)
     assert not contiguous_bfs(discontiguous_partition2)
 
 


### PR DESCRIPTION
_(I'm not sure if this is worth it yet, but figured I'd throw up a PR and we can do some benchmarks.)_ I was just reminded that using `__slots__` is known to improve memory usage (and sometimes performance) of Python classes [(see here)](https://book.pythontips.com/en/latest/__slots__magic.html), at least when the classes are small. I suspect our memory usage is dominated by large assignment dictionaries, but maybe this is a step in the right direction. `__slots__` also protects against abuse of the `Partition` class by preventing the use of additional fields, though this may break some people's code.