### PR TITLE
Opt/incorporate jeanne bfs ideas

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ help:
 	@echo "  install       - Install the package"
 	@echo "  install-docs  - Install documentation dependencies"
 	@echo "  test          - Run the test suite"
+	@echo "  test-all      - Run the test suite including slow tests"
 	@echo "  lint          - Run code linters"
 	@echo "  format        - Format the codebase"
 	@echo "  precommit     - Run pre-commit hooks"
@@ -60,6 +61,10 @@ check:
 test:
 	@echo "Running test suite..."
 	PYTHONHASHSEED=0 uv run pytest -v $(TEST_PATHS)
+
+test-all:
+	@echo "Running test suite (including slow tests)..."
+	PYTHONHASHSEED=0 uv run pytest -v --runslow $(TEST_PATHS)
 
 # Add this in later
 # type-check:

--- a/benchmarks/benchmark_recom.py
+++ b/benchmarks/benchmark_recom.py
@@ -70,7 +70,7 @@ from pathlib import Path
 SCRIPT_DIR = Path(__file__).resolve().parent
 TOP_DIR = SCRIPT_DIR.parent
 RESULT_MARKER = "@@RESULT "
-DEFAULT_JSON = SCRIPT_DIR / "graphs" / "hard_graph.json"
+DEFAULT_GRAPH = SCRIPT_DIR / "graphs" / "hard_graph.json"
 MAX_NUMPY_SEED = 2**32 - 1
 
 
@@ -104,7 +104,7 @@ def _init_pool_worker(args: argparse.Namespace) -> None:
 
     from gerrychain import Graph
 
-    _WORKER_STATE = (Graph.from_json(args.json), args, False)
+    _WORKER_STATE = (Graph.from_json(args.graph), args, False)
 
 
 def _run_one_seed(seed: int) -> dict:
@@ -227,9 +227,9 @@ def cmd_run(args: argparse.Namespace) -> None:
         print("note: --progress only applies to a single sequential seed; ignoring", flush=True)
         progress = False
 
