### PR TITLE
Add initial shims

### DIFF
--- a/gerrychain/shims/__init__.py
+++ b/gerrychain/shims/__init__.py
@@ -1,0 +1,3 @@
+from .frcw import frcw_recom, frcw_reversible_recom
+
+__all__ = ["frcw_recom", "frcw_reversible_recom"]

--- a/gerrychain/shims/frcw.py
+++ b/gerrychain/shims/frcw.py
@@ -1,0 +1,70 @@
+from .serialize import serialize_partition
+
+import random
+import functools
+import pcompress
+import gerrychain
+import tempfile
+import subprocess
+
+
+def frcw_recom(
+    partition: gerrychain.Partition,
+    pop_col: str,
+    pop_target: float,
+    pop_tol: float,
+    steps: int,
+    executable: str = "frcw",
+    variant: str = "district-pairs-rmst",
+    n_threads: int = 2,
+    batch_size: int = 2,
+):
+    with tempfile.TemporaryDirectory() as dirname:
+        graph_json_path = f"{dirname}/dual_graph.json"
+        chain_path = f"{dirname}/pcompress.chain"
+        serialize_partition(partition, graph_json_path)
+        serialize_partition(partition, "dual_graph.json")
+        command = [
+            executable,
+            "--graph-json",
+            graph_json_path,
+            "--assignment-col",
+            "assignment",
+            "--n-steps",
+            str(steps),
+            "--n-threads",
+            str(n_threads),
+            "--pop-col",
+            pop_col,
+            "--tol",
+            str(pop_tol),
+            "--variant",
+            variant,
+            "--writer",
+            "pcompress",
+            "--batch-size",
+            str(batch_size),
+            "--rng-seed",
+            str(random.randint(0, 10000)),  # raise UserWarning
+            "|",
+            "xz",
+            ">",
+            chain_path,
+        ]
+        subprocess.run(" ".join(command), shell=True)
+
+        for chain in pcompress.Replay(
+            partition.graph, chain_path, updaters=partition.updaters
+        ):
+            yield chain
+
+
+def frcw_reversible_recom(
+    partition: gerrychain.Partition,
+    pop_col: str,
+    pop_target: float,
+    pop_tol: float,
+    steps: int,
+    executable: str = "frcw",
+):
+    return functools.partial(frcw_recom, variant="reversible")

--- a/gerrychain/shims/serialize.py
+++ b/gerrychain/shims/serialize.py
@@ -1,0 +1,11 @@
+import gerrychain
+import pandas as pd
+
+
+def serialize_partition(partition: gerrychain.Partition, filename: str):
+    graph = partition.graph
+    graph.to_json(filename)
+
+    graph = gerrychain.Graph.from_json(filename)
+    graph.add_data(pd.DataFrame({"assignment": partition.assignment.to_series() + 1}))
+    graph.to_json(filename)


### PR DESCRIPTION
This is a PR to add some shims to alternate implementation/sampling methods. These shims can be called from GerryChain Python and behave as a drop-in replacement for normal chain running. The goal is to add shims for:
- [x] frcw
- [ ] GerryChain.NET (maybe)
- [ ] redist (maybe)
- [ ] GerryChain Julia (maybe)

## Example usage
```python
from gerrychain.shims.frcw import frcw_recom, frcw_reversible_recom

# generate seed partition, etc

for partition in frcw_recom(partition, "TOTPOP", ideal_pop, 0.01, steps=10000):
    # normal chain stuff here
```