### PR TITLE
Fix duplicate test name for geographic partition default updaters

### DIFF
--- a/tests/partition/test_partition.py
+++ b/tests/partition/test_partition.py
@@ -167,7 +167,7 @@ def test_geographic_partition_has_keys(example_geographic_partition):
     assert "cut_edges_by_part" in keys
 
 
-def test_partition_has_default_updaters(example_geographic_partition):
+def test_geographic_partition_has_default_updaters(example_geographic_partition):
     assert hasattr(example_geographic_partition, "perimeter")
     assert hasattr(example_geographic_partition, "exterior_boundaries")
     assert hasattr(example_geographic_partition, "interior_boundaries")


### PR DESCRIPTION
`mypy` detected a duplicate function definition, which this PR fixes by renaming the duplicate test name.