### PR TITLE
Initial EmbeddedGraph implementation.

### DIFF
--- a/gerrychain/partition/partition.py
+++ b/gerrychain/partition/partition.py
@@ -2,7 +2,7 @@ import json
 import geopandas
 import networkx
 
-from gerrychain.graph.graph import FrozenGraph, Graph
+from gerrychain.graph.graph import FrozenGraph, Graph, EmbeddedGraph
 from ..updaters import compute_edge_flows, flows_from_changes, cut_edges
 from .assignment import get_assignment
 from .subgraphs import SubgraphView
@@ -60,6 +60,10 @@ class Partition:
             self.graph = FrozenGraph(graph)
         elif isinstance(graph, FrozenGraph):
             self.graph = graph
+        elif isinstance(graph, EmbeddedGraph):
+            graph.geometries = None
+            graph.hulls = None
+            self.graph = FrozenGraph(graph)
         else:
             raise TypeError("Unsupported Graph object")
 


### PR DESCRIPTION
Because we are often interested in contour-based compactness scores (e.g. Polsby-Popper, Reock, Convex Hull, etc.), this implements the `EmbeddedGraph` class where each networkx node stores information about the (multi)polygon to which it's dual. Exterior nodes – those which form the boundary of the jurisdiction – store all the points from their dual polygons, while interior nodes store only the points on their dual polygons' convex hulls. This accomplishes a few things:

1. first, we can easily access geometric information about the graph's embedding (or, rather, the embedding of the set of polygons to which the graph is dual) and modify it easily;
2. the above enables us to – with some other optimizations/tricks – quickly calculate contour-based compactness scores without storing or otherwise keeping track of extraneous geometric information in other formats (e.g. shapefiles, GeoJSON;
3. if we choose _not_ to calculate compactness scores during chain runs, we can store only assignments, then re-project and score after-the-fact.

This is _of course_ a WIP and needs feedback from everyone, but I believe it's a useful tool and can serve us well in future.