### PR TITLE
Rustworkx acceleration

### DIFF
--- a/gerrychain/graph/graph.py
+++ b/gerrychain/graph/graph.py
@@ -415,7 +415,7 @@ class FrozenGraph:
     def degree(self, n):
         return self.graph.degree(n)
 
-    @functools.lru_cache(65536)
+    # @functools.lru_cache(65536) # memory leak
     def lookup(self, node, field):
         return self.graph.nodes[node][field]
 
@@ -426,7 +426,7 @@ class FrozenGraph:
             )
         )
 
-    @functools.cache
+    # @functools.cache
     def pygraph_pop_lookup(self, field: str):
         attrs = [0] * len(self.pygraph.node_indexes())
         for node in self.pygraph.node_indexes():

--- a/gerrychain/graph/graph.py
+++ b/gerrychain/graph/graph.py
@@ -4,6 +4,7 @@ from typing import Any
 import warnings
 
 import networkx
+import retworkx
 from networkx.classes.function import frozen
 from networkx.readwrite import json_graph
 import pandas as pd
@@ -357,8 +358,7 @@ class FrozenGraph:
     This speeds up chain runs and prevents having to deal with cache invalidation issues.
     This class behaves slightly differently than :class:`Graph` or :class:`networkx.Graph`.
     """
-
-    __slots__ = ["graph", "size"]
+    __slots__ = ["graph", "size", "pygraph"]
 
     def __init__(self, graph: Graph):
         self.graph = networkx.classes.function.freeze(graph)

--- a/gerrychain/graph/graph.py
+++ b/gerrychain/graph/graph.py
@@ -366,6 +366,7 @@ class FrozenGraph:
         self.graph.add_data = frozen
 
         self.size = len(self.graph)
+        self.pygraph = retworkx.networkx_converter(graph, keep_attributes=True)
 
     def __len__(self):
         return self.size

--- a/gerrychain/graph/graph.py
+++ b/gerrychain/graph/graph.py
@@ -396,11 +396,8 @@ class FrozenGraph:
     def __len__(self):
         return self.size
 
-    def __getattribute__(self, __name: str) -> Any:
-        try:
-            return object.__getattribute__(self, __name)
-        except AttributeError:
-            return object.__getattribute__(self.graph, __name)
+    def __getattr__(self, __name: str) -> Any:
+        return getattr(self.graph, __name)
 
     def __getitem__(self, __name: str) -> Any:
         return self.graph[__name]

--- a/gerrychain/graph/graph.py
+++ b/gerrychain/graph/graph.py
@@ -415,7 +415,7 @@ class FrozenGraph:
     def degree(self, n):
         return self.graph.degree(n)
 
-    # @functools.lru_cache(65536) # memory leak
+    @functools.lru_cache(65536)
     def lookup(self, node, field):
         return self.graph.nodes[node][field]
 

--- a/gerrychain/graph/graph.py
+++ b/gerrychain/graph/graph.py
@@ -366,7 +366,12 @@ class FrozenGraph:
         "rustworkx_networkx_mapping"
     ]
 
-    def __init__(self, graph: Graph, pygraph: retworkx.PyGraph = None, mappings: Tuple[dict, dict] = None):
+    def __init__(
+        self,
+        graph: Graph,
+        pygraph: retworkx.PyGraph = None,
+        mappings: Tuple[dict, dict] = None
+    ):
         self.graph = networkx.classes.function.freeze(graph)
         self.graph.join = frozen
         self.graph.add_data = frozen
@@ -381,8 +386,12 @@ class FrozenGraph:
         if mappings:
             self.retworkx_networkx_mapping, self.networkx_retworkx_mapping = mappings
         else:
-            self.retworkx_networkx_mapping = {node: self.pygraph[node]["__networkx_node__"] for node in self.pygraph.node_indexes()}
-            self.networkx_retworkx_mapping = {self.pygraph[node]["__networkx_node__"]: node for node in self.pygraph.node_indexes()}
+            self.retworkx_networkx_mapping = {
+                n: self.pygraph[n]["__networkx_node__"] for n in self.pygraph.node_indexes()
+            }
+            self.networkx_retworkx_mapping = {
+                self.pygraph[n]["__networkx_node__"]: n for n in self.pygraph.node_indexes()
+            }
 
     def __len__(self):
         return self.size
@@ -420,7 +429,8 @@ class FrozenGraph:
         return self.graph.nodes[node][field]
 
     def subgraph(self, nodes):
-        return FrozenGraph(self.graph.subgraph(nodes), 
+        return FrozenGraph(
+            self.graph.subgraph(nodes),
             self.pygraph.subgraph(
                 [self.networkx_retworkx_mapping[x] for x in nodes]
             )

--- a/gerrychain/partition/assignment.py
+++ b/gerrychain/partition/assignment.py
@@ -31,10 +31,11 @@ class Assignment(Mapping):
         self.parts = parts
 
         if not mapping:
-            self.mapping = {}
+            _mapping = {}
             for part, nodes in self.parts.items():
                 for node in nodes:
-                    self.mapping[node] = part
+                    _mapping[node] = part
+            self.mapping = dict(sorted(_mapping.items()))
         else:
             self.mapping = mapping
 
@@ -96,7 +97,7 @@ class Assignment(Mapping):
         return pandas.Series(self.mapping, dtype="uint32")
 
     def to_dict(self):
-        """Convert the assignment to a ``{node: part}`` dictionary."""
+        """Convert the assignment to a ``{node: part}`` sorted dictionary."""
         return self.mapping
 
     @classmethod

--- a/gerrychain/partition/assignment.py
+++ b/gerrychain/partition/assignment.py
@@ -93,10 +93,7 @@ class Assignment(Mapping):
 
     def to_series(self):
         """Convert the assignment to a :class:`pandas.Series`."""
-        groups = [
-            pandas.Series(data=part, index=nodes) for part, nodes in self.parts.items()
-        ]
-        return pandas.concat(groups)
+        return pandas.Series(self.mapping, dtype="uint32")
 
     def to_dict(self):
         """Convert the assignment to a ``{node: part}`` dictionary."""

--- a/gerrychain/partition/assignment.py
+++ b/gerrychain/partition/assignment.py
@@ -31,11 +31,10 @@ class Assignment(Mapping):
         self.parts = parts
 
         if not mapping:
-            _mapping = {}
+            self.mapping = {}
             for part, nodes in self.parts.items():
                 for node in nodes:
-                    _mapping[node] = part
-            self.mapping = dict(sorted(_mapping.items()))
+                    self.mapping[node] = part
         else:
             self.mapping = mapping
 
@@ -94,10 +93,13 @@ class Assignment(Mapping):
 
     def to_series(self):
         """Convert the assignment to a :class:`pandas.Series`."""
-        return pandas.Series(self.mapping, dtype="uint32")
+        groups = [
+            pandas.Series(data=part, index=nodes) for part, nodes in self.parts.items()
+        ]
+        return pandas.concat(groups)
 
     def to_dict(self):
-        """Convert the assignment to a ``{node: part}`` sorted dictionary."""
+        """Convert the assignment to a ``{node: part}`` dictionary."""
         return self.mapping
 
     @classmethod

--- a/gerrychain/proposals/tree_proposals.py
+++ b/gerrychain/proposals/tree_proposals.py
@@ -45,16 +45,15 @@ def recom(
         partition.parts[parts_to_merge[0]] | partition.parts[parts_to_merge[1]]
     )
 
-    flips = {
-        x: parts_to_merge[0] 
-        for x in bipartition_tree_retworkx(
-            subgraph,
-            pop_col=pop_col,
-            pop_target=pop_target,
-            epsilon=epsilon,
-            node_repeats=node_repeats,
-        )
-    }
+    flips = recursive_tree_part(
+        subgraph,
+        parts_to_merge,
+        pop_col=pop_col,
+        pop_target=pop_target,
+        epsilon=epsilon,
+        node_repeats=node_repeats,
+        method=method,
+    )
 
     return partition.flip(flips)
 

--- a/gerrychain/proposals/tree_proposals.py
+++ b/gerrychain/proposals/tree_proposals.py
@@ -4,12 +4,12 @@ from ..random import random
 from ..tree import (
     recursive_tree_part, bipartition_tree, bipartition_tree_random,
     _bipartition_tree_random_all, uniform_spanning_tree,
-    find_balanced_edge_cuts_memoization,
+    find_balanced_edge_cuts_memoization, bipartition_tree_retworkx
 )
 
 
 def recom(
-    partition, pop_col, pop_target, epsilon, node_repeats=1, method=bipartition_tree
+    partition, pop_col, pop_target, epsilon, node_repeats=1, method=bipartition_tree_retworkx
 ):
     """ReCom proposal.
 
