### PR TITLE
Remove duplicate frozen call in FrozenGraph

### DIFF
--- a/gerrychain/graph/graph.py
+++ b/gerrychain/graph/graph.py
@@ -351,7 +351,6 @@ class FrozenGraph:
         self.graph = networkx.classes.function.freeze(graph)
         self.graph.join = frozen
         self.graph.add_data = frozen
-        self.graph.add_data = frozen
 
         self.size = len(self.graph)
 


### PR DESCRIPTION
I think this was accidentally introduced during one of my rebases -- oops!