### PR TITLE
Add split pairs metric

### DIFF
--- a/gerrychain/updaters/locality_split_scores.py
+++ b/gerrychain/updaters/locality_split_scores.py
@@ -365,19 +365,21 @@ class LocalitySplits:
 
         :param partition: The partition to be scored.
 
-        :return: Proportion of the pairs of people in the same locality who are split into different districts,
-        population-weighted by locality
+        :return: Proportion of the pairs of people in the same locality
+        who are split into different districts, population-weighted by locality
         '''
 
         # get list of districts
         districts = dict(partition.parts).keys()
 
-        # initialize dictionary keyed by locality, values are dicts of district : intersection_pop
+        # initialize dictionary keyed by locality, values are dicts of
+        # district : intersection_pop
         district_pops_per_locality = {}
 
         # initialize inner dicts
         for locality in self.localities:
-            district_pops_per_locality[locality] = {district: 0.0 for district in districts}
+            district_pops_per_locality[locality] = {district: 0.0
+                                                    for district in districts}
 
         # for each district
         for district in districts:
@@ -385,12 +387,12 @@ class LocalitySplits:
             # get the vtds assigned to this district in the partition
             vtds = partition.parts[district]
 
-            # for each vtd, add the population to the appropriate locality-district pair
+            # for each vtd, add the population to the proper locality-district pair
             for vtd in vtds:
                 district_pops_per_locality[self.localitydict[vtd]][district] += \
                     partition.graph.nodes[vtd][self.pop_col]
 
-        # initialize lists for split pairs scores by locality and populations by locality
+        # initialize lists for split pairs scores by locality and populations
         scores = []
         loc_pops = []
 
@@ -411,4 +413,4 @@ class LocalitySplits:
             loc_pops += [total_pop]
 
         # return population-weighted average of split pairs score
-        return sum([scores[i] * pop for i, pop in enumerate(loc_pops)]) / sum(loc_pops)
+        return sum([scores[i] * p for i, p in enumerate(loc_pops)]) / sum(loc_pops)

--- a/gerrychain/updaters/locality_split_scores.py
+++ b/gerrychain/updaters/locality_split_scores.py
@@ -50,7 +50,7 @@ class LocalitySplits:
             score functions to compute at each step. This should be
             some subcollection of ```['num_parts', 'num_pieces',
             'naked_boundary', 'shannon_entropy', 'power_entropy',
-            'symmetric_entropy', 'num_split_localities']```
+            'symmetric_entropy', 'num_split_localities', 'split_pairs']```
         :param pent_alpha: A number between 0 and 1 which is
             passed as the exponent to :meth:`~LocalitySplits.power_entropy`
         """
@@ -138,6 +138,9 @@ class LocalitySplits:
 
             if s == 'num_split_localities':
                 self.scores[s] = self.num_split_localities(partition)
+
+            if s == 'split_pairs':
+                self.scores[s] = self.split_pairs(partition)
 
         return self.scores
 
@@ -355,3 +358,57 @@ class LocalitySplits:
                 total_splits += 1
 
         return total_splits
+
+    def split_pairs(self, partition):
+        '''
+        Calculates population-weighted split pairs score
+
+        :param partition: The partition to be scored.
+
+        :return: Proportion of the pairs of people in the same locality who are split into different districts,
+        population-weighted by locality
+        '''
+
+        # get list of districts
+        districts = dict(partition.parts).keys()
+
+        # initialize dictionary keyed by locality, values are dicts of district : intersection_pop
+        district_pops_per_locality = {}
+
+        # initialize inner dicts
+        for locality in self.localities:
+            district_pops_per_locality[locality] = {district: 0.0 for district in districts}
+
+        # for each district
+        for district in districts:
+
+            # get the vtds assigned to this district in the partition
+            vtds = partition.parts[district]
+
+            # for each vtd, add the population to the appropriate locality-district pair
+            for vtd in vtds:
+                district_pops_per_locality[self.localitydict[vtd]][district] += \
+                    partition.graph.nodes[vtd][self.pop_col]
+
+        # initialize lists for split pairs scores by locality and populations by locality
+        scores = []
+        loc_pops = []
+
+        # for each locality
+        for locality in self.localities:
+            # grab the population in each district
+            pops = district_pops_per_locality[locality].values()
+            pops = [float(i) for i in pops]
+
+            # get split pairs score for the locality
+            total_pop = sum(pops)
+            preserved_pairs = sum([i * (i - 1) / 2 for i in pops])
+            all_pairs = total_pop * (total_pop - 1) / 2
+            split_pairs_loc = 1 - preserved_pairs / all_pairs
+
+            # append score and locality population to list
+            scores += [split_pairs_loc]
+            loc_pops += [total_pop]
+
+        # return population-weighted average of split pairs score
+        return sum([scores[i] * pop for i, pop in enumerate(loc_pops)]) / sum(loc_pops)

--- a/tests/updaters/test_split_scores.py
+++ b/tests/updaters/test_split_scores.py
@@ -53,7 +53,7 @@ def partition(graph_with_counties):
         assignment={0: 1, 1: 1, 2: 1, 3: 2, 4: 2, 5: 2, 6: 3, 7: 3, 8: 3},
         updaters={"cut_edges":cut_edges, "splits": LocalitySplits("splittings", "county", "pop", ['num_parts', 'num_pieces',
             'naked_boundary', 'shannon_entropy', 'power_entropy',
-            'symmetric_entropy', 'num_split_localities'])},
+            'symmetric_entropy', 'num_split_localities', 'split_pairs'])},
     )
     return partition
 
@@ -65,7 +65,7 @@ def split_partition(graph_with_counties):
         assignment={0: 1, 1: 2, 2: 3, 3: 1, 4: 2, 5: 3, 6: 1, 7: 2, 8: 3},
         updaters={"cut_edges":cut_edges, "splits": LocalitySplits("splittings", "county", "pop", ['num_parts', 'num_pieces',
             'naked_boundary', 'shannon_entropy', 'power_entropy',
-            'symmetric_entropy', 'num_split_localities'])},
+            'symmetric_entropy', 'num_split_localities', 'split_pairs'])},
     )
     return partition
 
@@ -88,6 +88,7 @@ class TestSplittingScores:
         assert result["power_entropy"] == 0
         assert result["symmetric_entropy"] == 18
         assert result["num_split_localities"] == 0
+        assert result["split_pairs"] == 0
 
     def test_is_split(self, split_partition):
         part = split_partition.updaters["splits"](split_partition)
@@ -100,6 +101,7 @@ class TestSplittingScores:
         assert .6 > result["power_entropy"] > .5
         assert 32 > result["symmetric_entropy"] > 31 
         assert result["num_split_localities"] == 3
+        assert 1.01 > result["split_pairs"] > 0.99
 
 
 


### PR DESCRIPTION
Updating locality_split_scores.py with split pairs metric (see this [github repo](https://github.com/jacobwachspress/locality-splitting) and [paper](https://cdt.org/wp-content/uploads/2021/11/2021-11-04-Locality-splitting-report-final.pdf) for more details).

By the way, is locality_split_scores.py outdated? It looks like there is only support for CountySplit in updaters. Also the Shannon entropy metric seems to be calculated as though a VTD is a person. Is there code somewhere else that has updated metrics? If so, I am happy to contribute there.