### PR TITLE
Add option to disable cut_edges updater with use_cut_edges flag

### DIFF
--- a/tests/partition/test_partition.py
+++ b/tests/partition/test_partition.py
@@ -56,7 +56,7 @@ def example_geographic_partition():
 
 def test_geographic_partition_can_be_instantiated(example_geographic_partition):
     partition = example_geographic_partition
-    assert partition.updaters == GeographicPartition.default_updaters
+    assert isinstance(partition, GeographicPartition)
 
 
 def test_Partition_parts_is_a_dictionary_of_parts_to_nodes(example_partition):
@@ -144,11 +144,9 @@ def test_repr(example_partition):
 
 def test_partition_has_default_updaters(example_partition):
     partition = example_partition
-    default_updaters = partition.default_updaters
     should_have_updaters = {"cut_edges": cut_edges}
 
     for updater in should_have_updaters:
-        assert default_updaters.get(updater, None) is not None
         assert should_have_updaters[updater](partition) == partition[updater]
 
 


### PR DESCRIPTION
This is a PR broken out from #372 to ease the code review process.

As noted in #368, the `cut_edges` updater is forcibly enabled by default for every Partition object. However, the user has no way of opting out of this expensive updater. Prior to `pcompress`, this wasn't a big deal. However, now that GerryChain runs are replayable (and since most analysis is now done with replayable chains), it doesn't make sense to force every partition to calculate the `cut_edges` updater. 

As an example case where this would be useful, let's say that we want to draw election histograms or simply export a few sample maps in a recorded chain run (a fairly common occurrence). In this case, there would be no need to calculate the `cut_edges` and disabling the updater by providing the `use_cut_edges` flag would result in a significant speedup.

Note that this PR is backwards compatible. By default, `cut_edges` are calculated (`use_cut_edges` defaults to `True` and is an optional argument).

Fixes #368