### PR TITLE
Performance enhancements

### DIFF
--- a/gerrychain/constraints/contiguity.py
+++ b/gerrychain/constraints/contiguity.py
@@ -78,7 +78,7 @@ def single_flip_contiguous(partition):
         """Compute the district edge weight, which is 1 if the nodes have the same
         assignment, and infinity otherwise.
         """
-        if assignment[start_node] != assignment[end_node]:
+        if assignment.mapping[start_node] != assignment.mapping[end_node]:
             # Fun fact: networkx actually refuses to take edges with None
             # weight.
             return True
@@ -86,12 +86,12 @@ def single_flip_contiguous(partition):
         return False
 
     for changed_node in flips:
-        old_assignment = partition.parent.assignment[changed_node]
+        old_assignment = partition.parent.assignment.mapping[changed_node]
 
         old_neighbors = [
             node
             for node in graph.neighbors(changed_node)
-            if assignment[node] == old_assignment
+            if assignment.mapping[node] == old_assignment
         ]
 
         if not old_neighbors:
@@ -130,7 +130,7 @@ def affected_parts(partition):
     affected = set()
     for node, part in flips.items():
         affected.add(part)
-        affected.add(parent.assignment[node])
+        affected.add(parent.assignment.mapping[node])
 
     return affected
 

--- a/gerrychain/grid.py
+++ b/gerrychain/grid.py
@@ -3,6 +3,7 @@ import math
 import networkx
 
 from gerrychain.partition import Partition
