### PR TITLE
Replace references to assignment[node] to assignment.mapping[node] to reduce __getitem__ overhead

### DIFF
--- a/gerrychain/constraints/contiguity.py
+++ b/gerrychain/constraints/contiguity.py
@@ -78,7 +78,7 @@ def single_flip_contiguous(partition):
         """Compute the district edge weight, which is 1 if the nodes have the same
         assignment, and infinity otherwise.
         """
-        if assignment[start_node] != assignment[end_node]:
+        if assignment.mapping[start_node] != assignment.mapping[end_node]:
             # Fun fact: networkx actually refuses to take edges with None
             # weight.
             return True
@@ -86,12 +86,12 @@ def single_flip_contiguous(partition):
         return False
 
     for changed_node in flips:
-        old_assignment = partition.parent.assignment[changed_node]
+        old_assignment = partition.parent.assignment.mapping[changed_node]
 
         old_neighbors = [
             node
             for node in graph.neighbors(changed_node)
-            if assignment[node] == old_assignment
+            if assignment.mapping[node] == old_assignment
         ]
 
         if not old_neighbors:
@@ -130,7 +130,7 @@ def affected_parts(partition):
     affected = set()
     for node, part in flips.items():
         affected.add(part)
-        affected.add(parent.assignment[node])
+        affected.add(parent.assignment.mapping[node])
 
     return affected
 

--- a/gerrychain/grid.py
+++ b/gerrychain/grid.py
@@ -99,7 +99,7 @@ class Grid(Partition):
         grid.
         """
         m, n = self.dimensions
-        return [[self.assignment[(i, j)] for i in range(m)] for j in range(n)]
+        return [[self.assignment.mapping[(i, j)] for i in range(m)] for j in range(n)]
 
 
 def create_grid_graph(dimensions, with_diagonals):

--- a/gerrychain/metagraph.py
+++ b/gerrychain/metagraph.py
@@ -5,7 +5,7 @@ from .constraints import Validator
 
 def all_cut_edge_flips(partition):
     for edge, index in product(partition.cut_edges, (0, 1)):
-        yield {edge[index]: partition.assignment[edge[1 - index]]}
+        yield {edge[index]: partition.assignment.mapping[edge[1 - index]]}
 
 
 def all_valid_states_one_flip_away(partition, constraints):

--- a/gerrychain/partition/partition.py
+++ b/gerrychain/partition/partition.py
@@ -111,7 +111,7 @@ class Partition:
         :param edge: tuple of node IDs
         :rtype: bool
         """
-        return self.assignment[edge[0]] != self.assignment[edge[1]]
+        return self.assignment.mapping[edge[0]] != self.assignment.mapping[edge[1]]
 
     def __getitem__(self, key):
         """Allows accessing the values of updaters computed for this

--- a/gerrychain/proposals/proposals.py
+++ b/gerrychain/proposals/proposals.py
@@ -24,7 +24,7 @@ def propose_flip_every_district(partition):
 
         index = random.choice((0, 1))
         flipped_node, other_node = edge[index], edge[1 - index]
-        flip = {flipped_node: partition.assignment[other_node]}
+        flip = {flipped_node: partition.assignment.mapping[other_node]}
 
         flips.update(flip)
 
@@ -47,11 +47,11 @@ def propose_chunk_flip(partition):
     valid_flips = [
         nbr
         for nbr in partition.graph.neighbors(flipped_node)
-        if partition.assignment[nbr] != partition.assignment[flipped_node]
+        if partition.assignment.mapping[nbr] != partition.assignment.mapping[flipped_node]
     ]
 
     for flipped_neighbor in valid_flips:
-        flips.update({flipped_neighbor: partition.assignment[flipped_node]})
+        flips.update({flipped_neighbor: partition.assignment.mapping[flipped_node]})
 
     return partition.flip(flips)
 
@@ -67,7 +67,7 @@ def propose_random_flip(partition):
     edge = random.choice(tuple(partition["cut_edges"]))
     index = random.choice((0, 1))
     flipped_node, other_node = edge[index], edge[1 - index]
-    flip = {flipped_node: partition.assignment[other_node]}
+    flip = {flipped_node: partition.assignment.mapping[other_node]}
     return partition.flip(flip)
 
 
@@ -86,9 +86,9 @@ def slow_reversible_propose_bi(partition):
     b_nodes = {x[0] for x in partition["cut_edges"]}.union({x[1] for x in partition["cut_edges"]})
 
     flip = random.choice(list(b_nodes))
-    neighbor_assignments = list(set([partition.assignment[neighbor] for neighbor
+    neighbor_assignments = list(set([partition.assignment.mapping[neighbor] for neighbor
                                 in partition.graph.neighbors(flip)]))
-    neighbor_assignments.remove(partition.assignment[flip])
+    neighbor_assignments.remove(partition.assignment.mapping[flip])
     flips = {flip: random.choice(neighbor_assignments)}
 
     return partition.flip(flips)
@@ -107,8 +107,8 @@ def slow_reversible_propose(partition):
     :return: a proposed next `~gerrychain.Partition`
     """
 
