### PR TITLE
`MarkovChain` validators and `recursive_tree_part`

### DIFF
--- a/gerrychain/chain.py
+++ b/gerrychain/chain.py
@@ -41,10 +41,10 @@ class MarkovChain:
 
         """
         if callable(constraints):
-            is_valid = constraints
+            is_valid = Validator([constraints])
         else:
             is_valid = Validator(constraints)
-
+        
         if not is_valid(initial_state):
             failed = [
                 constraint

--- a/gerrychain/chain.py
+++ b/gerrychain/chain.py
@@ -44,7 +44,7 @@ class MarkovChain:
             is_valid = Validator([constraints])
         else:
             is_valid = Validator(constraints)
-            
+
         if not is_valid(initial_state):
             failed = [
                 constraint

--- a/gerrychain/chain.py
+++ b/gerrychain/chain.py
@@ -44,7 +44,7 @@ class MarkovChain:
             is_valid = Validator([constraints])
         else:
             is_valid = Validator(constraints)
-        
+            
         if not is_valid(initial_state):
             failed = [
                 constraint

--- a/gerrychain/tree.py
+++ b/gerrychain/tree.py
@@ -375,7 +375,6 @@ def recursive_tree_part(
         min_pop = max(pop_target * (1 - epsilon), pop_target * (1 - epsilon) - debt)
         max_pop = min(pop_target * (1 + epsilon), pop_target * (1 + epsilon) - debt)
         new_pop_target = (min_pop + max_pop) / 2
-
         nodes = method(
             graph.subgraph(remaining_nodes),
             pop_col=pop_col,

--- a/gerrychain/tree.py
+++ b/gerrychain/tree.py
@@ -374,11 +374,13 @@ def recursive_tree_part(
     for part in parts[:-1]:
         min_pop = max(pop_target * (1 - epsilon), pop_target * (1 - epsilon) - debt)
         max_pop = min(pop_target * (1 + epsilon), pop_target * (1 + epsilon) - debt)
+        new_pop_target = (min_pop + max_pop) / 2
+
         nodes = method(
             graph.subgraph(remaining_nodes),
             pop_col=pop_col,
-            pop_target=(min_pop + max_pop) / 2,
-            epsilon=(max_pop - min_pop) / (2 * pop_target),
+            pop_target=new_pop_target,
+            epsilon=(max_pop - min_pop) / (2 * new_pop_target),
             node_repeats=node_repeats,
         )
 
@@ -389,6 +391,7 @@ def recursive_tree_part(
         for node in nodes:
             flips[node] = part
             part_pop += graph.nodes[node][pop_col]
+
         debt += part_pop - pop_target
         remaining_nodes -= nodes
 


### PR DESCRIPTION
The edit to `chain.py` ensures that if a user only inputs one constraint to a `MarkovChain`, it will still be able to print the correct error message should the chain fail. The error message relies on the constraints being turned into a `Validator` object, and previously if the user input a single constraint it did not get turned into a `Validator`.

The edit to `tree.py` fixes an issue that occasionally caused `recursive_tree_part` to generate plans that were imbalanced in population. Here is an example to show why the previous computation was incorrect. Suppose the ideal size is 100, epsilon = .02, and the previous district had size 99. Then the debt=-1, the min_pop=99, and max_pop=102. The pop_target = 100.5, and the new value for epsilon is .015. But then the lower end of the population range is actually (100.5)*(1-.015)=98.9925, and the upper end is 100.5**1+.015)=102.0075. The only change required to fix this is to compute the new value for epsilon using the new population target, not the ideal size.