-    graph = Graph.from_json(args.json)
+    graph = Graph.from_json(args.graph)
     print(
-        f"graph={Path(args.json).name} nodes={len(graph.nodes)} "
+        f"graph={Path(args.graph).name} nodes={len(graph.nodes)} "
         f"parts={args.parts} epsilon={args.epsilon} "
         f"steps={args.steps} pop_col={args.pop_col} "
         f"seeds={seeds[0]}..{seeds[-1]} repeats={args.repeats} jobs={jobs}",
@@ -294,7 +294,7 @@ def cmd_run(args: argparse.Namespace) -> None:
     result = {
         "version": version,
         "module_file": gerrychain.__file__,
-        "graph": str(Path(args.json).resolve()),
+        "graph": str(Path(args.graph).resolve()),
         "steps": args.steps,
         "seeds": seeds,
         "repeats": args.repeats,
@@ -363,8 +363,8 @@ def cmd_compare(args: argparse.Namespace) -> None:
     script = str(Path(__file__).resolve())
     worker_args = [
         "run",
-        "--json",
-        str(Path(args.json).resolve()),
+        "--graph",
+        str(Path(args.graph).resolve()),
         "--parts",
         str(args.parts),
         "--epsilon",
@@ -415,7 +415,7 @@ def cmd_compare(args: argparse.Namespace) -> None:
     baseline = next((r for _, r in results if r is not None), None)
     width = max((len(label) for label, _ in results), default=0)
     print(
-        f"\n==== summary: graph={Path(args.json).name}, "
+        f"\n==== summary: graph={Path(args.graph).name}, "
         f"{args.num_seeds} seed(s) x {args.repeats} repeat(s) from seed {base_seed}, "
         f"{args.steps} steps, parts={args.parts}, epsilon={args.epsilon}, "
         f"jobs={args.jobs} ===="
@@ -444,9 +444,9 @@ def cmd_compare(args: argparse.Namespace) -> None:
 
 def add_benchmark_options(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
-        "--json",
-        default=str(DEFAULT_JSON),
-        help=f"dual graph JSON to run on (default: {DEFAULT_JSON})",
+        "--graph",
+        default=str(DEFAULT_GRAPH),
+        help=f"dual graph JSON to run on (default: {DEFAULT_GRAPH})",
     )
     parser.add_argument("--pop-col", default="TOTPOP", help="population column (default: TOTPOP)")
     parser.add_argument(

--- a/gerrychain/tree/bipartition_tree.py
+++ b/gerrychain/tree/bipartition_tree.py
@@ -254,6 +254,54 @@ class FindBalancedEdgeCutsFn(Protocol):
     ) -> list[_Cut]: ...
 
 
+def _bfs_predecessors_and_successors_for_tree(
+    tree: Graph, root: Any, build_successors: bool = False
+) -> tuple[dict[Any, Any], dict[Any, list[Any]] | None]:
+    """Return ``(pred, succ)`` parent/child maps for the tree ``graph`` rooted at ``root``.
+
+    ``pred`` maps every non-root node to its parent (the neighbor on the path toward
+    ``root``).  When ``build_successors`` is True, ``succ`` maps every internal node to the
+    list of its children; otherwise ``succ`` is None.
+
+    This is one tight breadth-first traversal that fetches ``graph.neighbors()`` once per
+    node as it is visited.  It replaces ``graph.predecessors(root)`` and
+    ``graph.successors(root)``, each of which ran its own traversal through the
+    ``Graph.generic_bfs_*`` generators. The memoization path previously paid for that traversal
+    twice (predecessors then successors); fusing them here computes both in one pass.
+
+    For a tree, every non-root node has a unique parent, so ``pred`` is identical to the map
+    the old BFS produced regardless of neighbor-visitation order.
+
+    Special thanks to Jeanne Clelland who's original work informed this section of code.
+
+    Args:
+        tree (Graph): The tree for which to compute predecessors and successors.
+        root (Any): The root node of the tree.
+        build_successors (bool, optional): Whether to build the successors map. Defaults to False.
+
+    Returns:
+        Tuple[Dict[Any, Any], Dict[Any, List[Any]] | None]: A tuple containing the predecessors
+        map and the successors map (or None if not built).
+    """
+    pred: dict[Any, Any] = {}
+    succ: dict[Any, list[Any]] | None = {} if build_successors else None
+    seen = {root}
+    queue = deque([root])
+    while queue:
+        node = queue.popleft()
+        children = None
+        for neighbor in tree.neighbors(node):
+            if neighbor not in seen:
+                seen.add(neighbor)
+                pred[neighbor] = node
+                queue.append(neighbor)
+                if build_successors:
+                    if children is None:
+                        children = succ[node] = []
+                    children.append(neighbor)
+    return pred, succ
+
+
 def find_balanced_edge_cuts_contraction(
     h: _PopulatedGraph, one_sided_cut: bool = False, rootnode_choice_fn: Callable = random.choice
 ) -> list[_Cut]:
@@ -275,8 +323,8 @@ def find_balanced_edge_cuts_contraction(
     root = rootnode_choice_fn(
         [node_id for node_id in h.graph.node_indices if h.degree(node_id) > 1]
     )
-    # BFS predecessors for iteratively contracting leaves
-    pred = h.graph.predecessors(root)
+    # Parent map for iteratively contracting leaves. This used to call h.graph.predecessors(root)
+    pred, _ = _bfs_predecessors_and_successors_for_tree(h.graph, root)
 
     cuts = []
 
@@ -477,8 +525,10 @@ def find_balanced_edge_cuts_memoization(
         [node_id for node_id in h.graph.node_indices if h.degree(node_id) > 1]
     )
 
-    pred = h.graph.predecessors(root)
-    succ = h.graph.successors(root)
+    # Parent and child maps for the tree rooted at `root`. For a tree each non-root node has a
+    # unique parent, so `pred` is identical to the old map; the order of children within
+    # succ[node] may differ, which does not affect the set of cuts found.
+    pred, succ = _bfs_predecessors_and_successors_for_tree(h.graph, root, build_successors=True)
     total_pop = h.tot_pop
 
     # Calculate the population of each subtree in the "succ" tree
@@ -523,7 +573,6 @@ def find_balanced_edge_cuts_memoization(
 
     # We are looking for a way to bisect the graph (one_sided_cut is False)
     for node, tree_pop in subtree_pops.items():
-
         if (abs(tree_pop - h.ideal_pop) <= h.ideal_pop * h.epsilon) and (
             abs((total_pop - tree_pop) - h.ideal_pop) <= h.ideal_pop * h.epsilon
         ):
@@ -837,7 +886,6 @@ def _internal_bipartition_tree(
 
     num_cuts = len(possible_cuts)
     if num_cuts != 0:
-
         # Note: There are two different function signatures for cut_choice_fn().
         #
         # One just takes the set of possible cuts, but the other takes
@@ -1073,7 +1121,6 @@ def _get_possible_edge_cuts_and_populated_graph(
     attempts = 0
 
     while attempts < max_attempts:
-
         # Try to find balanced edge cuts - note that the find_balanced_edge_cuts_fn()
         # typically permutes the spanning tree by selecting a root node for the tree
         # at random, which means that each successive call using the same graph
@@ -1118,7 +1165,6 @@ def _get_possible_edge_cuts_and_populated_graph(
         #
         num_times_current_spanning_tree_has_been_tried += 1
         if num_times_current_spanning_tree_has_been_tried == num_times_to_use_given_spanning_tree:
-
             spanning_tree = spanning_tree_fn(graph_to_split)
             num_times_current_spanning_tree_has_been_tried = 0
 

--- a/gerrychain/tree/bipartition_tree.py
+++ b/gerrychain/tree/bipartition_tree.py
@@ -283,6 +283,9 @@ def _bfs_predecessors_and_successors_for_tree(
         Tuple[Dict[Any, Any], Dict[Any, List[Any]] | None]: A tuple containing the predecessors
         map and the successors map (or None if not built).
     """
+    # TODO: Technically, you can run this on a graph and it should be fine, but there is an implicit
+    # assumption that the passed graph is a tree, and we should probably check this somewhere
+    # if there is a cheap way to do it.
     pred: dict[Any, Any] = {}
     succ: dict[Any, list[Any]] | None = {} if build_successors else None
     seen = {root}


### PR DESCRIPTION
## Summary

Post-migration performance pass to be reviewed following #444. This PR makes some simple modifications to the BFS implementation that we use to find balanced edge cuts. The main savings come from come from combining the computation of predecessors and successors into a single pass function.

Improvements here seem to show a ~20-30% speedup over the previous merge (3785ab1aeffe3b352e31941b65929d745c5a1dd6). Speed improvements were measured using the new benchmark suite included in this PR.

```bash
uv run python benchmarks/benchmark_recom.py \
  compare pypi:0.3.2 git:3785ab1aeffe3b352e31941b65929d745c5a1dd6 local \
  --graph benchmarks/graphs/<GRAPH> \
  --parts <PARTS> \
  --steps <STEPS>
```

### Results on some graphs

**PA.json: 1000 steps, 17 parts, 5 seeds, 1 trial per seed, ε=0.01**

| GerryChain Version  | Min Observed Time per Step | Max Observed Time per Step | Median Time per Step | Speedup vs. 0.3.2 |
| ------------------- | -------------------------- | -------------------------- | -------------------- | ----------------- |
| 0.3.2 (PyPI)        | 93.991 ms                  | 133.540 ms                 | 109.368 ms           | Baseline          |
| 1.0.0a2 (3785ab1ae) | 41.105 ms                  | 44.178 ms                  | 42.802 ms            | 2.56×             |
| 1.0.0a2 (local)     | 34.510 ms                  | 37.147 ms                  | 35.501 ms            | 3.08×             |

**hard_graph.json: 250 steps, 6 parts, 5 seeds, 1 trial per seed, ε=0.01**

| GerryChain Version  | Min Observed Time per Step | Max Observed Time per Step | Median Time per Step | Speedup vs. 0.3.2 |
| ------------------- | -------------------------- | -------------------------- | -------------------- | ----------------- |
| 0.3.2 (PyPI)        | 826.499 ms                 | 1327.474 ms                | 1053.129 ms          | Baseline          |
| 1.0.0a2 (3785ab1ae) | 460.001 ms                 | 685.946 ms                 | 553.602 ms           | 1.90×             |
| 1.0.0a2 (local)     | 381.407 ms                 | 543.359 ms                 | 449.221 ms           | 2.34×             |

**grid_8x8.json: 10000 steps, 8 parts, 5 seeds, 1 trial per seed, ε=0.01**

| GerryChain Version  | Min Observed Time per Step | Max Observed Time per Step | Median Time per Step | Speedup vs. 0.3.2 |
| ------------------- | -------------------------- | -------------------------- | -------------------- | ----------------- |
| 0.3.2 (PyPI)        | 0.508 ms                   | 0.521 ms                   | 0.516 ms             | Baseline          |
| 1.0.0a2 (3785ab1ae) | 0.278 ms                   | 0.288 ms                   | 0.284 ms             | 1.81×             |
| 1.0.0a2 (local)     | 0.236 ms                   | 0.245 ms                   | 0.241 ms             | 2.14×             |

**grid_25x25.json: 10000 steps, 5 parts, 5 seeds, 1 trial per seed, ε=0.01**

| GerryChain Version  | Min Observed Time per Step | Max Observed Time per Step | Median Time per Step | Speedup vs. 0.3.2 |
| ------------------- | -------------------------- | -------------------------- | -------------------- | ----------------- |
| 0.3.2 (PyPI)        | 12.240 ms                  | 12.776 ms                  | 12.319 ms            | Baseline          |
| 1.0.0a2 (3785ab1ae) | 6.015 ms                   | 6.181 ms                   | 6.112 ms             | 2.02×             |
| 1.0.0a2 (local)     | 4.828 ms                   | 4.956 ms                   | 4.918 ms             | 2.50×             |

**grid_50x50.json: 10000 steps, 25 parts, 5 seeds, 1 trial per seed, ε=0.01**

| GerryChain Version  | Min Observed Time per Step | Max Observed Time per Step | Median Time per Step | Speedup vs. 0.3.2 |
| ------------------- | -------------------------- | -------------------------- | -------------------- | ----------------- |
| 0.3.2 (PyPI)        | 9.841 ms                   | 10.151 ms                  | 10.115 ms            | Baseline          |
| 1.0.0a2 (3785ab1ae) | 4.775 ms                   | 4.870 ms                   | 4.820 ms             | 2.10×             |
| 1.0.0a2 (local)     | 3.881 ms                   | 3.969 ms                   | 3.922 ms             | 2.58×             |

**Actual Outputs:**

```console
==== summary: graph=PA.json, 5 seed(s) x 1 repeat(s) from seed 916946180, 1000 steps, parts=17, epsilon=0.01, jobs=5 ====
pypi:0.3.2                                                median   109.368 ms/step  [min    93.991, max   133.540]  gerrychain 0.3.2      (baseline)
git:3785ab1aeffe3b352e31941b65929d745c5a1dd6 (3785ab1ae)  median    42.802 ms/step  [min    41.105, max    44.178]  gerrychain 1.0.0a2    (2.56x baseline speed)
local (working tree)                                      median    35.501 ms/step  [min    34.510, max    37.147]  gerrychain 1.0.0a2    (3.08x baseline speed)


==== summary: graph=hard_graph.json, 5 seed(s) x 1 repeat(s) from seed 1915644050, 250 steps, parts=6, epsilon=0.01, jobs=5 ====
pypi:0.3.2                                                median  1053.129 ms/step  [min   826.499, max  1327.474]  gerrychain 0.3.2      (baseline)
git:3785ab1aeffe3b352e31941b65929d745c5a1dd6 (3785ab1ae)  median   553.602 ms/step  [min   460.001, max   685.946]  gerrychain 1.0.0a2    (1.90x baseline speed)
local (working tree)                                      median   449.221 ms/step  [min   381.407, max   543.359]  gerrychain 1.0.0a2    (2.34x baseline speed)

==== summary: graph=grid_8x8.json, 5 seed(s) x 1 repeat(s) from seed 1100107514, 10000 steps, parts=8, epsilon=0.01, jobs=5 ====
pypi:0.3.2                                                median     0.516 ms/step  [min     0.508, max     0.521]  gerrychain 0.3.2      (baseline)
git:3785ab1aeffe3b352e31941b65929d745c5a1dd6 (3785ab1ae)  median     0.284 ms/step  [min     0.278, max     0.288]  gerrychain 1.0.0a2    (1.81x baseline speed)
local (working tree)                                      median     0.241 ms/step  [min     0.236, max     0.245]  gerrychain 1.0.0a2    (2.14x baseline speed)

==== summary: graph=grid_25x25.json, 5 seed(s) x 1 repeat(s) from seed 1730922989, 10000 steps, parts=5, epsilon=0.01, jobs=5 ====
pypi:0.3.2                                                median    12.319 ms/step  [min    12.240, max    12.776]  gerrychain 0.3.2      (baseline)
git:3785ab1aeffe3b352e31941b65929d745c5a1dd6 (3785ab1ae)  median     6.112 ms/step  [min     6.015, max     6.181]  gerrychain 1.0.0a2    (2.02x baseline speed)
local (working tree)                                      median     4.918 ms/step  [min     4.828, max     4.956]  gerrychain 1.0.0a2    (2.50x baseline speed)

==== summary: graph=grid_50x50.json, 5 seed(s) x 1 repeat(s) from seed 1383655767, 10000 steps, parts=25, epsilon=0.01, jobs=5 ====
pypi:0.3.2                                                median    10.115 ms/step  [min     9.841, max    10.151]  gerrychain 0.3.2      (baseline)
git:3785ab1aeffe3b352e31941b65929d745c5a1dd6 (3785ab1ae)  median     4.820 ms/step  [min     4.775, max     4.870]  gerrychain 1.0.0a2    (2.10x baseline speed)
local (working tree)                                      median     3.922 ms/step  [min     3.881, max     3.969]  gerrychain 1.0.0a2    (2.58x baseline speed)


```

## Why

One of our super users, Jeanne Clelland, identified a bottle neck in the way that we computed population-balanced cut edges and wrote a custom BFS implementation to speed up the process. The central idea that Jeanne's implementation exploits is that we can compute the predecessor and successor sets for a tree in a single pass, rather than doing two separate BFS traversals

## Changes

- Add `_bfs_predecessors_and_successors_for_tree()` to `gerrychain/tree/bipartition_tree.py`: a single breadth-first traversal of the spanning tree that builds the predecessor (parent) map and, optionally, the successor (children) map in one pass.
- `find_balanced_edge_cuts_memoization()` now derives both `pred` and `succ` from that one call instead of two separate `Graph.predecessors()` + `Graph.successors()` traversals. This is where most of the speedup comes from, since this function runs on every cut attempt.
- `find_balanced_edge_cuts_contraction()` uses the same helper for its predecessor map (one traversal instead of `Graph.predecessors()`).
- Benchmark CLI: rename the `--json` flag to `--graph` (and `DEFAULT_JSON` -> `DEFAULT_GRAPH`) in `benchmarks/benchmark_recom.py`.
- Add a `test-all` Makefile target that runs the suite with `--runslow` (full suite including slow tests), and list it in `make help`.

## Testing

- [x] Tests pass locally (`make test-all` - 265 passed, 2 xfailed)

ReCom benchmarked on several graphs (PA, hard_graph, grid_8x8, grid_25x25, grid_50x50) with 5 seeds each, showing a consistent ∼20% speedup over the previous merge (3785ab1aeffe3b352e31941b65929d745c5a1dd6) and a ∼2-3× speedup over the 0.3.2 release.

## Reviewer Notes

- The helper is intentionally tree-only (note the `_for_tree` suffix). The guarantee that `pred` is identical to the previous output relies on the input being a tree: each non-root node then has a unique parent, independent of neighbor-visitation order. The cut-finders always operate on a `random_spanning_tree`, so this holds. On a general graph with cycles the resulting BFS tree (and thus `pred`/`succ`) would depend on traversal order.
- `succ` child ordering may differ from the old `Graph.successors()` output; this only changes the order in which cuts are discovered, not the set of cuts found, so results are equivalent.
- After this change, `Graph.predecessors()`, `Graph.successors()`, and the `generic_bfs_*` helpers in `gerrychain/graph/graph.py` are no longer used by the cut-finders (their only callers in the package). They remain part of the `Graph` API and are still covered by `tests/test_frm_graph.py`