-    b_nodes = {(x[0], partition.assignment[x[1]]) for x in partition["cut_edges"]
-               }.union({(x[1], partition.assignment[x[0]]) for x in partition["cut_edges"]})
+    b_nodes = {(x[0], partition.assignment.mapping[x[1]]) for x in partition["cut_edges"]
+               }.union({(x[1], partition.assignment.mapping[x[0]]) for x in partition["cut_edges"]})
 
     flip = random.choice(list(b_nodes))
     return partition.flip({flip[0]: flip[1]})

--- a/gerrychain/proposals/spectral_proposals.py
+++ b/gerrychain/proposals/spectral_proposals.py
@@ -59,7 +59,7 @@ def spectral_recom(partition, weight_type=None, lap_type="normalized"):
     """
 
     edge = random.choice(tuple(partition["cut_edges"]))
-    parts_to_merge = (partition.assignment[edge[0]], partition.assignment[edge[1]])
+    parts_to_merge = (partition.assignment.mapping[edge[0]], partition.assignment.mapping[edge[1]])
 
     subgraph = partition.graph.subgraph(
         partition.parts[parts_to_merge[0]] | partition.parts[parts_to_merge[1]]

--- a/gerrychain/proposals/tree_proposals.py
+++ b/gerrychain/proposals/tree_proposals.py
@@ -39,7 +39,7 @@ def recom(
 
     """
     edge = random.choice(tuple(partition["cut_edges"]))
