### PR TITLE
Track node to part mapping in Assignment to reduce overhead of expensive __getitem__ calls

### DIFF
--- a/gerrychain/partition/assignment.py
+++ b/gerrychain/partition/assignment.py
@@ -102,8 +102,7 @@ class Assignment(Mapping):
         return pandas.concat(groups)
 
     def to_dict(self):
-        """Convert the assignment to a ``{node: part}`` dictionary.
-        This is expensive and should be used rarely."""
+        """Convert the assignment to a ``{node: part}`` dictionary."""
         return self.mapping
 
     @classmethod

--- a/gerrychain/partition/assignment.py
+++ b/gerrychain/partition/assignment.py
@@ -18,7 +18,7 @@ class Assignment(Mapping):
     ``{part: <frozenset of nodes in part>}``.
     """
 
-    def __init__(self, parts, validate=True):
+    def __init__(self, parts, mapping=None, validate=True):
         if validate:
             number_of_keys = sum(len(keys) for keys in parts.values())
             number_of_unique_keys = len(set().union(*parts.values()))
@@ -27,6 +27,14 @@ class Assignment(Mapping):
             if not all(isinstance(keys, frozenset) for keys in parts.values()):
                 raise TypeError("Level sets must be frozensets")
         self.parts = parts
+
+        if not mapping:
+            self.mapping = {}
+            for part, nodes in self.parts.items():
+                for node in nodes:
+                    self.mapping[node] = part
+        else:
+            self.mapping = mapping
 
     def __repr__(self):
         return "<Assignment [{} keys, {} parts]>".format(len(self), len(self.parts))
@@ -38,16 +46,13 @@ class Assignment(Mapping):
         return sum(len(keys) for keys in self.parts.values())
 
     def __getitem__(self, node):
-        for part, nodes in self.parts.items():
-            if node in nodes:
-                return part
-        raise KeyError(node)
+        return self.mapping[node]
 
     def copy(self):
         """Returns a copy of the assignment.
         Does not duplicate the frozensets of nodes, just the parts dictionary.
         """
-        return Assignment(self.parts.copy(), validate=False)
+        return Assignment(self.parts.copy(), self.mapping.copy(), validate=False)
 
     def update(self, mapping):
         """Update the assignment for some nodes using the given mapping.
@@ -57,6 +62,9 @@ class Assignment(Mapping):
             # Union between frozenset and set returns an object whose type
             # matches the object on the left, which here is a frozenset
             self.parts[part] = (self.parts[part] - flow["out"]) | flow["in"]
+
+            for node in flow["in"]:
+                self.mapping[node] = part
 
     def items(self):
         """Iterate over ``(node, part)`` tuples, where ``node`` is assigned to ``part``.
@@ -83,6 +91,9 @@ class Assignment(Mapping):
         for part, nodes in new_parts.items():
             self.parts[part] = frozenset(nodes)
 
+            for node in nodes:
+                self.mapping[node] = part
+
     def to_series(self):
         """Convert the assignment to a :class:`pandas.Series`."""
         groups = [
@@ -93,7 +104,7 @@ class Assignment(Mapping):
     def to_dict(self):
         """Convert the assignment to a ``{node: part}`` dictionary.
         This is expensive and should be used rarely."""
-        return {node: part for part, nodes in self.parts.items() for node in nodes}
+        return self.mapping
 
     @classmethod
     def from_dict(cls, assignment):


### PR DESCRIPTION
This PR improves scoring/partition creating/replaying speeds by 2-3x (tested on PA congressional and MI state house ensembles). The performance issue I discovered is that because `cut_edges` is a default, forced updater for every partition class (there is actually no way to opt-out of this!), this function https://github.com/mggg/GerryChain/blob/198f43dae397a7e361dcaa059a7ac8a4e0ff18f3/gerrychain/updaters/flows.py#L65 is called on each flip/partition creation. This function creates a lot of `Assignment.__getitem__` calls, which opens up an area for speedups.

`Assignment.__getitem__` is called many, many times and is the most frequently called method/attribute when replaying a chain (according to cProfile). For example, on a replay of PA, it is called over `15376706` times. For context, the next most frequent function call has 1/5 the frequency and is a Python built-in.

In the previous implementation of `Assignment.__getitem__`, a mapping from nodes to parts is effectively **re-created and discarded** every single time the method is called. 

https://github.com/mggg/GerryChain/blob/198f43dae397a7e361dcaa059a7ac8a4e0ff18f3/gerrychain/partition/assignment.py#L40-L44

This PR changes this implicit map creation (which happens on each method call) to be an explicit action done during the initialization of the Assignment class. With this change, the (expensive) performance penalty of creating the node to part mapping in `__getitem__` happens only once. 

Beyond the `cut_edges` updater, other updaters may also experience similar speedups (so it is possible that one could see a >3x performance speedup). This also speeds up normal chain runs slightly (but this is hardly worth mentioning).

Another question this raises is why we do not provide the user with a way to opt out of the (clearly expensive) `cut_edges` updater.