### PR TITLE
Add neighborhood flips caching

### DIFF
--- a/gerrychain/updaters/cut_edges.py
+++ b/gerrychain/updaters/cut_edges.py
@@ -1,6 +1,6 @@
 import collections
 
-from .flows import on_edge_flow
+from .flows import on_edge_flow, neighbor_flips
 
 
 def put_edges_into_parts(edges, assignment):
@@ -15,9 +15,8 @@ def put_edges_into_parts(edges, assignment):
 def new_cuts(partition):
     """The edges that were not cut, but now are"""
     return {
-        tuple(sorted((node, neighbor)))
-        for node in partition.flips
-        for neighbor in partition.graph.neighbors(node)
+        (node, neighbor)
+        for node, neighbor in neighbor_flips(partition)
         if partition.crosses_parts((node, neighbor))
     }
 
@@ -25,9 +24,8 @@ def new_cuts(partition):
 def obsolete_cuts(partition):
     """The edges that were cut, but now are not"""
     return {
-        tuple(sorted((node, neighbor)))
-        for node in partition.flips
-        for neighbor in partition.graph.neighbors(node)
+        (node, neighbor)
+        for node, neighbor in neighbor_flips(partition)
         if partition.parent.crosses_parts((node, neighbor))
         and not partition.crosses_parts((node, neighbor))
     }

--- a/gerrychain/updaters/flows.py
+++ b/gerrychain/updaters/flows.py
@@ -2,6 +2,16 @@ import collections
 import functools
 
 
+@functools.lru_cache(maxsize=2)
+def neighbor_flips(partition):
+    """The neighbors of the flips in a partition"""
+    return {
+        tuple(sorted((node, neighbor)))
+        for node in partition.flips
+        for neighbor in partition.graph.neighbors(node)
+    }
+
+
 def create_flow():
     return {'in': set(), 'out': set()}
 
@@ -66,36 +76,36 @@ def compute_edge_flows(partition):
     edge_flows = collections.defaultdict(create_flow)
     assignment = partition.assignment
     old_assignment = partition.parent.assignment
-    for node in partition.flips:
-        for neighbor in partition.graph.neighbors(node):
-            edge = tuple(sorted((node, neighbor)))
 
-            old_source = old_assignment[node]
-            old_target = old_assignment[neighbor]
+    for (node, neighbor) in neighbor_flips(partition):
+        edge = (node, neighbor)
 
-            new_source = assignment[node]
-            new_target = assignment[neighbor]
+        old_source = old_assignment[node]
+        old_target = old_assignment[neighbor]
 
-            cut = new_source != new_target
-            was_cut = old_source != old_target
+        new_source = assignment[node]
+        new_target = assignment[neighbor]
 
-            if not cut and was_cut:
-                edge_flows[old_target]['out'].add(edge)
-                edge_flows[old_source]['out'].add(edge)
-            elif cut and not was_cut:
-                edge_flows[new_target]['in'].add(edge)
-                edge_flows[new_source]['in'].add(edge)
-            elif cut and was_cut:
-                # If an edge was cut and still is cut, we need to make sure the
-                # edge is listed under the correct parts.
-                no_longer_incident_parts = {old_target, old_source} - \
-                                            {new_target, new_source}
-                for part in no_longer_incident_parts:
-                    edge_flows[part]['out'].add(edge)
+        cut = new_source != new_target
+        was_cut = old_source != old_target
 
-                newly_incident_parts = {new_target, new_source} - {old_target, old_source}
-                for part in newly_incident_parts:
-                    edge_flows[part]['in'].add(edge)
+        if not cut and was_cut:
+            edge_flows[old_target]['out'].add(edge)
+            edge_flows[old_source]['out'].add(edge)
+        elif cut and not was_cut:
+            edge_flows[new_target]['in'].add(edge)
+            edge_flows[new_source]['in'].add(edge)
+        elif cut and was_cut:
+            # If an edge was cut and still is cut, we need to make sure the
+            # edge is listed under the correct parts.
+            no_longer_incident_parts = {old_target, old_source} - \
+                                        {new_target, new_source}
+            for part in no_longer_incident_parts:
+                edge_flows[part]['out'].add(edge)
+
+            newly_incident_parts = {new_target, new_source} - {old_target, old_source}
+            for part in newly_incident_parts:
+                edge_flows[part]['in'].add(edge)
     return edge_flows
 
 


### PR DESCRIPTION
This is a PR broken out from #372 to ease the code review process.

In particular, this patch is intended to improve the performance of calculating `cut_edges` by introducing a `neighbor_flips` function to cache the set of neighbors of all flipped nodes. This is used to calculate the cut edges of a plan as the set of all flipped nodes is a superset of the cut edges. 

Since this is looped over a few times throughout the lifetime of a Partition object, caching improves replay performance considerably.