-    parts_to_merge = (partition.assignment[edge[0]], partition.assignment[edge[1]])
+    parts_to_merge = (partition.assignment.mapping[edge[0]], partition.assignment.mapping[edge[1]])
 
     subgraph = partition.graph.subgraph(
         partition.parts[parts_to_merge[0]] | partition.parts[parts_to_merge[1]]
@@ -65,8 +65,8 @@ def reversible_recom(partition, pop_col, pop_target, epsilon,
     def dist_pair_edges(part, a, b):
         return set(
             e for e in part.graph.edges
-            if ((part.assignment[e[0]] == a and part.assignment[e[1]] == b) or
-                (part.assignment[e[0]] == b and part.assignment[e[1]] == a))
+            if ((part.assignment.mapping[e[0]] == a and part.assignment.mapping[e[1]] == b) or
+                (part.assignment.mapping[e[0]] == b and part.assignment.mapping[e[1]] == a))
         )
 
     def bounded_balance_edge_fn(*args, **kwargs):
@@ -95,7 +95,7 @@ def reversible_recom(partition, pop_col, pop_target, epsilon,
         return partition    # self-loop: no adjacency
 
     edge = random.choice(list(pair_edges))
-    parts_to_merge = (partition.assignment[edge[0]], partition.assignment[edge[1]])
+    parts_to_merge = (partition.assignment.mapping[edge[0]], partition.assignment.mapping[edge[1]])
     subgraph = partition.graph.subgraph(
         partition.parts[parts_to_merge[0]] | partition.parts[parts_to_merge[1]]
     )

--- a/gerrychain/updaters/compactness.py
+++ b/gerrychain/updaters/compactness.py
@@ -17,7 +17,7 @@ def boundary_nodes(partition, alias="boundary_nodes"):
 def initialize_exterior_boundaries_as_a_set(partition):
     part_boundaries = collections.defaultdict(set)
     for node in partition["boundary_nodes"]:
-        part_boundaries[partition.assignment[node]].add(node)
+        part_boundaries[partition.assignment.mapping[node]].add(node)
     return part_boundaries
 
 
@@ -31,7 +31,7 @@ def initialize_exterior_boundaries(partition):
     graph_boundary = partition["boundary_nodes"]
     boundaries = collections.defaultdict(lambda: 0)
     for node in graph_boundary:
-        part = partition.assignment[node]
+        part = partition.assignment.mapping[node]
         boundaries[part] += partition.graph.nodes[node]["boundary_perim"]
     return boundaries
 

--- a/gerrychain/updaters/county_splits.py
+++ b/gerrychain/updaters/county_splits.py
@@ -43,7 +43,7 @@ def compute_county_splits(partition, county_field, partition_field):
                 split, nodes, seen = CountySplit.NOT_SPLIT, [], set()
 
             nodes.append(node)
-            seen.update(set([partition.assignment[node]]))
+            seen.update(set([partition.assignment.mapping[node]]))
 
             if len(seen) > 1:
                 split = CountySplit.OLD_SPLIT
@@ -56,7 +56,7 @@ def compute_county_splits(partition, county_field, partition_field):
 
     parent = partition.parent
     for county, county_info in parent[partition_field].items():
-        seen = set(partition.assignment[node] for node in county_info.nodes)
+        seen = set(partition.assignment.mapping[node] for node in county_info.nodes)
 
         split = CountySplit.NOT_SPLIT
 

--- a/gerrychain/updaters/cut_edges.py
+++ b/gerrychain/updaters/cut_edges.py
@@ -7,8 +7,8 @@ def put_edges_into_parts(edges, assignment):
     by_part = collections.defaultdict(set)
     for edge in edges:
         # add edge to the sets corresponding to the parts it touches
-        by_part[assignment[edge[0]]].add(edge)
-        by_part[assignment[edge[1]]].add(edge)
+        by_part[assignment.mapping[edge[0]]].add(edge)
+        by_part[assignment.mapping[edge[1]]].add(edge)
     return by_part
 
 

--- a/gerrychain/updaters/flows.py
+++ b/gerrychain/updaters/flows.py
@@ -19,7 +19,7 @@ def create_flow():
 def flows_from_changes(old_assignment, flips):
     flows = collections.defaultdict(create_flow)
     for node, target in flips.items():
-        source = old_assignment[node]
+        source = old_assignment.mapping[node]
         if source != target:
             flows[target]['in'].add(node)
             flows[source]['out'].add(node)
@@ -80,11 +80,11 @@ def compute_edge_flows(partition):
     for (node, neighbor) in neighbor_flips(partition):
         edge = (node, neighbor)
 
-        old_source = old_assignment[node]
-        old_target = old_assignment[neighbor]
+        old_source = old_assignment.mapping[node]
+        old_target = old_assignment.mapping[neighbor]
 
-        new_source = assignment[node]
-        new_target = assignment[neighbor]
+        new_source = assignment.mapping[node]
+        new_target = assignment.mapping[neighbor]
 
         cut = new_source != new_target
         was_cut = old_source != old_target

--- a/gerrychain/updaters/locality_split_scores.py
+++ b/gerrychain/updaters/locality_split_scores.py
@@ -172,9 +172,9 @@ class LocalitySplits:
             locality = partition.graph.nodes[n][self.col_id]
             if locality not in locality_intersections:
                 locality_intersections[locality] = set(
-                    [partition.assignment[n]])
+                    [partition.assignment.mapping[n]])
 
-            locality_intersections[locality].update([partition.assignment[n]])
+            locality_intersections[locality].update([partition.assignment.mapping[n]])
 
         pieces = 0
         for locality in locality_intersections:


### PR DESCRIPTION
This is a PR broken out from #372 to ease the code review process. These sets of PRs are the second and final batch -- after every PR from this batch is merged in, the entire `perf-tuning` branch will be considered fully merged in and done.