### PR TITLE
Port GerryChain adjacency calcs to Shapely 2.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
             conda install pytest pytest-cov
             conda install codecov
             python -m pip install .[geo]
-            conda install shapely==1.6.4
+            conda install shapely>=2.0.1
 
             # run tests
             echo "backend: Agg" > "matplotlibrc"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,6 @@ jobs:
             conda install pytest pytest-cov
             conda install codecov
             python -m pip install .[geo]
-            conda install shapely>=2.0.1
 
             # run tests
             echo "backend: Agg" > "matplotlibrc"

--- a/gerrychain/graph/adjacency.py
+++ b/gerrychain/graph/adjacency.py
@@ -16,8 +16,7 @@ def str_tree(geometries):
     Use this for all spatial operations!
     """
     from shapely.strtree import STRtree
-    for i in geometries.index:
-        geometries[i].id = i
+
     try:
         tree = STRtree(geometries)
     except AttributeError:
@@ -26,17 +25,18 @@ def str_tree(geometries):
 
 
 def neighboring_geometries(geometries, tree=None):
-    """Generator yielding tuples of the form (id, (ids of neighbors)).
-    """
+    """Generator yielding tuples of the form (id, (ids of neighbors))."""
     if tree is None:
         tree = str_tree(geometries)
 
-    for geometry in geometries:
+    for geometry_id, geometry in geometries.items():
         possible = tree.query(geometry)
         actual = tuple(
-            p.id for p in possible if (not p.is_empty) and p.id != geometry.id
+            geometries.index[p]
+            for p in possible
+            if (not geometries.iloc[p].is_empty) and geometries.index[p] != geometry_id
         )
-        yield (geometry.id, actual)
+        yield (geometry_id, actual)
 
 
 def intersections_with_neighbors(geometries):

--- a/gerrychain/graph/adjacency.py
+++ b/gerrychain/graph/adjacency.py
@@ -31,7 +31,6 @@ def neighboring_geometries(geometries, tree=None):
 
     for geometry_id, geometry in geometries.items():
         possible = tree.query(geometry)
-        print("possible intersections:", possible)
         actual = tuple(
             geometries.index[p]
             for p in possible

--- a/gerrychain/graph/adjacency.py
+++ b/gerrychain/graph/adjacency.py
@@ -31,6 +31,7 @@ def neighboring_geometries(geometries, tree=None):
 
     for geometry_id, geometry in geometries.items():
         possible = tree.query(geometry)
+        print("possible intersections:", possible)
         actual = tuple(
             geometries.index[p]
             for p in possible

--- a/gerrychain/graph/graph.py
+++ b/gerrychain/graph/graph.py
@@ -6,9 +6,16 @@ import warnings
 import networkx
 from networkx.classes.function import frozen
 from networkx.readwrite import json_graph
+import pandas as pd
 
 from .adjacency import neighbors
 from .geo import GeometryError, invalid_geometries, reprojected
+
+def json_serialize(input_object):
+    """Serialize json so we can write to file
+    """
+    if pd.api.types.is_integer_dtype(input_object):  # handle int64
+        return int(input_object)
 
 
 class Graph(networkx.Graph):
@@ -18,6 +25,7 @@ class Graph(networkx.Graph):
     to save and load graphs as JSON files.
 
     """
+
     def __repr__(self):
         return "<Graph [{} nodes, {} edges]>".format(len(self.nodes), len(self.edges))
 
@@ -57,7 +65,7 @@ class Graph(networkx.Graph):
             remove_geometries(data)
 
         with open(json_file, "w") as f:
-            json.dump(data, f)
+            json.dump(data, f, default=json_serialize)
 
     @classmethod
     def from_file(
@@ -76,12 +84,14 @@ class Graph(networkx.Graph):
             add to the graph as node attributes. By default, all columns are added.
         """
         import geopandas as gp
+
         df = gp.read_file(filename)
         graph = cls.from_geodataframe(
-            df, adjacency=adjacency,
+            df,
+            adjacency=adjacency,
             cols_to_add=cols_to_add,
             reproject=reproject,
-            ignore_errors=ignore_errors
+            ignore_errors=ignore_errors,
         )
         graph.graph["crs"] = df.crs.to_json()
         return graph
@@ -93,7 +103,7 @@ class Graph(networkx.Graph):
         adjacency="rook",
         cols_to_add=None,
         reproject=False,
-        ignore_errors=False
+        ignore_errors=False,
     ):
         """Creates the adjacency :class:`Graph` of geometries described by `dataframe`.
         The areas of the polygons are included as node attributes (with key `area`).
@@ -275,6 +285,7 @@ def add_boundary_perimeters(graph, geometries):
     """
     from shapely.ops import unary_union
     from shapely.prepared import prep
+
     prepared_boundary = prep(unary_union(geometries).boundary)
 
     boundary_nodes = geometries.boundary.apply(prepared_boundary.intersects)
@@ -337,15 +348,13 @@ def convert_geometries_to_geojson(data):
 
 
 class FrozenGraph:
-    """ Represents an immutable graph to be partitioned. It is based off :class:`Graph`.
+    """Represents an immutable graph to be partitioned. It is based off :class:`Graph`.
 
     This speeds up chain runs and prevents having to deal with cache invalidation issues.
     This class behaves slightly differently than :class:`Graph` or :class:`networkx.Graph`.
     """
-    __slots__ = [
-        "graph",
-        "size"
-    ]
+
+    __slots__ = ["graph", "size"]
 
     def __init__(self, graph: Graph):
         self.graph = networkx.classes.function.freeze(graph)

--- a/gerrychain/graph/graph.py
+++ b/gerrychain/graph/graph.py
@@ -11,6 +11,7 @@ import pandas as pd
 from .adjacency import neighbors
 from .geo import GeometryError, invalid_geometries, reprojected
 
+
 def json_serialize(input_object):
     """Serialize json so we can write to file
     """

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,6 @@ setup(
         "License :: OSI Approved :: BSD License",
     ],
     extras_require={
-        'geo': ["shapely", "geopandas"]
+        'geo': ["shapely>=2.0.1", "geopandas>=0.12.2"]
     }
 )


### PR DESCRIPTION
Shapely 2.0 will introduce breaking changes for GerryChain. In particular, our adjacency calculation code will break (and we won't be able to make new dual graphs). Although Shapely 2.0 hasn't stabilized yet, it appears that recent updates in our dependencies (i.e. geopandas) has caused some issues to show up prior to Shapely 2.0 being offically stable.

Relevant issues:
- Fixes #392
- Closes #287

#369 was originally a stop-gap fix for this PR. We should be able to remove the import warning in `gerrychain/__init__.py`.