@@ -46,7 +46,7 @@ def recom(
     )
 
     flips = recursive_tree_part(
-        subgraph.graph,
+        subgraph,
         parts_to_merge,
         pop_col=pop_col,
         pop_target=pop_target,

--- a/gerrychain/proposals/tree_proposals.py
+++ b/gerrychain/proposals/tree_proposals.py
@@ -45,15 +45,16 @@ def recom(
         partition.parts[parts_to_merge[0]] | partition.parts[parts_to_merge[1]]
     )
 
-    flips = recursive_tree_part(
-        subgraph,
-        parts_to_merge,
-        pop_col=pop_col,
-        pop_target=pop_target,
-        epsilon=epsilon,
-        node_repeats=node_repeats,
-        method=method,
-    )
+    flips = {
+        x: parts_to_merge[0] 
+        for x in bipartition_tree_retworkx(
+            subgraph,
+            pop_col=pop_col,
+            pop_target=pop_target,
+            epsilon=epsilon,
+            node_repeats=node_repeats,
+        )
+    }
 
     return partition.flip(flips)
 

--- a/gerrychain/proposals/tree_proposals.py
+++ b/gerrychain/proposals/tree_proposals.py
@@ -45,15 +45,16 @@ def recom(
         partition.parts[parts_to_merge[0]] | partition.parts[parts_to_merge[1]]
     )
 
-    flips = recursive_tree_part(
+    flips_left, flips_right = bipartition_tree_retworkx(
         subgraph,
-        parts_to_merge,
         pop_col=pop_col,
         pop_target=pop_target,
         epsilon=epsilon,
         node_repeats=node_repeats,
-        method=method,
     )
+
+    flips = {node: parts_to_merge[0] for node in flips_left}
+    flips |= {node: parts_to_merge[1] for node in flips_right}
 
     return partition.flip(flips)
 

--- a/gerrychain/proposals/tree_proposals.py
+++ b/gerrychain/proposals/tree_proposals.py
@@ -54,7 +54,7 @@ def recom(
     )
 
     flips = {node: parts_to_merge[0] for node in flips_left}
-    flips |= {node: parts_to_merge[1] for node in flips_right}
+    flips.update({node: parts_to_merge[1] for node in flips_right})
 
     return partition.flip(flips)
 

--- a/gerrychain/proposals/tree_proposals.py
+++ b/gerrychain/proposals/tree_proposals.py
@@ -1,10 +1,11 @@
 from functools import partial
-from ..random import random
 
+from ..random import random
 from ..tree import (
-    recursive_tree_part, bipartition_tree, bipartition_tree_random,
+    bipartition_tree_random,
     _bipartition_tree_random_all, uniform_spanning_tree,
     find_balanced_edge_cuts_memoization, bipartition_tree_retworkx
+    # recursive_tree_part, bipartition_tree,
 )
 
 

--- a/gerrychain/proposals/tree_proposals.py
+++ b/gerrychain/proposals/tree_proposals.py
@@ -4,13 +4,12 @@ from ..random import random
 from ..tree import (
     bipartition_tree_random,
     _bipartition_tree_random_all, uniform_spanning_tree,
-    find_balanced_edge_cuts_memoization, bipartition_tree_retworkx
-    # recursive_tree_part, bipartition_tree,
+    find_balanced_edge_cuts_memoization, bipartition_tree_retworkx,
+    recursive_tree_part, bipartition_tree,
 )
 
-
 def recom(
-    partition, pop_col, pop_target, epsilon, node_repeats=1, method=bipartition_tree_retworkx
+    partition, pop_col, pop_target, epsilon, node_repeats=1, method=bipartition_tree
 ):
     """ReCom proposal.
 
@@ -46,12 +45,33 @@ def recom(
         partition.parts[parts_to_merge[0]] | partition.parts[parts_to_merge[1]]
     )
 
-    flips_left, flips_right = bipartition_tree_retworkx(
-        subgraph,
+    flips = recursive_tree_part(
+        subgraph.graph,
+        parts_to_merge,
         pop_col=pop_col,
         pop_target=pop_target,
         epsilon=epsilon,
         node_repeats=node_repeats,
+        method=method,
+    )
+
+    return partition.flip(flips)
+
+
+def recom_rust(partition, pop_col, pop_target, epsilon):
+    """Accelerated ReCom proposal (experimental, requires GerryChain.rs)."""
+    edge = random.choice(tuple(partition["cut_edges"]))
+    parts_to_merge = (partition.assignment.mapping[edge[0]], partition.assignment.mapping[edge[1]])
+
+    subgraph = partition.graph.subgraph(
+        partition.parts[parts_to_merge[0]] | partition.parts[parts_to_merge[1]]
+    )
+
+    flips_left, flips_right = bipartition_tree_retworkx(
+        subgraph,
+        pop_col=pop_col,
+        pop_target=pop_target,
+        epsilon=epsilon
     )
 
     flips = {node: parts_to_merge[0] for node in flips_left}

--- a/gerrychain/tree.py
+++ b/gerrychain/tree.py
@@ -189,7 +189,7 @@ def bipartition_tree_retworkx(
 
     balanced_node_choices = retworkx.bipartition_tree(graph.pygraph, lambda x: random.random(), pops, float(pop_target), float(epsilon))
     balanced_nodes = {graph.retworkx_networkx_mapping[x] for x in choice(balanced_node_choices)[1]}
-    return (balanced_nodes, graph.node_indicies - balanced_nodes)
+    return (balanced_nodes, graph.node_indices - balanced_nodes)
 
 
 def bipartition_tree(
@@ -229,7 +229,7 @@ def bipartition_tree(
     :param choice: :func:`random.choice`. Can be substituted for testing.
     :param max_atempts: The max number of attempts that should be made to bipartition.
     """
-    populations = {node: graph.lookup(node, pop_col) for node in graph.node_indicies}
+    populations = {node: graph.lookup(node, pop_col) for node in graph.node_indices}
 
     possible_cuts = []
     if spanning_tree is None:
@@ -267,7 +267,7 @@ def _bipartition_tree_random_all(
     max_attempts: Optional[int] = None
 ):
     """Randomly bipartitions a graph and returns all cuts."""
-    populations = {node: graph.lookup(node, pop_col) for node in graph.node_indicies}
+    populations = {node: graph.lookup(node, pop_col) for node in graph.node_indices}
 
     possible_cuts = []
     if spanning_tree is None:
@@ -452,7 +452,7 @@ def get_seed_chunks(
         new_epsilon = epsilon
 
     chunk_pop = 0
-    for node in graph.node_indicies:
+    for node in graph.node_indices:
         chunk_pop += graph.lookup(node, pop_col)
 
     while True:

--- a/gerrychain/tree.py
+++ b/gerrychain/tree.py
@@ -89,7 +89,7 @@ class PopulatedGraph:
     def contract_node(self, node, parent) -> None:
         self.population[parent] += self.population[node]
         self.subsets[parent] |= self.subsets[node]
-        self._degrees[parent] -= 1
+        self.degrees[parent] -= 1
 
     def has_ideal_population(self, node) -> bool:
         return (
@@ -103,12 +103,12 @@ Cut = namedtuple("Cut", "edge subset")
 def find_balanced_edge_cuts_contraction(
         h: PopulatedGraph, choice: Callable = random.choice) -> List[Cut]:
     # this used to be greater than 2 but failed on small grids:(
-    root = choice([x for x in h if h.degree(x) > 1])
+    root = choice([x for x in h if h.degrees[x] > 1])
     # BFS predecessors for iteratively contracting leaves
     pred = predecessors(h.graph, root)
 
     cuts = []
-    leaves = deque(x for x in h if h.degree(x) == 1)
+    leaves = deque(x for x in h if h.degrees[x] == 1)
     while len(leaves) > 0:
         leaf = leaves.popleft()
         if h.has_ideal_population(leaf):
@@ -116,7 +116,7 @@ def find_balanced_edge_cuts_contraction(
         # Contract the leaf:
         parent = pred[leaf]
         h.contract_node(leaf, parent)
-        if h.degree(parent) == 1 and parent != root:
+        if h.degrees[parent] == 1 and parent != root:
             leaves.append(parent)
     return cuts
 

--- a/gerrychain/tree.py
+++ b/gerrychain/tree.py
@@ -187,8 +187,9 @@ def bipartition_tree_retworkx(
 ):
     pops = graph.pygraph_pop_lookup(pop_col)
 
-    balanced_nodes = retworkx.bipartition_tree(graph.pygraph, lambda x: random.random(), pops, pop_target, epsilon)
-    return {graph.retworkx_networkx_mapping[x] for x in choice(balanced_nodes)[1]}
+    balanced_node_choices = retworkx.bipartition_tree(graph.pygraph, lambda x: random.random(), pops, float(pop_target), float(epsilon))
+    balanced_nodes = {graph.retworkx_networkx_mapping[x] for x in choice(balanced_node_choices)[1]}
+    return (balanced_nodes, graph.node_indicies - balanced_nodes)
 
 
 def bipartition_tree(

--- a/gerrychain/tree.py
+++ b/gerrychain/tree.py
@@ -78,7 +78,7 @@ class PopulatedGraph:
         self.tot_pop = sum(self.population.values())
         self.ideal_pop = ideal_pop
         self.epsilon = epsilon
-        self._degrees = {node: graph.degree(node) for node in graph.nodes}
+        self.degrees = {node: graph.degree(node) for node in graph.nodes}
 
     def __iter__(self):
         return iter(self.graph)

--- a/gerrychain/tree.py
+++ b/gerrychain/tree.py
@@ -208,7 +208,7 @@ def bipartition_tree(
     :param choice: :func:`random.choice`. Can be substituted for testing.
     :param max_atempts: The max number of attempts that should be made to bipartition.
     """
-    populations = {node: graph.nodes[node][pop_col] for node in graph.node_indices}
+    populations = {node: graph.lookup(node, pop_col) for node in graph.node_indicies}
 
     possible_cuts = []
     if spanning_tree is None:
@@ -246,7 +246,7 @@ def _bipartition_tree_random_all(
     max_attempts: Optional[int] = None
 ):
     """Randomly bipartitions a graph and returns all cuts."""
-    populations = {node: graph.nodes[node][pop_col] for node in graph.node_indices}
+    populations = {node: graph.lookup(node, pop_col) for node in graph.node_indicies}
 
     possible_cuts = []
     if spanning_tree is None:
@@ -383,7 +383,7 @@ def recursive_tree_part(
         part_pop = 0
         for node in nodes:
             flips[node] = part
-            part_pop += graph.nodes[node][pop_col]
+            part_pop += graph.lookup(node, pop_col)
         debt += part_pop - pop_target
         remaining_nodes -= nodes
 
@@ -425,8 +425,8 @@ def get_seed_chunks(
         new_epsilon = epsilon
 
     chunk_pop = 0
-    for node in graph.node_indices:
-        chunk_pop += graph.nodes[node][pop_col]
+    for node in graph.node_indicies:
+        chunk_pop += graph.lookup(node, pop_col)
 
     while True:
         epsilon = abs(epsilon)
@@ -466,7 +466,7 @@ def get_seed_chunks(
 
         part_pop = 0
         for node in remaining_nodes:
-            part_pop += graph.nodes[node][pop_col]
+            part_pop += graph.lookup(node, pop_col)
         part_pop_as_dist = part_pop / num_chunks_left
         fake_epsilon = epsilon
         if num_chunks_left != 1:

--- a/gerrychain/tree.py
+++ b/gerrychain/tree.py
@@ -185,12 +185,10 @@ def bipartition_tree_retworkx(
     balance_edge_fn=None,
     choice=random.choice
 ):
-    pops = [0] * len(graph.pygraph.node_indexes())
-    for node in graph.pygraph.node_indexes():
-        pops[node] = float(graph.pygraph[node][pop_col])
+    pops = graph.pygraph_pop_lookup(pop_col)
 
     balanced_nodes = retworkx.bipartition_tree(graph.pygraph, lambda x: random.random(), pops, float(pop_target), float(epsilon))
-    return {graph.pygraph[x]["__networkx_node__"] for x in choice(balanced_nodes)[1]}
+    return {graph.retworkx_networkx_mapping[x] for x in choice(balanced_nodes)[1]}
 
 
 def bipartition_tree(

--- a/gerrychain/tree.py
+++ b/gerrychain/tree.py
@@ -187,7 +187,7 @@ def bipartition_tree_retworkx(
 ):
     pops = graph.pygraph_pop_lookup(pop_col)
 
-    balanced_node_choices = retworkx.bipartition_graph(
+    balanced_node_choices = retworkx.bipartition_graph_mst(
         graph.pygraph,
         lambda x: random.random(),
         pops,

--- a/gerrychain/tree.py
+++ b/gerrychain/tree.py
@@ -1,3 +1,6 @@
+from gerrychain.graph.graph import FrozenGraph
+
+import retworkx
 import networkx as nx
 from networkx.algorithms import tree
 
@@ -169,6 +172,25 @@ def find_balanced_edge_cuts_memoization(
             cuts.append(Cut(edge=(node, pred[node]),
                             subset=set(h.graph.nodes) - part_nodes(node)))
     return cuts
+
+
+def bipartition_tree_retworkx(
+    graph: FrozenGraph,
+    pop_col: str,
+    pop_target: float,
+    epsilon: float,
+    node_repeats=1,
+    spanning_tree=None,
+    spanning_tree_fn=None,
+    balance_edge_fn=None,
+    choice=random.choice
+):
+    pops = [0] * len(graph.pygraph.node_indexes())
+    for node in graph.pygraph.node_indexes():
+        pops[node] = float(graph.pygraph[node][pop_col])
+
+    balanced_nodes = retworkx.bipartition_tree(graph.pygraph, lambda x: random.random(), pops, float(pop_target), float(epsilon))
+    return {graph.pygraph[x]["__networkx_node__"] for x in choice(balanced_nodes)[1]}
 
 
 def bipartition_tree(

--- a/gerrychain/tree.py
+++ b/gerrychain/tree.py
@@ -187,7 +187,13 @@ def bipartition_tree_retworkx(
 ):
     pops = graph.pygraph_pop_lookup(pop_col)
 
-    balanced_node_choices = retworkx.bipartition_tree(graph.pygraph, lambda x: random.random(), pops, float(pop_target), float(epsilon))
+    balanced_node_choices = retworkx.bipartition_tree(
+        graph.pygraph,
+        lambda x: random.random(),
+        pops,
+        float(pop_target),
+        float(epsilon)
+    )
     balanced_nodes = {graph.retworkx_networkx_mapping[x] for x in choice(balanced_node_choices)[1]}
     return (balanced_nodes, graph.node_indices - balanced_nodes)
 

--- a/gerrychain/tree.py
+++ b/gerrychain/tree.py
@@ -187,7 +187,7 @@ def bipartition_tree_retworkx(
 ):
     pops = graph.pygraph_pop_lookup(pop_col)
 
-    balanced_node_choices = retworkx.bipartition_tree(
+    balanced_node_choices = retworkx.bipartition_graph(
         graph.pygraph,
         lambda x: random.random(),
         pops,

--- a/gerrychain/tree.py
+++ b/gerrychain/tree.py
@@ -187,7 +187,7 @@ def bipartition_tree_retworkx(
 ):
     pops = graph.pygraph_pop_lookup(pop_col)
 
-    balanced_nodes = retworkx.bipartition_tree(graph.pygraph, lambda x: random.random(), pops, float(pop_target), float(epsilon))
+    balanced_nodes = retworkx.bipartition_tree(graph.pygraph, lambda x: random.random(), pops, pop_target, epsilon)
     return {graph.retworkx_networkx_mapping[x] for x in choice(balanced_nodes)[1]}
 
 
@@ -389,8 +389,14 @@ def recursive_tree_part(
     for part in parts[:-1]:
         min_pop = max(pop_target * (1 - epsilon), pop_target * (1 - epsilon) - debt)
         max_pop = min(pop_target * (1 + epsilon), pop_target * (1 + epsilon) - debt)
+
+        if len(parts[:-1]) == 1:  # prevent unnecessary subgraphing
+            subgraph = graph
+        else:
+            subgraph = graph.subgraph(remaining_nodes)
+
         nodes = method(
-            graph.subgraph(remaining_nodes),
+            subgraph,
             pop_col=pop_col,
             pop_target=(min_pop + max_pop) / 2,
             epsilon=(max_pop - min_pop) / (2 * pop_target),

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ requirements = [
     "scipy",
     "networkx",
     "matplotlib",
+    "retworkx",
 ]
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -6,12 +6,10 @@ with open("./README.rst") as f:
     long_description = f.read()
 
 requirements = [
-    # package requirements go here
     "pandas",
     "scipy",
     "networkx",
     "matplotlib",
-    "retworkx",
 ]
 
 setup(
@@ -37,6 +35,7 @@ setup(
         "License :: OSI Approved :: BSD License",
     ],
     extras_require={
-        'geo': ["shapely>=2.0.1", "geopandas>=0.12.2"]
+        'geo': ["shapely>=2.0.1", "geopandas>=0.12.2"],
+        'rust': ["gerrychain_rs>=0.1"],
     }
 )


### PR DESCRIPTION
This is a draft PR (based off `perf-tuning` that rewrites the balance edge picking algorithm in Rust using `retworkx`, yielding a ~16x speedup in chain run times).

PA chain run times (congressional) are now at 50 it/s on my computer with commit e9eddbef5b82522e4d1d3c12e68d35958fb1cae9 (as opposed to ~3 it/s). This also leaves a few more low-hanging fruit optimizations on the table which could yield more speedups in the future. 

Some of the new `retworkx` code has been upstreamed, other bits are in the process of being upstreamed. This PR works with my `feat-balanced-cut-edges` branch here: https://github.com/InnovativeInventor/retworkx/tree/feat-balanced-cut-edges.