### PR TITLE
Add seed and freeze test to loudly detect when breaking changes are made

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
 
             # run tests
             echo "backend: Agg" > "matplotlibrc"
-            pytest -v --cov=gerrychain --junitxml=test-reports/junit.xml tests
+            pytest -v --runslow --cov=gerrychain --junitxml=test-reports/junit.xml tests
             codecov
           environment:
             PYTHONHASHSEED: "0"
@@ -56,7 +56,7 @@ jobs:
       - run:
           name: install dependencies
           command: |
-            pip install --upgrade setuptools wheel
+            pip install --upgrade setuptools wheel twine
             python setup.py install
       - run:
           name: set up .pypirc

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,3 +60,23 @@ def example_partition():
     assignment = {0: 1, 1: 1, 2: 2}
     partition = Partition(graph, assignment, {"cut_edges": cut_edges})
     return partition
+
+# From the docs: https://docs.pytest.org/en/latest/example/simple.html#control-skipping-of-tests-according-to-command-line-option
+def pytest_addoption(parser):
+    parser.addoption(
+        "--runslow", action="store_true", default=False, help="run slow tests"
+    )
+
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", "slow: mark test as slow to run")
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--runslow"):
+        # --runslow given in cli: do not skip slow tests
+        return
+    skip_slow = pytest.mark.skip(reason="need --runslow option to run")
+    for item in items:
+        if "slow" in item.keywords:
+            item.add_marker(skip_slow)

--- a/tests/test_reproducibility.py
+++ b/tests/test_reproducibility.py
@@ -59,6 +59,7 @@ def test_repeatable(three_by_three_grid):
     print(flips)
     assert flips == expected_flips
 
+@pytest.mark.slow
 def test_pa_freeze():
     from gerrychain import (
         GeographicPartition,


### PR DESCRIPTION
Some time ago, I flagged a few historical commits that unintentionally produce different chain outputs (with the same seed, etc). This is concerning (since it could mean that correctness issues were introduced in those commits). This PR adds a "seed and freeze" test to loudly detect such changes.