+from gerrychain.graph import Graph
 from gerrychain.updaters import (
     Tally,
     boundary_nodes,
@@ -63,7 +64,7 @@ class Grid(Partition):
         """
         if dimensions:
             self.dimensions = dimensions
-            graph = create_grid_graph(dimensions, with_diagonals)
+            graph = Graph.from_networkx(create_grid_graph(dimensions, with_diagonals))
 
             if not assignment:
                 thresholds = tuple(math.floor(n / 2) for n in self.dimensions)

--- a/gerrychain/grid.py
+++ b/gerrychain/grid.py
@@ -99,7 +99,7 @@ class Grid(Partition):
         grid.
         """
         m, n = self.dimensions
-        return [[self.assignment[(i, j)] for i in range(m)] for j in range(n)]
+        return [[self.assignment.mapping[(i, j)] for i in range(m)] for j in range(n)]
 
 
 def create_grid_graph(dimensions, with_diagonals):

--- a/gerrychain/metagraph.py
+++ b/gerrychain/metagraph.py
@@ -5,7 +5,7 @@ from .constraints import Validator
 
 def all_cut_edge_flips(partition):
     for edge, index in product(partition.cut_edges, (0, 1)):
-        yield {edge[index]: partition.assignment[edge[1 - index]]}
+        yield {edge[index]: partition.assignment.mapping[edge[1 - index]]}
 
 
 def all_valid_states_one_flip_away(partition, constraints):

--- a/gerrychain/partition/assignment.py
+++ b/gerrychain/partition/assignment.py
@@ -1,5 +1,4 @@
 from collections import defaultdict
-from itertools import chain, repeat
 from collections.abc import Mapping
 
 import pandas
@@ -70,17 +69,13 @@ class Assignment(Mapping):
     def items(self):
         """Iterate over ``(node, part)`` tuples, where ``node`` is assigned to ``part``.
         """
-        for part, nodes in self.parts.items():
-            for node in nodes:
-                yield (node, part)
+        yield from self.mapping.items()
 
     def keys(self):
-        return chain(*self.parts.values())
+        yield from self.mapping.keys()
 
     def values(self):
-        return chain(
-            *(repeat(value, times=len(keys)) for value, keys in self.parts.items())
-        )
+        yield from self.mapping.values()
 
     def update_parts(self, new_parts):
         """Update some parts of the assignment. Does not check that every node is

--- a/gerrychain/partition/assignment.py
+++ b/gerrychain/partition/assignment.py
@@ -4,8 +4,6 @@ from collections.abc import Mapping
 
 import pandas
 
-from ..updaters.flows import flows_from_changes
-
 
 class Assignment(Mapping):
     """An assignment of nodes into parts.
@@ -58,10 +56,9 @@ class Assignment(Mapping):
         """
         return Assignment(self.parts.copy(), self.mapping.copy(), validate=False)
 
-    def update(self, mapping):
-        """Update the assignment for some nodes using the given mapping.
+    def update_flows(self, flows):
+        """Update the assignment for some nodes using the given flows.
         """
-        flows = flows_from_changes(self, mapping)
         for part, flow in flows.items():
             # Union between frozenset and set returns an object whose type
             # matches the object on the left, which here is a frozenset

--- a/gerrychain/partition/partition.py
+++ b/gerrychain/partition/partition.py
@@ -1,5 +1,8 @@
 import json
 import geopandas
+import networkx
+
+from gerrychain.graph.graph import FrozenGraph, Graph
 from ..updaters import compute_edge_flows, flows_from_changes, cut_edges
 from .assignment import get_assignment
 from .subgraphs import SubgraphView
@@ -50,7 +53,16 @@ class Partition:
         self.subgraphs = SubgraphView(self.graph, self.parts)
 
     def _first_time(self, graph, assignment, updaters, use_cut_edges):
-        self.graph = graph
+        if isinstance(graph, Graph):
+            self.graph = FrozenGraph(graph)
+        elif isinstance(graph, networkx.Graph):
+            graph = Graph.from_networkx(graph)
+            self.graph = FrozenGraph(graph)
+        elif isinstance(graph, FrozenGraph):
+            self.graph = graph
+        else:
+            raise TypeError("Unsupported Graph object")
+
         self.assignment = get_assignment(assignment, graph)
 
         if set(self.assignment) != set(graph):

--- a/gerrychain/partition/partition.py
+++ b/gerrychain/partition/partition.py
@@ -111,7 +111,7 @@ class Partition:
         :param edge: tuple of node IDs
         :rtype: bool
         """
-        return self.assignment[edge[0]] != self.assignment[edge[1]]
+        return self.assignment.mapping[edge[0]] != self.assignment.mapping[edge[1]]
 
     def __getitem__(self, key):
         """Allows accessing the values of updaters computed for this

--- a/gerrychain/partition/partition.py
+++ b/gerrychain/partition/partition.py
@@ -75,13 +75,13 @@ class Partition:
         self.parent = parent
         self.flips = flips
 
-        self.assignment = parent.assignment.copy()
-        self.assignment.update(flips)
-
         self.graph = parent.graph
         self.updaters = parent.updaters
 
         self.flows = flows_from_changes(parent.assignment, flips)
+
+        self.assignment = parent.assignment.copy()
+        self.assignment.update_flows(self.flows)
 
         if "cut_edges" in self.updaters:
             self.edge_flows = compute_edge_flows(self)

--- a/gerrychain/partition/partition.py
+++ b/gerrychain/partition/partition.py
@@ -78,7 +78,7 @@ class Partition:
         self.graph = parent.graph
         self.updaters = parent.updaters
 
-        self.flows = flows_from_changes(parent.assignment, flips)
+        self.flows = flows_from_changes(parent, self)  # careful
 
         self.assignment = parent.assignment.copy()
         self.assignment.update_flows(self.flows)

--- a/gerrychain/proposals/proposals.py
+++ b/gerrychain/proposals/proposals.py
@@ -24,7 +24,7 @@ def propose_flip_every_district(partition):
 
         index = random.choice((0, 1))
         flipped_node, other_node = edge[index], edge[1 - index]
-        flip = {flipped_node: partition.assignment[other_node]}
+        flip = {flipped_node: partition.assignment.mapping[other_node]}
 
         flips.update(flip)
 
@@ -47,11 +47,11 @@ def propose_chunk_flip(partition):
     valid_flips = [
         nbr
         for nbr in partition.graph.neighbors(flipped_node)
-        if partition.assignment[nbr] != partition.assignment[flipped_node]
+        if partition.assignment.mapping[nbr] != partition.assignment.mapping[flipped_node]
     ]
 
     for flipped_neighbor in valid_flips:
-        flips.update({flipped_neighbor: partition.assignment[flipped_node]})
+        flips.update({flipped_neighbor: partition.assignment.mapping[flipped_node]})
 
     return partition.flip(flips)
 
@@ -67,7 +67,7 @@ def propose_random_flip(partition):
     edge = random.choice(tuple(partition["cut_edges"]))
     index = random.choice((0, 1))
     flipped_node, other_node = edge[index], edge[1 - index]
-    flip = {flipped_node: partition.assignment[other_node]}
+    flip = {flipped_node: partition.assignment.mapping[other_node]}
     return partition.flip(flip)
 
 
@@ -86,9 +86,9 @@ def slow_reversible_propose_bi(partition):
     b_nodes = {x[0] for x in partition["cut_edges"]}.union({x[1] for x in partition["cut_edges"]})
 
     flip = random.choice(list(b_nodes))
-    neighbor_assignments = list(set([partition.assignment[neighbor] for neighbor
+    neighbor_assignments = list(set([partition.assignment.mapping[neighbor] for neighbor
                                 in partition.graph.neighbors(flip)]))
-    neighbor_assignments.remove(partition.assignment[flip])
+    neighbor_assignments.remove(partition.assignment.mapping[flip])
     flips = {flip: random.choice(neighbor_assignments)}
 
     return partition.flip(flips)
@@ -107,8 +107,8 @@ def slow_reversible_propose(partition):
     :return: a proposed next `~gerrychain.Partition`
     """
 
-    b_nodes = {(x[0], partition.assignment[x[1]]) for x in partition["cut_edges"]
-               }.union({(x[1], partition.assignment[x[0]]) for x in partition["cut_edges"]})
+    b_nodes = {(x[0], partition.assignment.mapping[x[1]]) for x in partition["cut_edges"]
+               }.union({(x[1], partition.assignment.mapping[x[0]]) for x in partition["cut_edges"]})
 
     flip = random.choice(list(b_nodes))
     return partition.flip({flip[0]: flip[1]})

--- a/gerrychain/proposals/spectral_proposals.py
+++ b/gerrychain/proposals/spectral_proposals.py
@@ -15,7 +15,7 @@ def spectral_cut(graph, part_labels, weight_type, lap_type):
     n = len(nlist)
 
     if weight_type == "random":
-        for edge in graph.edges():
+        for edge in graph.edge_indicies:
             graph.edges[edge]["weight"] = random.random()
 
     if lap_type == "normalized":

--- a/gerrychain/proposals/spectral_proposals.py
+++ b/gerrychain/proposals/spectral_proposals.py
@@ -59,7 +59,7 @@ def spectral_recom(partition, weight_type=None, lap_type="normalized"):
     """
 
     edge = random.choice(tuple(partition["cut_edges"]))
-    parts_to_merge = (partition.assignment[edge[0]], partition.assignment[edge[1]])
+    parts_to_merge = (partition.assignment.mapping[edge[0]], partition.assignment.mapping[edge[1]])
 
     subgraph = partition.graph.subgraph(
         partition.parts[parts_to_merge[0]] | partition.parts[parts_to_merge[1]]

--- a/gerrychain/proposals/tree_proposals.py
+++ b/gerrychain/proposals/tree_proposals.py
@@ -39,7 +39,7 @@ def recom(
 
     """
     edge = random.choice(tuple(partition["cut_edges"]))
-    parts_to_merge = (partition.assignment[edge[0]], partition.assignment[edge[1]])
+    parts_to_merge = (partition.assignment.mapping[edge[0]], partition.assignment.mapping[edge[1]])
 
     subgraph = partition.graph.subgraph(
         partition.parts[parts_to_merge[0]] | partition.parts[parts_to_merge[1]]
@@ -65,8 +65,8 @@ def reversible_recom(partition, pop_col, pop_target, epsilon,
     def dist_pair_edges(part, a, b):
         return set(
             e for e in part.graph.edges
-            if ((part.assignment[e[0]] == a and part.assignment[e[1]] == b) or
-                (part.assignment[e[0]] == b and part.assignment[e[1]] == a))
+            if ((part.assignment.mapping[e[0]] == a and part.assignment.mapping[e[1]] == b) or
+                (part.assignment.mapping[e[0]] == b and part.assignment.mapping[e[1]] == a))
         )
 
     def bounded_balance_edge_fn(*args, **kwargs):
@@ -95,7 +95,7 @@ def reversible_recom(partition, pop_col, pop_target, epsilon,
         return partition    # self-loop: no adjacency
 
     edge = random.choice(list(pair_edges))
-    parts_to_merge = (partition.assignment[edge[0]], partition.assignment[edge[1]])
+    parts_to_merge = (partition.assignment.mapping[edge[0]], partition.assignment.mapping[edge[1]])
     subgraph = partition.graph.subgraph(
         partition.parts[parts_to_merge[0]] | partition.parts[parts_to_merge[1]]
     )

--- a/gerrychain/proposals/tree_proposals.py
+++ b/gerrychain/proposals/tree_proposals.py
@@ -46,7 +46,7 @@ def recom(
     )
 
     flips = recursive_tree_part(
-        subgraph,
+        subgraph.graph,
         parts_to_merge,
         pop_col=pop_col,
         pop_target=pop_target,

--- a/gerrychain/tree.py
+++ b/gerrychain/tree.py
@@ -201,7 +201,7 @@ def bipartition_tree(
         tree is not provided
     :param choice: :func:`random.choice`. Can be substituted for testing.
     """
-    populations = {node: graph.nodes[node][pop_col] for node in graph.node_indicies}
+    populations = {node: graph.lookup(node, pop_col) for node in graph.node_indicies}
 
     possible_cuts = []
     if spanning_tree is None:
@@ -231,7 +231,7 @@ def _bipartition_tree_random_all(
     choice=random.choice,
 ):
     """Randomly bipartitions a graph and returns all cuts."""
-    populations = {node: graph.nodes[node][pop_col] for node in graph.node_indicies}
+    populations = {node: graph.lookup(node, pop_col) for node in graph.node_indicies}
 
     possible_cuts = []
     if spanning_tree is None:
@@ -342,7 +342,7 @@ def recursive_tree_part(
         part_pop = 0
         for node in nodes:
             flips[node] = part
-            part_pop += graph.nodes[node][pop_col]
+            part_pop += graph.lookup(node, pop_col)
         debt += part_pop - pop_target
         remaining_nodes -= nodes
 
@@ -385,7 +385,7 @@ def get_seed_chunks(
 
     chunk_pop = 0
     for node in graph.node_indicies:
-        chunk_pop += graph.nodes[node][pop_col]
+        chunk_pop += graph.lookup(node, pop_col)
 
     while True:
         epsilon = abs(epsilon)
@@ -425,7 +425,7 @@ def get_seed_chunks(
 
         part_pop = 0
         for node in remaining_nodes:
-            part_pop += graph.nodes[node][pop_col]
+            part_pop += graph.lookup(node, pop_col)
         part_pop_as_dist = part_pop / num_chunks_left
         fake_epsilon = epsilon
         if num_chunks_left != 1:

--- a/gerrychain/tree.py
+++ b/gerrychain/tree.py
@@ -15,7 +15,7 @@ def successors(h, root):
 
 def random_spanning_tree(graph):
     """ Builds a spanning tree chosen by Kruskal's method using random weights.
-        :param graph: Networkx Graph
+        :param graph: FrozenGraph
 
         Important Note:
         The key is specifically labelled "random_weight" instead of the previously
@@ -24,7 +24,7 @@ def random_spanning_tree(graph):
         This meant that the laplacian would change for the graph step to step,
         something that we do not intend!!
     """
-    for edge in graph.edges:
+    for edge in graph.edge_indicies:
         graph.edges[edge]["random_weight"] = random.random()
 
     spanning_tree = tree.maximum_spanning_tree(
@@ -39,14 +39,14 @@ def uniform_spanning_tree(graph, choice=random.choice):
         :param graph: Networkx Graph
         :param choice: :func:`random.choice`
     """
-    root = choice(list(graph.nodes))
+    root = choice(graph.node_indicies)
     tree_nodes = set([root])
     next_node = {root: None}
 
-    for node in graph.nodes:
+    for node in graph.node_indicies:
         u = node
         while u not in tree_nodes:
-            next_node[u] = choice(list(nx.neighbors(graph, u)))
+            next_node[u] = choice(graph.neighbors(u))
             u = next_node[u]
 
         u = node
@@ -65,12 +65,12 @@ def uniform_spanning_tree(graph, choice=random.choice):
 class PopulatedGraph:
     def __init__(self, graph, populations, ideal_pop, epsilon):
         self.graph = graph
-        self.subsets = {node: {node} for node in graph}
+        self.subsets = {node: {node} for node in graph.node_indicies}
         self.population = populations.copy()
         self.tot_pop = sum(self.population.values())
         self.ideal_pop = ideal_pop
         self.epsilon = epsilon
-        self._degrees = {node: graph.degree(node) for node in graph}
+        self._degrees = {node: graph.degree(node) for node in graph.node_indicies}
 
     def __iter__(self):
         return iter(self.graph)
@@ -194,7 +194,7 @@ def bipartition_tree(
         tree is not provided
     :param choice: :func:`random.choice`. Can be substituted for testing.
     """
-    populations = {node: graph.nodes[node][pop_col] for node in graph}
+    populations = {node: graph.nodes[node][pop_col] for node in graph.node_indicies}
 
     possible_cuts = []
     if spanning_tree is None:
@@ -224,7 +224,7 @@ def _bipartition_tree_random_all(
     choice=random.choice,
 ):
     """Randomly bipartitions a graph and returns all cuts."""
-    populations = {node: graph.nodes[node][pop_col] for node in graph}
+    populations = {node: graph.nodes[node][pop_col] for node in graph.node_indicies}
 
     possible_cuts = []
     if spanning_tree is None:
@@ -303,11 +303,12 @@ def recursive_tree_part(
     :param epsilon: How far (as a percentage of ``pop_target``) from ``pop_target`` the parts
         of the partition can be
     :param node_repeats: Parameter for :func:`~gerrychain.tree_methods.bipartition_tree` to use.
+    :param method: The partition method to use.
     :return: New assignments for the nodes of ``graph``.
     :rtype: dict
     """
     flips = {}
-    remaining_nodes = set(graph.nodes)
+    remaining_nodes = graph.node_indicies
     # We keep a running tally of deviation from ``epsilon`` at each partition
     # and use it to tighten the population constraints on a per-partition
     # basis such that every partition, including the last partition, has a
@@ -376,7 +377,7 @@ def get_seed_chunks(
         new_epsilon = epsilon
 
     chunk_pop = 0
-    for node in graph.nodes:
+    for node in graph.node_indicies:
         chunk_pop += graph.nodes[node][pop_col]
 
     while True:

--- a/gerrychain/updaters/compactness.py
+++ b/gerrychain/updaters/compactness.py
@@ -17,7 +17,7 @@ def boundary_nodes(partition, alias="boundary_nodes"):
 def initialize_exterior_boundaries_as_a_set(partition):
     part_boundaries = collections.defaultdict(set)
     for node in partition["boundary_nodes"]:
-        part_boundaries[partition.assignment[node]].add(node)
+        part_boundaries[partition.assignment.mapping[node]].add(node)
     return part_boundaries
 
 
@@ -31,7 +31,7 @@ def initialize_exterior_boundaries(partition):
     graph_boundary = partition["boundary_nodes"]
     boundaries = collections.defaultdict(lambda: 0)
     for node in graph_boundary:
-        part = partition.assignment[node]
+        part = partition.assignment.mapping[node]
         boundaries[part] += partition.graph.nodes[node]["boundary_perim"]
     return boundaries
 

--- a/gerrychain/updaters/county_splits.py
+++ b/gerrychain/updaters/county_splits.py
@@ -43,7 +43,7 @@ def compute_county_splits(partition, county_field, partition_field):
                 split, nodes, seen = CountySplit.NOT_SPLIT, [], set()
 
             nodes.append(node)
-            seen.update(set([partition.assignment[node]]))
+            seen.update(set([partition.assignment.mapping[node]]))
 
             if len(seen) > 1:
                 split = CountySplit.OLD_SPLIT
@@ -56,7 +56,7 @@ def compute_county_splits(partition, county_field, partition_field):
 
     parent = partition.parent
     for county, county_info in parent[partition_field].items():
-        seen = set(partition.assignment[node] for node in county_info.nodes)
+        seen = set(partition.assignment.mapping[node] for node in county_info.nodes)
 
         split = CountySplit.NOT_SPLIT
 

--- a/gerrychain/updaters/county_splits.py
+++ b/gerrychain/updaters/county_splits.py
@@ -35,7 +35,7 @@ def compute_county_splits(partition, county_field, partition_field):
     if not partition.parent:
         county_dict = dict()
 
-        for node in partition.graph:
+        for node in partition.graph.nodes:
             county = partition.graph.nodes[node][county_field]
             if county in county_dict:
                 split, nodes, seen = county_dict[county]

--- a/gerrychain/updaters/cut_edges.py
+++ b/gerrychain/updaters/cut_edges.py
@@ -7,8 +7,8 @@ def put_edges_into_parts(edges, assignment):
     by_part = collections.defaultdict(set)
     for edge in edges:
         # add edge to the sets corresponding to the parts it touches
-        by_part[assignment[edge[0]]].add(edge)
-        by_part[assignment[edge[1]]].add(edge)
+        by_part[assignment.mapping[edge[0]]].add(edge)
+        by_part[assignment.mapping[edge[1]]].add(edge)
     return by_part
 
 

--- a/gerrychain/updaters/flows.py
+++ b/gerrychain/updaters/flows.py
@@ -19,7 +19,7 @@ def create_flow():
 def flows_from_changes(old_assignment, flips):
     flows = collections.defaultdict(create_flow)
     for node, target in flips.items():
-        source = old_assignment[node]
+        source = old_assignment.mapping[node]
         if source != target:
             flows[target]['in'].add(node)
             flows[source]['out'].add(node)
@@ -80,11 +80,11 @@ def compute_edge_flows(partition):
     for (node, neighbor) in neighbor_flips(partition):
         edge = (node, neighbor)
 
-        old_source = old_assignment[node]
-        old_target = old_assignment[neighbor]
+        old_source = old_assignment.mapping[node]
+        old_target = old_assignment.mapping[neighbor]
 
-        new_source = assignment[node]
-        new_target = assignment[neighbor]
+        new_source = assignment.mapping[node]
+        new_target = assignment.mapping[neighbor]
 
         cut = new_source != new_target
         was_cut = old_source != old_target

--- a/gerrychain/updaters/flows.py
+++ b/gerrychain/updaters/flows.py
@@ -16,10 +16,11 @@ def create_flow():
     return {'in': set(), 'out': set()}
 
 
-def flows_from_changes(old_assignment, flips):
+@functools.lru_cache(maxsize=2)
+def flows_from_changes(old_partition, new_partition):
     flows = collections.defaultdict(create_flow)
-    for node, target in flips.items():
-        source = old_assignment.mapping[node]
+    for node, target in new_partition.flips.items():
+        source = old_partition.assignment.mapping[node]
         if source != target:
             flows[target]['in'].add(node)
             flows[source]['out'].add(node)

--- a/gerrychain/updaters/locality_split_scores.py
+++ b/gerrychain/updaters/locality_split_scores.py
@@ -172,9 +172,9 @@ class LocalitySplits:
             locality = partition.graph.nodes[n][self.col_id]
             if locality not in locality_intersections:
                 locality_intersections[locality] = set(
-                    [partition.assignment[n]])
+                    [partition.assignment.mapping[n]])
 
-            locality_intersections[locality].update([partition.assignment[n]])
+            locality_intersections[locality].update([partition.assignment.mapping[n]])
 
         pieces = 0
         for locality in locality_intersections:

--- a/gerrychain/updaters/tally.py
+++ b/gerrychain/updaters/tally.py
@@ -9,6 +9,11 @@ class DataTally:
     """An updater for tallying numerical data that is not necessarily stored as
     node attributes
     """
+    __slots__ = [
+        "data",
+        "alias",
+        "_call"
+    ]
 
     def __init__(self, data, alias):
         """
@@ -54,6 +59,11 @@ class DataTally:
 class Tally:
     """An updater for keeping a tally of one or more node attributes.
     """
+    __slots__ = [
+        "fields",
+        "alias",
+        "dtype"
+    ]
 
     def __init__(self, fields, alias=None, dtype=int):
         """
@@ -116,12 +126,12 @@ class Tally:
         return new_tally
 
     def _get_tally_from_node(self, partition, node):
-        return sum(partition.graph.nodes[node][field] for field in self.fields)
+        return sum(partition.graph.lookup(node, field) for field in self.fields)
 
 
 def compute_out_flow(graph, fields, flow):
-    return sum(graph.nodes[node][field] for node in flow["out"] for field in fields)
+    return sum(graph.lookup(node, field) for node in flow["out"] for field in fields)
 
 
 def compute_in_flow(graph, fields, flow):
-    return sum(graph.nodes[node][field] for node in flow["in"] for field in fields)
+    return sum(graph.lookup(node, field) for node in flow["in"] for field in fields)

--- a/gerrychain/updaters/tally.py
+++ b/gerrychain/updaters/tally.py
@@ -102,14 +102,13 @@ class Tally:
         :param partition: :class:`Partition` class.
         """
         parent = partition.parent
-        flips = partition.flips
 
         old_tally = parent[self.alias]
         new_tally = dict(old_tally)
 
         graph = partition.graph
 
-        for part, flow in flows_from_changes(parent.assignment, flips).items():
+        for part, flow in flows_from_changes(parent, partition).items():
             out_flow = compute_out_flow(graph, self.fields, flow)
             in_flow = compute_in_flow(graph, self.fields, flow)
             new_tally[part] = old_tally[part] - out_flow + in_flow

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,7 +56,7 @@ def graph(three_by_three_grid):
 
 @pytest.fixture
 def example_partition():
-    graph = networkx.complete_graph(3)
+    graph = Graph.from_networkx(networkx.complete_graph(3))
     assignment = {0: 1, 1: 1, 2: 2}
     partition = Partition(graph, assignment, {"cut_edges": cut_edges})
     return partition

--- a/tests/constraints/test_validity.py
+++ b/tests/constraints/test_validity.py
@@ -11,6 +11,7 @@ from gerrychain.constraints import (SelfConfiguringLowerBound, Validator,
                                     single_flip_contiguous)
 from gerrychain.partition import Partition
 from gerrychain.partition.partition import get_assignment
+from gerrychain.graph import Graph
 
 
 @pytest.fixture
@@ -18,7 +19,7 @@ def contiguous_partition_with_flips():
     graph = nx.Graph()
     graph.add_nodes_from(range(4))
     graph.add_edges_from([(0, 1), (1, 2), (2, 3), (3, 0)])
-    partition = Partition(graph, {0: 0, 1: 1, 2: 1, 3: 0})
+    partition = Partition(Graph.from_networkx(graph), {0: 0, 1: 1, 2: 1, 3: 0})
 
     # This flip will maintain contiguity.
     return partition, {0: 1}
@@ -29,7 +30,7 @@ def discontiguous_partition_with_flips():
     graph = nx.Graph()
     graph.add_nodes_from(range(4))
     graph.add_edges_from([(0, 1), (1, 2), (2, 3)])
-    partition = Partition(graph, {0: 0, 1: 1, 2: 1, 3: 0})
+    partition = Partition(Graph.from_networkx(graph), {0: 0, 1: 1, 2: 1, 3: 0})
 
     # This flip will maintain discontiguity.
     return partition, {1: 0}

--- a/tests/constraints/test_validity.py
+++ b/tests/constraints/test_validity.py
@@ -169,6 +169,6 @@ def test_no_vanishing_districts_works():
     partition = MagicMock()
     partition.parent = parent
     partition.assignment = parent.assignment.copy()
-    partition.assignment.update({2: 1})
+    partition.assignment.update_flows({1: {"out": set(), "in": {2}}, 2: {"out": {2}, "in": set()}})
 
     assert not no_vanishing_districts(partition)

--- a/tests/partition/test_assignment.py
+++ b/tests/partition/test_assignment.py
@@ -12,7 +12,7 @@ def assignment():
 
 class TestAssignment:
     def test_assignment_can_be_updated(self, assignment):
-        assignment.update({2: 1})
+        assignment.update_flows({1: {"out": set(), "in": {2}}, 2: {"out": {2}, "in": set()}})
         assert assignment[2] == 1
 
     def test_assignment_copy_does_not_copy_the_node_sets(self, assignment):

--- a/tests/partition/test_partition.py
+++ b/tests/partition/test_partition.py
@@ -7,6 +7,7 @@ import pytest
 
 from gerrychain.partition import GeographicPartition, Partition
 from gerrychain.proposals import propose_random_flip
+from gerrychain.graph import Graph
 from gerrychain.updaters import cut_edges
 
 
@@ -17,14 +18,14 @@ def test_Partition_can_be_flipped(example_partition):
 
 
 def test_Partition_misnamed_vertices_raises_keyerror():
-    graph = networkx.complete_graph(3)
+    graph = Graph.from_networkx(networkx.complete_graph(3))
     assignment = {"0": 1, "1": 1, "2": 2}
     with pytest.raises(KeyError):
         Partition(graph, assignment, {"cut_edges": cut_edges})
 
 
 def test_Partition_unlabelled_vertices_raises_keyerror():
-    graph = networkx.complete_graph(3)
+    graph = Graph.from_networkx(networkx.complete_graph(3))
     assignment = {0: 1, 2: 2}
     with pytest.raises(KeyError):
         Partition(graph, assignment, {"cut_edges": cut_edges})
@@ -44,7 +45,7 @@ def test_propose_random_flip_proposes_a_partition(example_partition):
 
 @pytest.fixture
 def example_geographic_partition():
-    graph = networkx.complete_graph(3)
+    graph = Graph.from_networkx(networkx.complete_graph(3))
     assignment = {0: 1, 1: 1, 2: 2}
     for node in graph.nodes:
         graph.nodes[node]["boundary_node"] = False

--- a/tests/test_reproducibility.py
+++ b/tests/test_reproducibility.py
@@ -107,4 +107,4 @@ def test_pa_freeze():
         result += str(len(partition.cut_edges))
         result += str(count) + "\n"
 
-    assert hashlib.sha256(result.encode()).hexdigest() == "3bef9ac8c0bfa025fb75e32aea3847757a8fba56b2b2be6f9b3b952088ae3b3c"
+    assert hashlib.sha256(result.encode()).hexdigest() == "309316e6ca5685c8b3601268b1814a966771e00715a6c69973a8ede810f4c8cf"

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -5,6 +5,7 @@ import pytest
 
 from gerrychain import MarkovChain
 from gerrychain.constraints import contiguous, within_percent_of_ideal_population
+from gerrychain.graph import Graph
 from gerrychain.partition import Partition
 from gerrychain.proposals import recom
 from gerrychain.tree import (
@@ -22,7 +23,7 @@ from gerrychain.updaters import Tally, cut_edges
 def graph_with_pop(three_by_three_grid):
     for node in three_by_three_grid:
         three_by_three_grid.nodes[node]["pop"] = 1
-    return three_by_three_grid
+    return Graph.from_networkx(three_by_three_grid)
 
 
 @pytest.fixture
@@ -41,7 +42,7 @@ def twelve_by_twelve_with_pop():
     grid = networkx.relabel_nodes(xy_grid, nodes)
     for node in grid:
         grid.nodes[node]["pop"] = 1
-    return grid
+    return Graph.from_networkx(grid)
 
 
 def test_bipartition_tree_returns_a_subset_of_nodes(graph_with_pop):
@@ -92,9 +93,9 @@ def test_random_spanning_tree_returns_tree_with_pop_attribute(graph_with_pop):
 
 def test_bipartition_tree_returns_a_tree(graph_with_pop):
     ideal_pop = sum(graph_with_pop.nodes[node]["pop"] for node in graph_with_pop) / 2
-    tree = networkx.Graph(
+    tree = Graph.from_networkx(networkx.Graph(
         [(0, 1), (1, 2), (1, 4), (3, 4), (4, 5), (3, 6), (6, 7), (6, 8)]
-    )
+    ))
     for node in tree:
         tree.nodes[node]["pop"] = graph_with_pop.nodes[node]["pop"]
 
@@ -123,9 +124,9 @@ def test_recom_works_as_a_proposal(partition_with_pop):
 
 
 def test_find_balanced_cuts_contraction():
-    tree = networkx.Graph(
+    tree = Graph.from_networkx(networkx.Graph(
         [(0, 1), (1, 2), (1, 4), (3, 4), (4, 5), (3, 6), (6, 7), (6, 8)]
-    )
+    ))
 
     # 0 - 1 - 2
     #   ||

--- a/tests/updaters/test_updaters.py
+++ b/tests/updaters/test_updaters.py
@@ -5,6 +5,7 @@ import pytest
 
 from gerrychain import MarkovChain
 from gerrychain.constraints import Validator, no_vanishing_districts
+from gerrychain.graph import Graph
 from gerrychain.partition import Partition
 from gerrychain.proposals import propose_random_flip
 from gerrychain.random import random
@@ -62,7 +63,7 @@ def test_Partition_can_update_stats():
 
     updaters = {"total_stat": Tally("stat", alias="total_stat")}
 
-    partition = Partition(graph, assignment, updaters)
+    partition = Partition(Graph.from_networkx(graph), assignment, updaters)
     assert partition["total_stat"][2] == 3
     flip = {1: 2}
 


### PR DESCRIPTION
This is a work-in-progress, draft PR with some performance enhancements. In particular,
- `__slots__` is enabled for a few frequently-created classes (`Assignment` and `SubgraphView`), resulting in minor performance improvements
- caching for iterating over the neighbors of all flips is implemented to improve flow and cut edge calculation runtimes
- caching for iterating over the neighbors of a node in a graph is implemented (since `networkx`'s neighbors function is quite expensive and a partition's graph will always remain static)
- `Graph.nodes` and `Graph.edges` is cached

Combined, these speedups improve *both* standard GerryChain run performance and replay performance. In particular, the time it takes to run 100 steps on PA goes from 29.8 seconds to 26 seconds (~13% decrease) and the time spent on each loop when replaying goes from 610 ms (based on #363) to 469 ms (~23% decrease).

Some caveats:
- I used `functools.cache`, which is a Python 3.9 feature. We should switch to `functools.lru_cache` or something with better compatibility with older versions of Python before we merge this in.
- For caching reasons, GerryChain Partitions will no longer accept a `networkx` graph (to convert a `networkx` graph to a `gerrychain.Graph` object, a new method `Graph.from_networkx` is introduced in this PR). I had to rewrite the tests accordingly.