### PR TITLE
Bump CircleCI Python version to 3.8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   test:
     docker:
-      - image: python:3.7
+      - image: python:3.8
     working_directory: ~/repo
     steps:
       - checkout
@@ -19,8 +19,8 @@ jobs:
           command: |
             ls $HOME
             if [ ! -d "/home/circleci/conda" ]; then
-                wget https://repo.anaconda.com/miniconda/Miniconda3-py37_4.9.2-Linux-x86_64.sh
-                /bin/bash Miniconda3-py37_4.9.2-Linux-x86_64.sh -b -p $HOME/conda
+                wget https://repo.anaconda.com/miniconda/Miniconda3-py38_4.10.3-Linux-x86_64.sh
+                /bin/bash Miniconda3-py38_4.10.3-Linux-x86_64.sh -b -p $HOME/conda
                 export PATH=$HOME/conda/bin:$PATH
                 conda install -y -c defaults -c conda-forge sregistry
             else
@@ -49,7 +49,7 @@ jobs:
 
   deploy:
     docker:
-      - image: python:3.7
+      - image: python:3.8
     working_directory: ~/repo
     steps:
       - checkout

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,8 @@ setup(
     classifiers=[
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Operating System :: OS Independent",
         "License :: OSI Approved :: BSD License",
     ],

--- a/setup.py
+++ b/setup.py
@@ -31,8 +31,8 @@ setup(
     install_requires=requirements,
     keywords="GerryChain",
     classifiers=[
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Operating System :: OS Independent",
         "License :: OSI Approved :: BSD License",
     ],


### PR DESCRIPTION
Some of the latest releases of our upstream dependencies no longer support Python 3.7 (apparently, from a cursory glance at our CircleCI logs). This fixes CI so we can get on with GerryChain development and merge in #363.

Some other notes:
- I can confirm that Python 3.7 still works on my computer with some manual dependency wrangling (a simple `python setup.py install` won't work). 
- Python 3.6 is end-of-life, so I think we should remove it from the list of officially supported Python versions