### PR TITLE
Update all of the types and get them passing ty + pyright

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,11 @@ PYTHON_VERSION = 3.11
 VENV_DIR ?= .venv
 PKG ?= gerrychain
 TEST_PATHS ?= tests
+TYPECHECK_PATHS ?= $(PKG) tests/typing_assertions.py
 export UV_MANAGED_PYTHON = 1
 
-.PHONY: all
+.PHONY: help check_prereq setup install install-docs check test test-all type-check format lint \
+	precommit docs clean
 
 help:
 	@echo "Available targets:"
@@ -15,7 +17,8 @@ help:
 	@echo "  install-docs  - Install documentation dependencies"
 	@echo "  test          - Run the test suite"
 	@echo "  test-all      - Run the test suite including slow tests"
-	@echo "  lint          - Run code linters"
+	@echo "  lint          - Run Ruff and both type checkers"
+	@echo "  type-check    - Run ty, then Pyright"
 	@echo "  format        - Format the codebase"
 	@echo "  precommit     - Run pre-commit hooks"
 	@echo "  docs          - Build the documentation"
@@ -36,9 +39,7 @@ setup: check_prereq
 	@echo
 	uv python install $(PYTHON_VERSION)
 	@echo "Creating virtual environment and installing dev dependencies..."
-	uv sync --python $(PYTHON_VERSION) 
-	uv sync --all-groups
-	uv pip install -e .
+	uv sync --python $(PYTHON_VERSION) --all-groups
 	uv run pre-commit install
 	@echo ""
 	@echo "Development environment setup complete!"
@@ -46,13 +47,10 @@ setup: check_prereq
 install: check_prereq
 	@echo "Installing GerryChain package..."
 	uv sync --python $(PYTHON_VERSION)
-	uv pip install -e .
 
 install-docs: check_prereq
 	@echo "Installing GerryChain package with all just the documentation dependencies..."
-	uv sync --python $(PYTHON_VERSION)
-	uv sync --group docs
-	uv pip install -e .
+	uv sync --python $(PYTHON_VERSION) --group docs
 
 check:
 	$(MAKE) format
@@ -66,19 +64,20 @@ test-all:
 	@echo "Running test suite (including slow tests)..."
 	PYTHONHASHSEED=0 uv run pytest -v --runslow $(TEST_PATHS)
 
-# Add this in later
-# type-check:
-# 	@echo "Running type checking with mypy..."
-# 	uv run mypy $(PKG) ${TEST_PATHS}
+type-check:
+	@echo "Running fast type checking with ty..."
+	uv run ty check $(TYPECHECK_PATHS)
+	@echo "Running thorough type checking with Pyright..."
+	uv run pyright $(TYPECHECK_PATHS)
 
 format:
-	@echo "Formatting codebase with black..."
-	uv run isort $(PKG) $(TEST_PATHS)
-	uv run black $(PKG) $(TEST_PATHS)
+	@echo "Formatting codebase with Ruff..."
+	uv run ruff format $(PKG) $(TEST_PATHS)
 
-lint: 
-	@echo "Running linters (ruff)..."
+lint:
+	@echo "Running Ruff..."
 	uv run ruff check $(PKG) $(TEST_PATHS)
+	$(MAKE) type-check
 
 precommit:
 	@echo "Running pre-commit hooks..."

--- a/gerrychain/__init__.py
+++ b/gerrychain/__init__.py
@@ -1,5 +1,4 @@
 import warnings
-from modulefinder import Module
 
 from ._config import runtime_checks, runtime_checks_enabled, set_runtime_checks
 from .chain import MarkovChain

--- a/gerrychain/chain.py
+++ b/gerrychain/chain.py
@@ -28,10 +28,11 @@ from __future__ import annotations
 
 import random
 from collections.abc import Callable, Iterable
+from typing import cast
 
 from gerrychain._rng import make_rng
 from gerrychain.accept import AcceptFn
-from gerrychain.constraints import Bounds, Validator
+from gerrychain.constraints import Validator
 from gerrychain.partition import Partition
 from gerrychain.proposals import ProposalFn
 
@@ -58,7 +59,9 @@ class MarkovChain:
         self,
         # proposal: Callable[[Partition], Partition],
         proposal: ProposalFn,
-        constraints: Iterable[Callable] | Validator | Iterable[Bounds] | Callable,
+        constraints: Iterable[Callable[[Partition], bool]]
+        | Validator
+        | Callable[[Partition], bool],
         accept: AcceptFn,
         initial_state: Partition,
         total_steps: int,
@@ -71,16 +74,16 @@ class MarkovChain:
             proposal (Callable): Function called as ``proposal(state, rng=chain.rng)`` to propose
                 the next state. The chain's RNG takes precedence over an ``rng`` bound into a
                 ``functools.partial`` proposal.
-            constraints (Union[Iterable[Callable], Validator, Iterable[Bounds], Callable]): A
-                function with signature ``Partition -> bool`` determining whether the proposed next
-                state is valid (passes all binary constraints). Usually this is a
-                Validator class instance.
+            constraints (Iterable[Callable[[Partition], bool]] | Validator |
+                Callable[[Partition], bool]): A function with signature ``Partition -> bool``
+                determining whether the proposed next state is valid (passes all binary
+                constraints). Usually this is a Validator class instance.
             accept (Callable): Function called as ``accept(proposed_state, rng=chain.rng)`` to
                 accept or reject the proposed state. In the most basic use case, this always
                 returns ``True``.
             initial_state (Partition): Initial Partition class.
             total_steps (int): Number of steps to run.
-            rng (Union[random.Random, int, None], optional): Source of randomness for the run.
+            rng (random.Random | int | None, optional): Source of randomness for the run.
                 An integer creates a reproducible ``random.Random``; a supplied instance is kept
                 by identity; ``None`` creates an independent RNG from system entropy.
 
@@ -88,20 +91,21 @@ class MarkovChain:
             ValueError: If the initial_state is not valid according to the constraints.
         """
 
-        if callable(constraints):
-            is_valid = Validator([constraints])
+        if isinstance(constraints, Validator):
+            is_valid = constraints
+        elif callable(constraints):
+            is_valid = Validator([cast(Callable[[Partition], bool], constraints)])
         else:
             is_valid = Validator(constraints)
 
         if not is_valid(initial_state):
             failed = [
-                constraint
-                for constraint in is_valid.constraints  # type: ignore
-                if not constraint(initial_state)
+                constraint for constraint in is_valid.constraints if not constraint(initial_state)
             ]
             message = (
                 "The given initial_state is not valid according is_valid. "
-                "The failed constraints were: " + ",".join([f.__name__ for f in failed])
+                "The failed constraints were: "
+                + ",".join(getattr(f, "__name__", type(f).__name__) for f in failed)
             )
             raise ValueError(message)
 
@@ -118,14 +122,16 @@ class MarkovChain:
         """Read_only property for the constraints of the Markov chain.
 
         Returns:
-            String: The constraints of the Markov chain.
+            Validator: The constraints of the Markov chain.
         """
         return self.is_valid
 
     @constraints.setter
     def constraints(
         self,
-        constraints: Iterable[Callable] | Validator | Iterable[Bounds] | Callable,
+        constraints: Iterable[Callable[[Partition], bool]]
+        | Validator
+        | Callable[[Partition], bool],
     ) -> None:
         """Setter for the constraints property.
 
@@ -134,27 +140,30 @@ class MarkovChain:
         failed constraints.
 
         Args:
-            constraints (Union[Iterable[Callable], Validator, Iterable[Bounds], Callable]): The new
-                constraints to be imposed on the Markov chain.
+            constraints (Iterable[Callable[[Partition], bool]] | Validator |
+                Callable[[Partition], bool]): The new constraints to impose on the Markov chain.
 
         Raises:
             ValueError: If the initial_state is not valid according to the new constraints.
         """
 
-        if callable(constraints):
-            is_valid = Validator([constraints])
+        if isinstance(constraints, Validator):
+            is_valid = constraints
+        elif callable(constraints):
+            is_valid = Validator([cast(Callable[[Partition], bool], constraints)])
         else:
             is_valid = Validator(constraints)
 
         if not is_valid(self.initial_state):
             failed = [
                 constraint
-                for constraint in is_valid.constraints  # type: ignore
+                for constraint in is_valid.constraints
                 if not constraint(self.initial_state)
             ]
             message = (
                 "The given initial_state is not valid according to the new constraints. "
-                "The failed constraints were: " + ",".join([f.__name__ for f in failed])
+                "The failed constraints were: "
+                + ",".join(getattr(f, "__name__", type(f).__name__) for f in failed)
             )
             raise ValueError(message)
 
@@ -173,7 +182,7 @@ class MarkovChain:
         self.state = self.initial_state
         return self
 
-    def __next__(self) -> Partition | None:
+    def __next__(self) -> Partition:
         """Advances the Markov chain to the next state.
 
         This method is called to get the next item in the iteration. It proposes the next state and
@@ -182,7 +191,7 @@ class MarkovChain:
         StopIteration exception.
 
         Returns:
-            Optional[Partition]: The next state of the Markov chain.
+            Partition: The next state of the Markov chain.
 
         Raises:
             StopIteration: If the total number of steps has been reached.
@@ -194,8 +203,7 @@ class MarkovChain:
         while self.counter < self.total_steps:
             proposed_next_state = self.proposal(self.state, rng=self.rng)
             # Erase the parent of the parent, to avoid memory leak
-            if self.state is not None:
-                self.state.parent = None
+            self.state.parent = None
 
             if self.is_valid(proposed_next_state):
                 if self.accept(proposed_next_state, rng=self.rng):
@@ -222,7 +230,7 @@ class MarkovChain:
         Requires the `tqdm` package to be installed.
 
         Returns:
-            Any: A tqdm-wrapped Markov chain.
+            Iterable[Partition]: A progress-reporting iterable over the chain.
         """
         from tqdm.auto import tqdm
 

--- a/gerrychain/constraints/bounds.py
+++ b/gerrychain/constraints/bounds.py
@@ -1,9 +1,12 @@
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
+from typing import Generic, ParamSpec
 
 from ..partition import Partition
 
+P = ParamSpec("P")
 
-class Bounds:
+
+class Bounds(Generic[P]):
     """
     Wrapper for numeric-validators to enforce upper and lower limits.
 
@@ -13,33 +16,33 @@ class Bounds:
 
     """
 
-    def __init__(self, func: Callable, bounds: tuple[float, float]) -> None:
+    def __init__(self, func: Callable[P, Iterable[float]], bounds: tuple[float, float]) -> None:
         """Initialize a Bounds instance.
 
         This initializer sets up `Bounds` with the provided arguments and validates required state.
 
         Args:
             func (Callable): Numeric validator function. Should return an iterable of values.
-            bounds (Tuple[float, float]): Tuple of (lower, upper) numeric bounds.
+            bounds (tuple[float, float]): Tuple of (lower, upper) numeric bounds.
 
         """
         self.func = func
         self.bounds = bounds
 
-    def __call__(self, *args: object, **kwargs: object) -> bool:
+    def __call__(self, *args: P.args, **kwargs: P.kwargs) -> bool:
         lower, upper = self.bounds
         values = self.func(*args, **kwargs)
         return lower <= min(values) and max(values) <= upper
 
     @property
     def __name__(self) -> str:
-        return f"Bounds({self.func.__name__},{str(self.bounds)})"
+        return f"Bounds({getattr(self.func, '__name__', type(self.func).__name__)},{self.bounds})"
 
     def __repr__(self) -> str:
         return f"<{self.__name__}>"
 
 
-class UpperBound:
+class UpperBound(Generic[P]):
     """
     Wrapper for numeric-validators to enforce upper limits.
 
@@ -48,7 +51,7 @@ class UpperBound:
     and ``False`` otherwise.
     """
 
-    def __init__(self, func: Callable, bound: float) -> None:
+    def __init__(self, func: Callable[P, float], bound: float) -> None:
         """Initialize a UpperBound instance.
 
         This initializer sets up `UpperBound` with the provided arguments and validates required
@@ -56,24 +59,24 @@ class UpperBound:
 
         Args:
             func (Callable): Numeric validator function. Should return a comparable value.
-            bounds (float): Comparable upper bound.
+            bound (float): Comparable upper bound.
 
         """
         self.func = func
         self.bound = bound
 
-    def __call__(self, *args: object, **kwargs: object) -> bool:
+    def __call__(self, *args: P.args, **kwargs: P.kwargs) -> bool:
         return self.func(*args, **kwargs) <= self.bound
 
     @property
     def __name__(self) -> str:
-        return f"UpperBound({self.func.__name__} >= {self.bound})"
+        return f"UpperBound({getattr(self.func, '__name__', type(self.func).__name__)} >= {self.bound})"
 
     def __repr__(self) -> str:
         return f"<{self.__name__}>"
 
 
-class LowerBound:
+class LowerBound(Generic[P]):
     """
     Wrapper for numeric-validators to enforce lower limits.
 
@@ -82,7 +85,7 @@ class LowerBound:
     and ``False`` otherwise.
     """
 
-    def __init__(self, func: Callable, bound: float) -> None:
+    def __init__(self, func: Callable[P, float], bound: float) -> None:
         """Initialize a LowerBound instance.
 
         This initializer sets up `LowerBound` with the provided arguments and validates required
@@ -90,18 +93,18 @@ class LowerBound:
 
         Args:
             func (Callable): Numeric validator function. Should return a comparable value.
-            bounds (float): Comparable lower bound.
+            bound (float): Comparable lower bound.
 
         """
         self.func = func
         self.bound = bound
 
-    def __call__(self, *args: object, **kwargs: object) -> bool:
+    def __call__(self, *args: P.args, **kwargs: P.kwargs) -> bool:
         return self.func(*args, **kwargs) >= self.bound
 
     @property
     def __name__(self) -> str:
-        return f"LowerBound({self.func.__name__} <= {self.bound})"
+        return f"LowerBound({getattr(self.func, '__name__', type(self.func).__name__)} <= {self.bound})"
 
     def __repr__(self) -> str:
         return f"<{self.__name__}>"
@@ -119,7 +122,7 @@ class SelfConfiguringUpperBound:
     and ``False`` otherwise.
     """
 
-    def __init__(self, func: Callable) -> None:
+    def __init__(self, func: Callable[[Partition], float]) -> None:
         """Initialize a SelfConfiguringUpperBound instance.
 
         This initializer sets up `SelfConfiguringUpperBound` with the provided arguments and
@@ -139,7 +142,9 @@ class SelfConfiguringUpperBound:
 
     @property
     def __name__(self) -> str:
-        return f"SelfConfiguringUpperBound({self.func.__name__})"
+        return (
+            f"SelfConfiguringUpperBound({getattr(self.func, '__name__', type(self.func).__name__)})"
+        )
 
     def __repr__(self) -> str:
         return f"<{self.__name__}>"
@@ -157,7 +162,7 @@ class SelfConfiguringLowerBound:
     and ``False`` otherwise.
     """
 
-    def __init__(self, func: Callable, epsilon: float = 0.05) -> None:
+    def __init__(self, func: Callable[[Partition], float], epsilon: float = 0.05) -> None:
         """Initialize a SelfConfiguringLowerBound instance.
 
         This initializer sets up `SelfConfiguringLowerBound` with the provided arguments and
@@ -180,7 +185,9 @@ class SelfConfiguringLowerBound:
 
     @property
     def __name__(self) -> str:
-        return f"SelfConfiguringLowerBound({self.func.__name__})"
+        return (
+            f"SelfConfiguringLowerBound({getattr(self.func, '__name__', type(self.func).__name__)})"
+        )
 
     def __repr__(self) -> str:
         return f"<{self.__name__}>"
@@ -199,7 +206,7 @@ class WithinPercentRangeOfBounds:
     percentage range of the initial value, and ``False`` otherwise.
     """
 
-    def __init__(self, func: Callable, percent: float) -> None:
+    def __init__(self, func: Callable[[Partition], float], percent: float) -> None:
         """Initialize a WithinPercentRangeOfBounds instance.
 
         This initializer sets up `WithinPercentRangeOfBounds` with the provided arguments and
@@ -227,7 +234,7 @@ class WithinPercentRangeOfBounds:
 
     @property
     def __name__(self) -> str:
-        return f"WithinPercentRangeOfBounds({self.func.__name__})"
+        return f"WithinPercentRangeOfBounds({getattr(self.func, '__name__', type(self.func).__name__)})"
 
     def __repr__(self) -> str:
         return f"<{self.__name__}>"

--- a/gerrychain/constraints/contiguity.py
+++ b/gerrychain/constraints/contiguity.py
@@ -1,13 +1,17 @@
 from collections import deque
-from typing import Any
+from collections.abc import Hashable, Iterable
 
-from ..graph import Graph
+from ..graph import FrozenGraph, Graph
 from ..partition import Partition
 from .bounds import SelfConfiguringLowerBound
 
 
 def _are_reachable(
-    graph: Graph, start_node: Any, mapping: dict[Any, int], part: int, targets: Any
+    graph: Graph | FrozenGraph,
+    start_node: Hashable,
+    mapping: dict[Hashable, Hashable],
+    part: Hashable,
+    targets: Iterable[Hashable],
 ) -> bool:
     """Check if the targets are reachable from the start_node without leaving the given district.
 
@@ -17,10 +21,10 @@ def _are_reachable(
 
     Args:
         graph (Graph): Graph
-        start_node (int): The starting node; must be in ``part``
-        mapping (dict[Any, int]): The node_id -> part assignment mapping
-        part (int): The part (district) the search is confined to
-        targets (Any): The target nodes that we would like to reach
+        start_node (Hashable): The starting node; must be in ``part``
+        mapping (dict[Hashable, Hashable]): The node_id -> part assignment mapping
+        part (Hashable): The part (district) the search is confined to
+        targets (Iterable[Hashable]): The target nodes that we would like to reach
 
     Returns:
         bool: True if all of the targets are reachable from the start_node node
@@ -96,21 +100,21 @@ def single_flip_contiguous(partition: Partition) -> bool:
     return True
 
 
-def _affected_parts(partition: Partition) -> set[int]:
+def _affected_parts(partition: Partition) -> set[Hashable]:
     """Checks which partitions were affected by the change of nodes.
 
     Args:
         partition (Partition): The proposed next Partition
 
     Returns:
-        Set[int]: The set of IDs of all parts that gained or lost a node when compared to the
+        set[Hashable]: The set of IDs of all parts that gained or lost a node when compared to the
             parent partition.
     """
     flips = partition.flips
     parent = partition.parent
 
     if flips is None:
-        return partition.parts
+        return set(partition.parts)
 
     if parent is None:
         return set(flips.values())
@@ -164,7 +168,7 @@ def number_of_contiguous_parts(partition: Partition) -> int:
 no_more_discontiguous = SelfConfiguringLowerBound(number_of_contiguous_parts)
 
 
-def contiguous_components(partition: Partition) -> dict[int, list]:
+def contiguous_components(partition: Partition) -> dict[Hashable, list[Graph]]:
     """Determines the connected components of each of the subgraphs of the parts of the partition.
 
     Args:
@@ -175,10 +179,9 @@ def contiguous_components(partition: Partition) -> dict[int, list]:
             part of the partition
     """
 
-    connected_components_in_each_partition = {}
+    connected_components_in_each_partition: dict[Hashable, list[Graph]] = {}
     for part, subgraph in partition.subgraphs.items():
         # create a subgraph for each set of connected nodes in the part's nodes
-        list_of_connected_subgraphs = subgraph.subgraphs_for_connected_components()
-        connected_components_in_each_partition[part] = list_of_connected_subgraphs
+        connected_components_in_each_partition[part] = subgraph.subgraphs_for_connected_components()
 
     return connected_components_in_each_partition

--- a/gerrychain/constraints/validity.py
+++ b/gerrychain/constraints/validity.py
@@ -1,4 +1,4 @@
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Hashable, Iterable
 
 import numpy
 
@@ -21,17 +21,17 @@ class Validator:
         chain = MarkovChain(proposal, is_valid, accept, initial_state, total_steps)
 
     Attributes:
-        constraints (List[Callable]): List of validator functions that will check partitions.
+        constraints (list[Callable]): List of validator functions that will check partitions.
     """
 
-    def __init__(self, constraints: list[Callable]) -> None:
+    def __init__(self, constraints: Iterable[Callable[[Partition], bool]]) -> None:
         """Initialize a Validator instance.
 
         Args:
-            constraints (List[Callable]): List of validator functions that will check partitions.
+            constraints (list[Callable]): List of validator functions that will check partitions.
 
         """
-        self.constraints = constraints
+        self.constraints = list(constraints)
 
     def __call__(self, partition: Partition) -> bool:
         """Determine if the given partition is valid.
@@ -60,13 +60,16 @@ class Validator:
         return True
 
     def __repr__(self) -> str:
-        constraint_names = [constraint.__name__ for constraint in self.constraints]
+        constraint_names = [
+            getattr(constraint, "__name__", type(constraint).__name__)
+            for constraint in self.constraints
+        ]
         return f"Validator(constraints={constraint_names})"
 
 
 def within_percent_of_ideal_population(
     initial_partition: Partition, percent: float = 0.01, pop_key: str = "population"
-) -> Bounds:
+) -> Bounds[[Partition]]:
     """Construct a bounds object to ensure all districts are closed to a target population.
 
     Args:
@@ -91,7 +94,9 @@ def within_percent_of_ideal_population(
     return Bounds(population, bounds=bounds)
 
 
-def deviation_from_ideal(partition: Partition, attribute: str = "population") -> dict[int, float]:
+def deviation_from_ideal(
+    partition: Partition, attribute: str = "population"
+) -> dict[Hashable, float]:
     """Determine the deviation of the given attribute from the ideal value
     among parts of the partition.
 
@@ -107,7 +112,7 @@ def deviation_from_ideal(partition: Partition, attribute: str = "population") ->
             deviation for. Default is ``"population"``.
 
     Returns:
-        Dict[int, float]: dictionary from parts to their deviation
+        dict[Hashable, float]: dictionary from parts to their deviation
     """
     number_of_districts = len(partition[attribute].keys())
     total = sum(partition[attribute].values())
@@ -127,7 +132,7 @@ def districts_within_tolerance(
 
     Args:
         partition (Partition): Partition class instance
-        attrName (str, optional): String that is the name of an updater in partition. Default is
+        attribute_name (str, optional): Name of an updater in ``partition``. Defaults to
             ``"population"``.
         percentage (float, optional): What percent (as a number between 0 and 1) difference is
             allowed. Default is 0.1.

--- a/gerrychain/examples/__init__.py
+++ b/gerrychain/examples/__init__.py
@@ -42,6 +42,6 @@ def gerrymandria() -> Graph:
         >>> sorted({graph.node_data(n)["county"] for n in graph.node_indices})
         ['1', '2', '3', '4']
     """
-    resource = files(__package__).joinpath("gerrymandria.json")
+    resource = files("gerrychain.examples").joinpath("gerrymandria.json")
     with as_file(resource) as path:
         return Graph.from_json(str(path))

--- a/gerrychain/graph/adjacency.py
+++ b/gerrychain/graph/adjacency.py
@@ -11,13 +11,16 @@ unspecified because of import issues.
 
 import warnings
 from collections.abc import Hashable, Iterable, Iterator
+from typing import cast
 
 from geopandas import GeoDataFrame, GeoSeries
 from shapely.geometry.base import BaseGeometry
 from shapely.strtree import STRtree
 
+Adjacency = dict[Hashable, dict[Hashable, dict[str, float]]]
 
-def neighbors(df: GeoDataFrame, adjacency: str) -> dict:
+
+def neighbors(df: GeoDataFrame, adjacency: str) -> Adjacency:
     if adjacency not in ("rook", "queen"):
         raise ValueError(
             "The adjacency parameter provided is not supported. "
@@ -31,11 +34,11 @@ def str_tree(geometries: GeoSeries) -> STRtree:
     """Creates a STR tree for spatial indexing. Useful for spatial operations.
 
     Args:
-        geometries (shapely.geometry.BaseGeometry): A Shapely geometry object to construct the tree
+        geometries (GeoSeries): A Shapely geometry object to construct the tree
             from.
 
     Returns:
-        shapely.strtree.STRtree: A Sort-Tile-Recursive tree for spatial indexing.
+        STRtree: A Sort-Tile-Recursive tree for spatial indexing.
     """
     from shapely.strtree import STRtree
 
@@ -52,21 +55,22 @@ def neighboring_geometries(
     """Generator yielding tuples of the form (id, (ids of neighbors)).
 
     Args:
-        geometries (shapely.geometry.BaseGeometry): A Shapeley geometry object to construct the
+        geometries (GeoSeries): A Shapeley geometry object to construct the
             tree from
-        tree (shapely.strtree.STRtree, optional): A Sort-Tile-Recursive tree for spatial indexing.
-            Default is None.
+        tree (STRtree | None, optional): A Sort-Tile-Recursive tree for spatial indexing.
+            Defaults to None.
 
     Returns:
-        Generator: A generator yielding tuples of the form (id, (ids of neighbors))
+        Iterator[tuple[Hashable, tuple[Hashable, ...]]]: Geometry IDs and their neighboring IDs.
     """
     if tree is None:
         tree = str_tree(geometries)
 
     for geometry_id, geometry in geometries.items():
+        geometry = cast(BaseGeometry, geometry)
         possible = tree.query(geometry)
         actual = tuple(
-            geometries.index[p]
+            cast(Hashable, geometries.index[p])
             for p in possible
             if (not geometries.iloc[p].is_empty) and geometries.index[p] != geometry_id
         )
@@ -82,13 +86,17 @@ def intersections_with_neighbors(
         The intersections may be empty!
 
     Args:
-        geometries (shapely.geometry.BaseGeometry): A Shapeley geometry object.
+        geometries (GeoSeries): A Shapeley geometry object.
 
     Returns:
-        Generator: A generator yielding tuples of the form (id, {neighbor_id: intersection})
+        Iterator[tuple[Hashable, dict[Hashable, BaseGeometry]]]: Geometry IDs mapped to their
+            intersections with neighboring geometries.
     """
     for i, neighbors in neighboring_geometries(geometries):
-        intersections = {j: geometries[i].intersection(geometries[j]) for j in neighbors}
+        geometry = cast(BaseGeometry, geometries[i])
+        intersections = {
+            j: geometry.intersection(cast(BaseGeometry, geometries[j])) for j in neighbors
+        }
         yield (i, intersections)
 
 
@@ -98,20 +106,20 @@ def warn_for_overlaps(
     """Return A generator yielding tuples of intersection pairs.
 
     Args:
-        intersection_pairs (Iterable): An iterable of tuples of the form (id, {neighbor_id:
-            intersection})
+        intersection_pairs (Iterable[tuple[Hashable, dict[Hashable, BaseGeometry]]]): Geometry IDs
+            mapped to their intersections with neighboring geometries.
 
     Returns:
-        Generator: A generator yielding tuples of intersection pairs
+        Iterator[tuple[Hashable, dict[Hashable, BaseGeometry]]]: The original intersection pairs.
 
     Raises:
         UserWarning: if there are overlaps among the given polygons
     """
-    overlaps = set()
+    overlaps: set[frozenset[Hashable]] = set()
     for i, intersections in intersection_pairs:
         overlaps.update(
             set(
-                tuple(sorted([i, j]))
+                frozenset((i, j))
                 for j, intersection in intersections.items()
                 if intersection.area > 0
             )
@@ -121,14 +129,14 @@ def warn_for_overlaps(
         warnings.warn(f"Found overlaps among the given polygons. Indices of overlaps: {overlaps}")
 
 
-def queen(geometries: GeoSeries) -> dict[Hashable, dict[Hashable, dict[str, float]]]:
+def queen(geometries: GeoSeries) -> Adjacency:
     """Return queen adjacency dictionary for the given collection of polygons.
 
     Args:
-        geometries (shapely.geometry.BaseGeometry): A Shapeley geometry object.
+        geometries (GeoSeries): A Shapeley geometry object.
 
     Returns:
-        Dict: The queen adjacency dictionary for the given collection of polygons.
+        Adjacency: The queen adjacency dictionary for the given collection of polygons.
     """
     intersection_pairs = warn_for_overlaps(intersections_with_neighbors(geometries))
 
@@ -142,14 +150,14 @@ def queen(geometries: GeoSeries) -> dict[Hashable, dict[Hashable, dict[str, floa
     }
 
 
-def rook(geometries: GeoSeries) -> dict[Hashable, dict[Hashable, dict[str, float]]]:
+def rook(geometries: GeoSeries) -> Adjacency:
     """Return rook adjacency dictionary for the given collection of polygons.
 
     Args:
-        geometries (shapely.geometry.BaseGeometry): A Shapeley geometry object.
+        geometries (GeoSeries): A Shapeley geometry object.
 
     Returns:
-        Dict: The rook adjacency dictionary for the given collection of polygons.
+        Adjacency: The rook adjacency dictionary for the given collection of polygons.
     """
     return {
         i: {j: data for j, data in neighbors.items() if data["shared_perim"] > 0}

--- a/gerrychain/graph/geo.py
+++ b/gerrychain/graph/geo.py
@@ -6,6 +6,7 @@ within a given GeoDataFrame.
 """
 
 from collections import Counter
+from collections.abc import Hashable
 
 from geopandas import GeoDataFrame
 from shapely.geometry import Point
@@ -57,14 +58,14 @@ def explain_validity(geo: BaseGeometry) -> str:
     return shapely.validation.explain_validity(geo)
 
 
-def invalid_geometries(df: GeoDataFrame) -> list[int]:
+def invalid_geometries(df: GeoDataFrame) -> list[Hashable]:
     """Given a GeoDataFrame, returns a list of row indices with invalid geometries.
 
     Args:
         df (GeoDataFrame): The GeoDataFrame to examine
 
     Returns:
-        list of int: List of row indices with invalid geometries
+        list[Hashable]: Row indices with invalid geometries.
     """
     invalid = []
     for idx, row in df.iterrows():

--- a/gerrychain/graph/graph.py
+++ b/gerrychain/graph/graph.py
@@ -24,10 +24,11 @@ from __future__ import annotations
 import functools
 import json
 import warnings
-from collections.abc import Generator, Iterable, Sequence
+from collections.abc import Generator, Hashable, Iterable, Iterator, Mapping, Sequence
+from collections.abc import Set as AbstractSet
 
 # frm: codereview note: removed type hints that are now baked into Python
-from typing import Any
+from typing import Any, Protocol, TypedDict, TypeVar, cast
 
 import geopandas as gp
 import networkx
@@ -36,6 +37,7 @@ import pandas as pd
 import rustworkx
 import scipy
 from networkx.readwrite import json_graph
+from shapely.geometry.base import BaseGeometry
 from shapely.ops import unary_union
 from shapely.prepared import prep
 
@@ -44,11 +46,25 @@ from .adjacency import neighbors
 from .geo import GeometryError, invalid_geometries, reprojected
 
 
+class _AdjacencyData(TypedDict):
+    nodes: list[dict[str, object]]
+
+
+class _GeoInterface(Protocol):
+    __geo_interface__: dict[str, object]
+
+
+_AttributeDict = dict[str, Any]
+_NodeT = TypeVar("_NodeT", bound=Hashable)
+_NodeDataT = TypeVar("_NodeDataT", bound=_AttributeDict)
+_EdgeDataT = TypeVar("_EdgeDataT", bound=_AttributeDict)
+
+
 class GraphValidationError(Exception):
     """Raised when a Graph fails an integrity check (see ``verify_graph_is_valid``)."""
 
 
-def json_serialize(input_object: Any) -> int | None:
+def json_serialize(input_object: object) -> int | None:
     """Return converted pandas object or None if input is not of type pd.Int64Dtype.
 
     This function is used to handle one of the common issues that appears when trying to convert a
@@ -58,12 +74,12 @@ def json_serialize(input_object: Any) -> int | None:
     can serialize it and so that we can write graphs out to JSON files.
 
     Args:
-        input_object (Any (expected to be a pd.Int64Dtype)): The object to be converted
+        input_object (object): An object expected to be a NumPy integer.
 
     Returns:
-        Optional[int]: The converted pandas object or None if input is not of type pd.Int64Dtype
+        int | None: The converted pandas object or None if input is not of type pd.Int64Dtype
     """
-    if pd.api.types.is_integer_dtype(input_object):  # handle int64
+    if isinstance(input_object, numpy.integer):
         return int(input_object)
 
     return None
@@ -112,11 +128,15 @@ class Graph:
     #       ``is_rx_graph()`` can test them directly without ever triggering attribute
     #       fallback. A bare, unconfigured Graph therefore has both set to None, which
     #       ``verify_graph_is_valid()`` reports as a clear error.
-    _nx_graph = None
-    _rx_graph = None
+    _nx_graph: networkx.Graph[Hashable, _AttributeDict, _AttributeDict] | None = None
+    _rx_graph: rustworkx.PyGraph[_AttributeDict, _AttributeDict] | None = None
+    _is_a_subgraph = False
+    _node_id_to_parent_node_id_map: dict[Hashable, Hashable] = {}
+    _node_id_to_original_nx_node_id_map: dict[Hashable, Hashable] = {}
+    nx_to_rx_node_id_map: dict[Hashable, Hashable] | None = None
 
     @classmethod
-    def from_networkx(cls, nx_graph: networkx.Graph) -> Graph:
+    def from_networkx(cls, nx_graph: networkx.Graph[_NodeT, _NodeDataT, _EdgeDataT]) -> Graph:
         """Create a Graph from a NetworkX.Graph object.
 
         This supports the use case of users creating a graph using NetworkX which is convenient -
@@ -142,7 +162,7 @@ class Graph:
             )
 
         graph = cls()
-        graph._nx_graph = nx_graph
+        graph._nx_graph = cast("networkx.Graph[Hashable, _AttributeDict, _AttributeDict]", nx_graph)
         graph._rx_graph = None
         graph._is_a_subgraph = False  # See comments on RX subgraph issues.
         # Maps node_ids in the graph to the "parent" node_ids in the parent graph.
@@ -173,11 +193,11 @@ class Graph:
             Graph: A Graph object with no nodes
         """
 
-        nx_graph = networkx.Graph()
+        nx_graph: networkx.Graph[Hashable, _AttributeDict, _AttributeDict] = networkx.Graph()
         return Graph.from_networkx(nx_graph)
 
     @classmethod
-    def from_rustworkx(cls, rx_graph: rustworkx.PyGraph) -> Graph:
+    def from_rustworkx(cls, rx_graph: rustworkx.PyGraph[_NodeDataT, Any]) -> Graph:
         """Create a Graph from a RustworkX.PyGraph object.
 
         There are three primary use cases for this routine: 1) converting an NX-based Graph to be
@@ -206,7 +226,7 @@ class Graph:
             rx_graph (rustworkx.PyGraph): a RustworkX PyGraph object
 
         Returns:
-            "Graph": a GerryChain Graph object with an embedded RustworkX.PyGraph object
+            'Graph': a GerryChain Graph object with an embedded RustworkX.PyGraph object
         """
         if not isinstance(rx_graph, rustworkx.PyGraph):
             raise GraphValidationError(
@@ -254,7 +274,7 @@ class Graph:
                 graph.update_edge_by_index(edge_id, {"__original_rx_edge_data": data_dict})
 
         graph = cls()
-        graph._rx_graph = rx_graph
+        graph._rx_graph = cast(rustworkx.PyGraph[_AttributeDict, _AttributeDict], rx_graph)
         graph._nx_graph = None
         graph._is_a_subgraph = False  # See comments on RX subgraph issues.
 
@@ -301,7 +321,9 @@ class Graph:
 
         return graph
 
-    def to_networkx_graph(self) -> networkx.Graph:
+    def to_networkx_graph(
+        self,
+    ) -> networkx.Graph[Hashable, _AttributeDict, _AttributeDict]:
         """Create a NetworkX.Graph object that has the same nodes, edges, node_data, and edge_data.
         as the GerryChain Graph object.
 
@@ -320,10 +342,10 @@ class Graph:
             networkx.Graph: A NetworkX.Graph object that is equivalent to the GerryChain Graph
                 object (nodes, edges, node_data, edge_data)
         """
-        if self.is_nx_graph():
+        if self._nx_graph is not None:
             return self.get_nx_graph()
 
-        if not self.is_rx_graph():
+        if self._rx_graph is None:
             raise TypeError("Graph passed to 'to_networkx_graph()' must be a rustworkx graph")
 
         # We have an RX-based Graph, and we want to create a NetworkX Graph object
@@ -380,7 +402,12 @@ class Graph:
         # Create a NetworkX Graph object from the edges_df, using
         # "source", and "tartet" to define edge node_ids, and adding
         # all attribute data (True).
-        nx_graph = networkx.from_pandas_edgelist(edges_df, "source", "target", True, networkx.Graph)
+        nx_graph = cast(
+            "networkx.Graph[Hashable, _AttributeDict, _AttributeDict]",
+            networkx.from_pandas_edgelist(
+                edges_df, source="source", target="target", edge_attr=True
+            ),
+        )
 
         # Add all of the node_data, using the "node_name" attr as the NX Graph node_id
         nodes_df = nodes_df.set_index("node_name")
@@ -388,46 +415,46 @@ class Graph:
 
         return nx_graph
 
-    def original_nx_node_id_for_internal_node_id(self, internal_node_id: Any) -> Any:
+    def original_nx_node_id_for_internal_node_id(self, internal_node_id: Hashable) -> Hashable:
         """Translate a node_id to its "original" node_id.
 
         Args:
-            internal_node_id (Any): A node_id to be translated
+            internal_node_id (Hashable): A node ID to translate.
 
         Returns:
-            Any: A translated node_id
+            Hashable: The translated node ID.
         """
         return self._node_id_to_original_nx_node_id_map[internal_node_id]
 
-    def original_nx_node_ids_for_set(self, set_of_node_ids: set[Any]) -> Any:
+    def original_nx_node_ids_for_set(self, set_of_node_ids: set[Hashable]) -> set[Hashable]:
         """Translate a set of node_ids to their "original" node_ids.
 
         Args:
-            set_of_node_ids (set[Any]): A set of node_ids to be translated
+            set_of_node_ids (set[Hashable]): Node IDs to translate.
 
         Returns:
-            set[Any]: A set of translated node_ids
+            set[Hashable]: The translated node IDs.
         """
         _node_id_to_original_nx_node_id_map = self._node_id_to_original_nx_node_id_map
         new_set = {_node_id_to_original_nx_node_id_map[node_id] for node_id in set_of_node_ids}
         return new_set
 
-    def original_nx_node_ids_for_list(self, list_of_node_ids: list[Any]) -> list[Any]:
+    def original_nx_node_ids_for_list(self, list_of_node_ids: list[Hashable]) -> list[Hashable]:
         """Translate a list of node_ids to their "original" node_ids.
 
 
         Args:
-            list_of_node_ids (list[Any]): A list of node_ids to be translated
+            list_of_node_ids (list[Hashable]): Node IDs to translate.
 
         Returns:
-            list[Any]: A list of translated node_ids
+            list[Hashable]: The translated node IDs.
         """
         # Utility routine to quickly translate a set of node_ids to their original node_ids
         _node_id_to_original_nx_node_id_map = self._node_id_to_original_nx_node_id_map
         new_list = [_node_id_to_original_nx_node_id_map[node_id] for node_id in list_of_node_ids]
         return new_list
 
-    def internal_node_id_for_original_nx_node_id(self, original_nx_node_id: Any) -> Any:
+    def internal_node_id_for_original_nx_node_id(self, original_nx_node_id: Hashable) -> Hashable:
         """Return corresponding "internal" node_id.
 
         Discover the "internal" node_id in the current GerryChain graph that corresponds to the
@@ -438,10 +465,10 @@ class Graph:
         made using the "internal" (RX) node_ids.
 
         Args:
-            original_nx_node_id (Any): The "original" node_id
+            original_nx_node_id (Hashable): The original node ID.
 
         Returns:
-            Any: The corresponding "internal" node_id
+            Hashable: The corresponding internal node ID.
         """
         # Note: TODO: Performance: This code is inefficient but it is not a priority to fix now...
         #
@@ -480,7 +507,7 @@ class Graph:
           The test suite enables it.
 
         Args:
-            thorough (Optional[bool]): Whether to run the expensive audit. If ``None`` (default),
+            thorough (bool | None): Whether to run the expensive audit. If ``None`` (default),
                 follows the global runtime-checks setting. Pass ``True`` to force it on or ``False``
                 to force it off (e.g. on hot construction paths that build many short-lived
                 subgraphs).
@@ -529,13 +556,15 @@ class Graph:
                     raise GraphValidationError(
                         f"Edge {edge_id} does not carry a dict data payload."
                     )
-        else:
+        elif self._nx_graph is not None:
             nx_graph = self._nx_graph
             for node_id, data in nx_graph.nodes(data=True):
                 if not isinstance(data, dict):
                     raise GraphValidationError(
                         f"Node {node_id} does not carry a dict data payload."
                     )
+        else:
+            raise GraphValidationError("Graph has no NetworkX or RustworkX backing graph.")
 
     # frm: TODO: Performance:  is_nx_graph() and is_rx_graph() are expensive.
     #
@@ -550,23 +579,25 @@ class Graph:
         #     self.verify_graph_is_valid()
         return self._nx_graph is not None
 
-    def get_nx_graph(self) -> networkx.Graph:
+    def get_nx_graph(
+        self,
+    ) -> networkx.Graph[Hashable, _AttributeDict, _AttributeDict]:
         """Return the embedded NX graph object.
 
         Returns:
             networkx.Graph:
         """
-        if not self.is_nx_graph():
+        if self._nx_graph is None:
             raise TypeError("Graph passed to 'get_nx_graph()' must be a networkx graph")
         return self._nx_graph
 
-    def get_rx_graph(self) -> rustworkx.PyGraph:
+    def get_rx_graph(self) -> rustworkx.PyGraph[_AttributeDict, _AttributeDict]:
         """Return the embedded RX graph object.
 
         Returns:
             rustworkx.PyGraph:
         """
-        if not self.is_rx_graph():
+        if self._rx_graph is None:
             raise TypeError("Graph passed to 'get_rx_graph()' must be a rustworkx graph")
         return self._rx_graph
 
@@ -586,7 +617,7 @@ class Graph:
         Partition object.
 
         Returns:
-            "Graph": An RX-based graph that is "the same" as the given NX-based graph
+            'Graph': An RX-based graph that is "the same" as the given NX-based graph
         """
 
         # Note that in both cases in the if-stmt below, the nodes are not copied.
@@ -597,7 +628,7 @@ class Graph:
         # or if we are converting it from NX.
         #
         self.verify_graph_is_valid()
-        if self.is_nx_graph():
+        if self._nx_graph is not None:
             if self._is_a_subgraph:
                 # This routine is intended to be used in exactly one place - in converting
                 # an NX based Graph object to be RX based when creating a Partition object.
@@ -607,6 +638,9 @@ class Graph:
 
             nx_graph = self._nx_graph
             rx_graph = rustworkx.networkx_converter(nx_graph, keep_attributes=True)
+            if not isinstance(rx_graph, rustworkx.PyGraph):
+                raise TypeError("NetworkX conversion unexpectedly produced a directed graph")
+            rx_graph = cast(rustworkx.PyGraph[_AttributeDict, _AttributeDict], rx_graph)
 
             # Note that the resulting RX graph will have multigraph set to False which
             # ensures that there is never more than one edge between two specific nodes.
@@ -618,14 +652,16 @@ class Graph:
 
             # Some graphs have geometry data (from a geodataframe), so preserve it if it exists
             if hasattr(self, "geometry"):
-                converted_graph.geometry = self.geometry
+                setattr(converted_graph, "geometry", getattr(self, "geometry"))
 
             # Create a mapping from the old NX node_ids to the new RX node_ids (created by
             # RX when it converts from NX)
-            nx_to_rx_node_id_map = {
-                converted_graph.node_data(node_id)["__networkx_node__"]: node_id
-                for node_id in converted_graph._rx_graph.node_indices()
-            }
+            nx_to_rx_node_id_map: dict[Hashable, Hashable] = {}
+            for node_id in converted_graph.get_rx_graph().node_indices():
+                original_node_id = cast(
+                    Hashable, converted_graph.node_data(node_id)["__networkx_node__"]
+                )
+                nx_to_rx_node_id_map[original_node_id] = node_id
             converted_graph.nx_to_rx_node_id_map = nx_to_rx_node_id_map
 
             # We also have to update the _node_id_to_original_nx_node_id_map to refer to the
@@ -639,7 +675,7 @@ class Graph:
             )
 
             return converted_graph
-        elif self.is_rx_graph():
+        elif self._rx_graph is not None:
             return self
         else:
             raise TypeError(
@@ -647,7 +683,7 @@ class Graph:
                 "a networkx-based graph nor a rustworkx-based graph"
             )
 
-    def get_nx_to_rx_node_id_map(self) -> dict[Any, Any]:
+    def get_nx_to_rx_node_id_map(self) -> dict[Hashable, Hashable]:
         """Return the dict that maps NX node_ids to RX node_ids.
 
         The primary use case for this routine is to support automatically converting NX-based graph
@@ -657,12 +693,14 @@ class Graph:
         to the new RX node_ids when initializing a Partition object.
 
         Returns:
-            dict[Any, Any]:
+            dict[Hashable, Hashable]: NetworkX node IDs mapped to RustworkX node IDs.
         """
         # Simple getter method
-        if not self.is_rx_graph():
+        if self._rx_graph is None:
             raise TypeError("Graph passed to 'get_nx_to_rx_node_id()' is not a rustworkx graph")
 
+        if self.nx_to_rx_node_id_map is None:
+            raise TypeError("Graph does not have a NetworkX-to-RustworkX node mapping")
         return self.nx_to_rx_node_id_map
 
     @classmethod
@@ -692,9 +730,9 @@ class Graph:
             A minimal two-node example::
 
                 {
-                  "directed": false, "multigraph": false, "graph": [],
-                  "nodes": [{"pop": 5, "id": 0}, {"pop": 3, "id": 1}],
-                  "adjacency": [[{"id": 1}], [{"id": 0}]]
+                  'directed': false, "multigraph": false, "graph": [],
+                  'nodes': [{"pop": 5, "id": 0}, {"pop": 3, "id": 1}],
+                  'adjacency': [[{"id": 1}], [{"id": 0}]]
                 }
 
             Node and edge attributes are preserved and become accessible as
@@ -809,10 +847,10 @@ class Graph:
             >>> graph.to_json("./my_state_copy.json")       # doctest: +SKIP
         """
         # frm TODO: Code: Implement graph.to_json for an RX based graph
-        if not self.is_nx_graph():
+        if self._nx_graph is None:
             raise TypeError("Graph passed to 'to_json()' is not a networkx graph")
 
-        data = json_graph.adjacency_data(self._nx_graph)
+        data = cast(_AdjacencyData, json_graph.adjacency_data(self.get_nx_graph()))
 
         if include_geometries_as_geojson:
             convert_geometries_to_geojson(data)
@@ -841,7 +879,7 @@ class Graph:
             filename (str): Path to the shapefile / GeoPackage / GeoJSON / etc.
             adjacency (str, optional): The adjacency type to use ("rook" or "queen"). Default is
                 "rook"
-            cols_to_add (Optional[list[str]], optional): The names of the columns that you want to
+            cols_to_add (list[str] | None, optional): The names of the columns that you want to
                 add to the graph as node attributes. Default is None.
             reproject (bool, optional): Whether to reproject to a UTM projection before creating
                 the graph. Default is False.
@@ -867,13 +905,13 @@ class Graph:
         )
 
         # Store CRS data as an attribute of the NX graph
-        graph._nx_graph.graph["crs"] = df.crs.to_json()
+        graph.get_nx_graph().graph["crs"] = df.crs.to_json() if df.crs is not None else None
         return graph
 
     @classmethod
     def from_geodataframe(
         cls,
-        dataframe: pd.DataFrame,
+        dataframe: gp.GeoDataFrame,
         adjacency: str = "rook",
         cols_to_add: list[str] | None = None,
         reproject: bool = False,
@@ -900,13 +938,13 @@ class Graph:
             dataframe (GeoDataFrame): The GeoDateFrame to convert
             adjacency (str, optional): The adjacency type to use ("rook" or "queen"). Default is
                 "rook".
-            cols_to_add (Optional[list[str]], optional): The names of the columns that you want to
+            cols_to_add (list[str] | None, optional): The names of the columns that you want to
                 add to the graph as node attributes. Default is None.
             reproject (bool, optional): Whether to reproject to a UTM projection before creating
                 the graph. Default is ``False``.
             ignore_errors (bool, optional): Whether to ignore all invalid geometries and attept to
                 create the graph anyway. Default is ``False``.
-            crs_override (Optional[Union[str,int]], optional): Value to override the CRS of the
+            crs_override (str | int | None, optional): Value to override the CRS of the
                 GeoDataFrame. Default is None.
 
         Returns:
@@ -945,7 +983,10 @@ class Graph:
         # to the requested adjacency rule
         adjacencies = neighbors(df, adjacency)  # Note - this is adjacency.neighbors()
 
-        nx_graph = networkx.Graph(adjacencies)
+        nx_graph = cast(
+            "networkx.Graph[Hashable, _AttributeDict, _AttributeDict]",
+            networkx.Graph(adjacencies),
+        )
 
         # The geometry attribute on df is a special attribute that only appears on
         # geodataframes. This is just a list of polygons representing some real-life
@@ -963,7 +1004,7 @@ class Graph:
         # might be best to just make a Graph.dataframe attribute to store all of the
         # graph data on, and add attributes to _nxgraph and _rxgraph nodes as needed
 
-        nx_graph.geometry = df.geometry
+        setattr(nx_graph, "geometry", df.geometry)
 
         # Add "exterior" perimeters to the boundary nodes
         _add_boundary_perimeters_to_nx_graph(nx_graph, df.geometry)
@@ -1006,7 +1047,7 @@ class Graph:
     #
 
     @property
-    def node_indices(self) -> set[Any]:
+    def node_indices(self) -> set[Hashable]:
         """Return a ``set`` of the node_ids in the graph.
 
         This is the canonical accessor for the graph's node_ids. It returns a ``set``, so it is
@@ -1016,7 +1057,7 @@ class Graph:
         specifically required.
 
         Returns:
-            set[Any]: An (unordered) set of the node_ids in the graph.
+            set[Hashable]: An unordered set of node IDs in the graph.
         """
         if self._rx_graph is not None:
             return set(self._rx_graph.node_indices())
@@ -1029,7 +1070,7 @@ class Graph:
             )
 
     @property
-    def edge_indices(self) -> set[Any]:
+    def edge_indices(self) -> set[Hashable]:
         """Return a ``set`` of the edge *ids* in the graph.
 
         Unlike :meth:`nodes`/:meth:`node_indices` (which carry the same content up to a
@@ -1039,7 +1080,7 @@ class Graph:
         :meth:`get_edge_from_edge_id` / :meth:`get_edge_id_from_edge` to convert between the two.
 
         Returns:
-            set[Any]: A set of the edge_ids in the graph.
+            set[Hashable]: The edge IDs in the graph.
         """
         if self._rx_graph is not None:
             # A set of edge_ids for the edges
@@ -1053,7 +1094,7 @@ class Graph:
                 "a networkx-based graph nor a rustworkx-based graph"
             )
 
-    def get_edge_from_edge_id(self, edge_id: Any) -> tuple[Any, Any]:
+    def get_edge_from_edge_id(self, edge_id: Hashable) -> tuple[Hashable, Hashable]:
         """Return the edge (tuple of node_ids) corresponding to the given edge_id.
 
         Note that in NX, an edge_id is the same as an edge - it is just a tuple of node_ids.
@@ -1061,26 +1102,26 @@ class Graph:
         need to use the edge_id to get that tuple...
 
         Args:
-            edge_id (Any): The ID of the desired edge
+            edge_id (Hashable): The desired edge ID.
 
         Returns:
-            tuple[Any, Any]: An edge, namely a tuple of node_ids
+            tuple[Hashable, Hashable]: The edge's node IDs.
         """
 
         if self._rx_graph is not None:
             # In RX, we need to go get the edge tuple
-            endpoints = self._rx_graph.get_edge_endpoints_by_index(edge_id)
+            endpoints = self._rx_graph.get_edge_endpoints_by_index(cast(int, edge_id))
             return (endpoints[0], endpoints[1])
-        elif self.is_nx_graph():
+        elif self._nx_graph is not None:
             # In NX, the edge_id is also the edge tuple
-            return edge_id
+            return cast(tuple[Hashable, Hashable], edge_id)
         else:
             raise TypeError(
                 "Graph passed to 'get_edge_from_edge_id()' is neither "
                 "a networkx-based graph nor a rustworkx-based graph"
             )
 
-    def get_edge_id_from_edge(self, edge: tuple[Any, Any]) -> Any:
+    def get_edge_id_from_edge(self, edge: tuple[Hashable, Hashable]) -> Hashable:
         """Get the edge_id that corresponds to the given edge.
 
         In RX an edge_id is an integer that designates an edge (an edge is a tuple of node_ids). In
@@ -1089,13 +1130,13 @@ class Graph:
         the edge_id.
 
         Args:
-            edge (tuple[Any, Any]): A tuple of node_ids.
+            edge (tuple[Hashable, Hashable]): A tuple of node IDs.
 
         Returns:
-            Any: The ID associated with the given edge
+            Hashable: The ID associated with the edge.
         """
 
-        if self.is_rx_graph():
+        if self._rx_graph is not None:
             # frm: TODO: Performance: Perhaps get_edge_id_from_edge() is too expensive...
             #
             # If this routine becomes a signficant performance issue, then perhaps
@@ -1120,9 +1161,11 @@ class Graph:
             # returning a single edge because the RX graph object has multigraph set
             # to false by RX.networkx_converter() - because the NX graph was undirected...
             #
-            edge_indices = self._rx_graph.edge_indices_from_endpoints(edge[0], edge[1])
+            edge_indices = self._rx_graph.edge_indices_from_endpoints(
+                cast(int, edge[0]), cast(int, edge[1])
+            )
             return edge_indices[0]  # there will always be one and only one
-        elif self.is_nx_graph():
+        elif self._nx_graph is not None:
             # In NX, the edge_id is also the edge tuple
             return edge
         else:
@@ -1132,7 +1175,7 @@ class Graph:
             )
 
     @property
-    def nodes(self) -> list[Any]:
+    def nodes(self) -> list[Hashable]:
         """Return a ``list`` of all of the node_ids in the graph.
 
         This returns the same node_ids as :meth:`node_indices`, the difference being only the
@@ -1156,15 +1199,15 @@ class Graph:
         in the RustworkX world.
 
         Returns:
-            list[Any]: An ordered list of all of the node_ids in the graph.
+            list[Hashable]: An ordered list of node IDs in the graph.
         """
 
         # Note: graph.nodes continues to exist because it was used often in legacy code.
         #
-        if self.is_rx_graph():
+        if self._rx_graph is not None:
             # A list of integer node_ids
             return list(self._rx_graph.node_indices())
-        elif self.is_nx_graph():
+        elif self._nx_graph is not None:
             # A list of node_ids -
             return list(self._nx_graph.nodes)
         else:
@@ -1174,7 +1217,7 @@ class Graph:
             )
 
     @property
-    def edges(self) -> set[tuple[Any, Any]]:
+    def edges(self) -> set[tuple[Hashable, Hashable]]:
         """Return a ``set`` of all of the edges in the graph, where each edge is a ``(u, v)`` tuple
         of node_ids.
 
@@ -1183,14 +1226,14 @@ class Graph:
         integers under RustworkX) see :meth:`edge_indices`.
 
         Returns:
-            set[tuple[Any, Any]]: A set of ``(u, v)`` node_id tuples, one per edge.
+            set[tuple[Hashable, Hashable]]: One ``(u, v)`` node ID tuple per edge.
         """
         # Return a set of edge tuples
 
-        if self.is_rx_graph():
+        if self._rx_graph is not None:
             # A set of tuples for the edges
             return set(self._rx_graph.edge_list())
-        elif self.is_nx_graph():
+        elif self._nx_graph is not None:
             # A set of tuples extracted from the graph's EdgeView
             return set(self._nx_graph.edges)
         else:
@@ -1199,14 +1242,14 @@ class Graph:
                 "a networkx-based graph nor a rustworkx-based graph"
             )
 
-    def add_edge(self, node_id1: Any, node_id2: Any) -> None:
+    def add_edge(self, node_id1: Hashable, node_id2: Hashable) -> None:
         """Add an edge to the graph from node_id1 to node_id2.
 
         Note that both nodes need to already be members of the graph
 
         Args:
-            node_id1 (Any): The node_id for one of the nodes in the edge
-            node_id2 (Any): The node_id for one of the nodes in the edge
+            node_id1 (Hashable): One node ID in the edge.
+            node_id2 (Hashable): The other node ID in the edge.
 
         """
 
@@ -1215,14 +1258,15 @@ class Graph:
         # It remains for legacy reasons, and because users may find it convenient
         # to operate on a gerrychain Graph instead of an NX graph.
 
-        if self.is_rx_graph():
-            node1_exists = self._rx_graph.has_node(node_id1)
-            node2_exists = self._rx_graph.has_node(node_id2)
+        if self._rx_graph is not None:
+            rx_node_id1, rx_node_id2 = cast(int, node_id1), cast(int, node_id2)
+            node1_exists = self._rx_graph.has_node(rx_node_id1)
+            node2_exists = self._rx_graph.has_node(rx_node_id2)
             if (not node1_exists) or (not node2_exists):
                 raise Exception("add_edge(): both nodes in the edge must already exist")
             # empty dict tells RX the edge data will be a dict
-            self._rx_graph.add_edge(node_id1, node_id2, {})
-        elif self.is_nx_graph():
+            self._rx_graph.add_edge(rx_node_id1, rx_node_id2, {})
+        elif self._nx_graph is not None:
             node1_exists = self._nx_graph.has_node(node_id1)
             node2_exists = self._nx_graph.has_node(node_id2)
             if (not node1_exists) or (not node2_exists):
@@ -1239,28 +1283,29 @@ class Graph:
 
         Args:
             df (DataFrame): Dataframe containing given columns.
-            columns (Optional[Iterable[str]], optional): list of dataframe column names to add.
+            columns (Iterable[str] | None, optional): list of dataframe column names to add.
                 Default is None.
 
         """
 
-        if not (self.is_nx_graph()):
+        if not (self._nx_graph is not None):
             raise TypeError("Graph passed to 'add_data()' is not a networkx graph")
 
-        if columns is None:
-            columns = list(df.columns)
+        columns = list(df.columns if columns is None else columns)
 
-        check_dataframe(df[columns])
+        selected = cast(pd.DataFrame, df[columns])
+        check_dataframe(selected)
 
         # Create dict: {node_id: {attr_name: attr_value}}
         column_dictionaries = df.to_dict("index")
         nx_graph = self._nx_graph
         networkx.set_node_attributes(nx_graph, column_dictionaries)
 
-        if hasattr(nx_graph, "data"):
-            nx_graph.data[columns] = df[columns]  # type: ignore
+        data = getattr(nx_graph, "data", None)
+        if data is not None:
+            data[columns] = df[columns]
         else:
-            nx_graph.data = df[columns]
+            setattr(nx_graph, "data", df[columns])
 
     def join(
         self,
@@ -1276,11 +1321,11 @@ class Graph:
 
         Args:
             dataframe (DataFrame): DataFrame.
-            columns (Optional[list[str]], optional): The columns whose data you wish to add to the
+            columns (list[str] | None, optional): The columns whose data you wish to add to the
                 graph. If not provided, all columns are added. Default is None.
-            left_index (Optional[str], optional): The node attribute used to match nodes to rows.
+            left_index (str | None, optional): The node attribute used to match nodes to rows.
                 If not provided, node IDs are used. Default is None.
-            right_index (Optional[str], optional): The DataFrame column name to use to match rows
+            right_index (str | None, optional): The DataFrame column name to use to match rows
                 to nodes. If not provided, the DataFrame's index is used. Default is None.
 
         """
@@ -1290,14 +1335,14 @@ class Graph:
             df = dataframe
 
         if columns is not None:
-            df = df[columns]
+            df = cast(pd.DataFrame, df[columns])
 
         check_dataframe(df)
 
         column_dictionaries = df.to_dict()
 
         # In the future it might make sense to support this for RX...
-        if not self.is_nx_graph():
+        if self._nx_graph is None:
             raise TypeError("Graph passed to join() is not a networkx graph")
         nx_graph = self._nx_graph
 
@@ -1316,14 +1361,14 @@ class Graph:
         networkx.set_node_attributes(nx_graph, node_attributes)
 
     @property
-    def islands(self) -> set[Any]:
+    def islands(self) -> set[Hashable]:
         """Return A set of all node_ids for nodes of degree 0.
 
         Return a set of all node_ids that are not connected via an edge to any other node in the
         graph - that is, nodes with degree = 0
 
         Returns:
-            set[Any]: A set of all node_ids for nodes of degree 0
+            set[Hashable]: Node IDs for nodes of degree zero.
         """
         # Return all nodes of degree 0 (those not connected in an edge to another node)
         return set(node_id for node_id in self.node_indices if self.degree(node_id) == 0)
@@ -1391,7 +1436,7 @@ class Graph:
             __name (str): The attribute being requested.
 
         Returns:
-            Any: The attribute value from the embedded NetworkX graph.
+            Any: The dynamically delegated attribute value from the NetworkX graph.
 
         Raises:
             AttributeError: If the name is a dunder, the Graph is not NetworkX-backed, or the NX
@@ -1409,27 +1454,27 @@ class Graph:
             "attributes); it is not forwarded to a RustworkX backing graph."
         )
 
-    def __getitem__(self, __name: str) -> Any:
-        if self.is_rx_graph():
+    def __getitem__(self, node_id: Hashable) -> Mapping[Hashable, _AttributeDict]:
+        if self._rx_graph is not None:
             # frm TODO: Code: Decide if __getitem__() should work for RX
             raise TypeError("Graph._getitem__() is not defined for a rustworkx graph")
-        elif self.is_nx_graph():
-            return self._nx_graph[__name]
+        elif self._nx_graph is not None:
+            return self._nx_graph[node_id]
         else:
             raise TypeError(
                 "Graph passed to '__getitem__()' is neither "
                 "a networkx-based graph nor a rustworkx-based graph"
             )
 
-    def __iter__(self) -> Iterable[Any]:
+    def __iter__(self) -> Iterator[Hashable]:
         """Yields the node_ids in the graph.
 
         Returns:
-            Iterable[Any]: Returns the next node_id in the graph each time it is called.
+            Iterator[Hashable]: The graph's node IDs.
         """
         yield from self.node_indices
 
-    def subgraph(self, nodes: Iterable[Any]) -> Graph:
+    def subgraph(self, nodes: Iterable[Hashable]) -> Graph:
         """Create a subgraph that contains the given nodes.
 
         Note that creating a subgraph of an RustworkX (RX) graph renumbers the nodes, so that a
@@ -1443,10 +1488,10 @@ class Graph:
         creation of those maps in the code below.
 
         Args:
-            nodes (Iterable[Any]): The nodes to be included in the subgraph
+            nodes (Iterable[Hashable]): Nodes to include in the subgraph.
 
         Returns:
-            "Graph": A subgraph containing the given nodes.
+            'Graph': A subgraph containing the given nodes.
         """
 
         """
@@ -1490,18 +1535,16 @@ class Graph:
         helps to educate future readers of the code that subgraphs are "interesting"...
         """
 
+        nodes = list(nodes)
         new_subgraph = None
 
-        if self.is_nx_graph():
+        if self._nx_graph is not None:
             nx_subgraph = self._nx_graph.subgraph(nodes)
             new_subgraph = self.from_networkx(nx_subgraph)
             # for NX, the node_ids in subgraph are the same as in the parent graph
             _node_id_to_parent_node_id_map = {node: node for node in nodes}
             _node_id_to_original_nx_node_id_map = {node: node for node in nodes}
-        elif self.is_rx_graph():
-            if isinstance(nodes, frozenset) or isinstance(nodes, set):
-                nodes = list(nodes)
-
+        elif self._rx_graph is not None:
             # For RX, the node_ids in the subgraph change, so we need a way to map subgraph node_ids
             # into parent graph node_ids.  To do so, we add the parent node_id into the node data
             # so that in the subgraph we can find it and then create the map.
@@ -1528,7 +1571,7 @@ class Graph:
                 if "__networkx_node__" not in self.node_data(node_id):
                     raise Exception("subgraph: internal error: original_nx_node_id not set")
 
-            rx_subgraph = self._rx_graph.subgraph(nodes)
+            rx_subgraph = self._rx_graph.subgraph(cast(list[int], nodes))
             new_subgraph = self.from_rustworkx(rx_subgraph)
 
             # frm: Create the map from subgraph node_id to parent graph node_id
@@ -1558,7 +1601,9 @@ class Graph:
 
         return new_subgraph
 
-    def translate_subgraph_node_ids_for_flips(self, flips: dict[Any, int]) -> dict[Any, int]:
+    def translate_subgraph_node_ids_for_flips(
+        self, flips: dict[Hashable, Hashable]
+    ) -> dict[Hashable, Hashable]:
         """Translate the given flips so that the subgraph node_ids in the flips correspond
         to the appropriate node_ids in the parent graph.
 
@@ -1571,11 +1616,11 @@ class Graph:
         For more details, refer to the larger comment on subgraphs...
 
         Args:
-            flips (dict[Any, int]): A dict containing "flips" which associate a node with a new
+            flips (dict[Hashable, Hashable]): A dictionary associating nodes with new
                 part in a partition (a "part" is the same as a district in common parlance).
 
         Returns:
-            dict[Any, int]: A dict containing "flips" that have been translated to have node_ids
+            dict[Hashable, Hashable]: Flips translated to use node IDs
                 appropriate for the parent graph
         """
 
@@ -1586,7 +1631,9 @@ class Graph:
 
         return translated_flips
 
-    def translate_subgraph_node_ids_for_set_of_nodes(self, set_of_nodes: set[Any]) -> set[Any]:
+    def translate_subgraph_node_ids_for_set_of_nodes(
+        self, set_of_nodes: AbstractSet[Hashable]
+    ) -> set[Hashable]:
         """Translate the given set_of_nodes to have the appropriate node_ids for the parent graph.
 
         This routine is used when a computation that creates a set of nodes is made on a subgraph,
@@ -1596,10 +1643,10 @@ class Graph:
         For more details, refer to the larger comment on subgraphs...
 
         Args:
-            set_of_nodes (set[Any]): A set of node_ids in a subgraph
+            set_of_nodes (AbstractSet[Hashable]): Node IDs in a subgraph.
 
         Returns:
-            set[Any]: A set of node_ids that have been translated to have the node_ids appropriate
+            set[Hashable]: Node IDs translated to have the IDs appropriate
                 for the parent graph
         """
         # This routine replaces the node_ids of the subgraph with the node_ids
@@ -1611,15 +1658,17 @@ class Graph:
             translated_set_of_nodes.add(self._node_id_to_parent_node_id_map[node_id])
         return translated_set_of_nodes
 
-    def _generic_bfs_edges(self, source: Any) -> Generator[tuple[Any, Any], None, None]:
+    def _generic_bfs_edges(
+        self, source: Hashable
+    ) -> Generator[tuple[Hashable, Hashable], None, None]:
         """Yield parent/child pairs in a breadth first traversal of the graph starting at "source".
 
         Args:
-            source (Any): The node_id of the first "parent" node - the starting node for the
+            source (Hashable): The first parent node ID, which starts the
                 breadth first search
 
         Returns:
-            Generator[tuple[Any, Any], None, None]: The next parent/child pair in a depth first
+            Generator[tuple[Hashable, Hashable], None, None]: Parent-child pairs in a breadth-first
                 traversal of the given graph, starting at the "source" node
         """
 
@@ -1715,8 +1764,8 @@ class Graph:
             depth += 1
 
     def generic_bfs_successors_generator(
-        self, root_node_id: Any
-    ) -> Generator[tuple[Any, list[Any]], None, None]:
+        self, root_node_id: Hashable
+    ) -> Generator[tuple[Hashable, list[Hashable]], None, None]:
         """Yield BFS ``(parent, children)`` pairs starting from ``root_node_id``.
 
         Each yielded tuple contains a parent node and its children in breadth-first traversal order.
@@ -1726,10 +1775,10 @@ class Graph:
         traversed along with the children of that node.
 
         Args:
-            root_node_id (Any): The node_id for the node to use to start the BFS traversal
+            root_node_id (Hashable): Node ID at which to start the BFS traversal.
 
         Returns:
-            Generator[tuple[Any, list[Any]], None, None]:: Yields tuple (parent, children) of graph
+            Generator[tuple[Hashable, list[Hashable]], None, None]: Parent and children pairs
                 in breadth-first order, with the first parent specified by the "root_node_id"
         """
         # frm: Generate in sequence a tuple for the parent (node_id) and
@@ -1751,7 +1800,7 @@ class Graph:
             parent = p
         yield (parent, children)
 
-    def generic_bfs_successors(self, root_node_id: Any) -> dict[Any : list[Any]]:
+    def generic_bfs_successors(self, root_node_id: Hashable) -> dict[Hashable, list[Hashable]]:
         """Return the BFS successors mapping for ``root_node_id``.
 
         The returned dictionary maps each parent node_id to a list of child node_ids.
@@ -1761,15 +1810,15 @@ class Graph:
         that node's children.
 
         Args:
-            root_node_id (Any): The node_id for the node to use to start the BFS traversal
+            root_node_id (Hashable): Node ID at which to start the BFS traversal.
 
         Returns:
-            dict[Any: list[Any]]: A dict mapping parent node_ids to a list of the node_ids for that
+            dict[Hashable, list[Hashable]]: Parent node IDs mapped to their
                 node's children.
         """
         return dict(self.generic_bfs_successors_generator(root_node_id))
 
-    def generic_bfs_predecessors(self, root_node_id: Any) -> dict[Any, Any]:
+    def generic_bfs_predecessors(self, root_node_id: Hashable) -> dict[Hashable, Hashable]:
         """Return A dict mapping each node_id to the node_id of its parent node.
 
         Returns a dict mapping each node_id in the graph to its predecessor node_id where the
@@ -1779,10 +1828,10 @@ class Graph:
         Note that this works for both NX and RX based Graph objects.
 
         Args:
-            root_node_id (Any): The node at the "root" of the breadth-first travesal
+            root_node_id (Hashable): Root node of the breadth-first traversal.
 
         Returns:
-            dict[Any, Any]: A dict mapping each node_id to the node_id of its parent node.
+            dict[Hashable, Hashable]: Node IDs mapped to their parent node IDs.
         """
         # frm Note:  We had do implement our own, because the built-in RX version only worked
         #               for directed graphs.
@@ -1791,7 +1840,7 @@ class Graph:
             predecessors.append((t, s))
         return dict(predecessors)
 
-    def predecessors(self, root_node_id: Any) -> dict[Any:Any]:
+    def predecessors(self, root_node_id: Hashable) -> dict[Hashable, Hashable]:
         """Return A dict mapping each node_id to the node_id of its parent node.
 
         Returns a dict mapping each node_id in the graph to its predecessor node_id where the
@@ -1808,10 +1857,10 @@ class Graph:
         In the case of an RX-based graph, this code delegates to generic_bfs_predecessors().
 
         Args:
-            root_node_id (Any): The node at the "root" of the breadth-first travesal
+            root_node_id (Hashable): Root node of the breadth-first traversal.
 
         Returns:
-            dict[Any, Any]: A dict mapping each node_id to the node_id of its parent node.
+            dict[Hashable, Hashable]: Node IDs mapped to their parent node IDs.
         """
 
         """
@@ -1859,9 +1908,9 @@ class Graph:
               version is significantly better than the generic one.
         """
 
-        if self.is_rx_graph():
+        if self._rx_graph is not None:
             return self.generic_bfs_predecessors(root_node_id)
-        elif self.is_nx_graph():
+        elif self._nx_graph is not None:
             return {a: b for a, b in networkx.bfs_predecessors(self._nx_graph, root_node_id)}
         else:
             raise TypeError(
@@ -1869,8 +1918,8 @@ class Graph:
                 "a networkx-based graph nor a rustworkx-based graph"
             )
 
-    def successors(self, root_node_id: Any) -> dict[Any : list[Any]]:
-        """Return list[Any]]: Returns a dict mapping each node to a list of its children.
+    def successors(self, root_node_id: Hashable) -> dict[Hashable, list[Hashable]]:
+        """Return a dictionary mapping each node to a list of its children.
 
         Does a breadth-first traversal of the given graph, starting at the node specified by
         "root_node_id", and returns a dict mapping parent node_ids to a list of the node_ids for
@@ -1884,15 +1933,15 @@ class Graph:
         faster - which may or may not actually be the case.
 
         Args:
-            root_node_id (Any): The node_id for the node at which to start the breadth-first
+            root_node_id (Hashable): Node ID at which to start the breadth-first
                 traversal of the graph.
 
         Returns:
-            dict[Any: list[Any]]: Returns a dict mapping each node to a list of its children
+            dict[Hashable, list[Hashable]]: Nodes mapped to their children.
         """
-        if self.is_rx_graph():
+        if self._rx_graph is not None:
             return self.generic_bfs_successors(root_node_id)
-        elif self.is_nx_graph():
+        elif self._nx_graph is not None:
             return {a: b for a, b in networkx.bfs_successors(self._nx_graph, root_node_id)}
         else:
             raise TypeError(
@@ -1907,7 +1956,7 @@ class Graph:
         returns a Graph object containing the miniumum spanning tree given the edge weights.
 
         Args:
-            edge_weight_attribute_nanme (str): The name of the edge attribute containing the weight
+            edge_weight_attribute_name (str): The name of the edge attribute containing the weight
                 of the edge
 
         Returns:
@@ -1916,16 +1965,16 @@ class Graph:
 
         # Note that the RX version of this function is MUCH faster than the NX version.
 
-        if self.is_nx_graph():
+        if self._nx_graph is not None:
             nx_graph = self.get_nx_graph()
             spanning_tree = networkx.algorithms.tree.minimum_spanning_tree(
                 nx_graph, algorithm="kruskal", weight=edge_weight_attribute_name
             )
             spanning_graph = Graph.from_networkx(spanning_tree)
-        elif self.is_rx_graph():
+        elif self._rx_graph is not None:
             rx_graph = self.get_rx_graph()
 
-            def get_weight(edge_data: dict[str, float]) -> float:
+            def get_weight(edge_data: _AttributeDict) -> float:
                 # function to get the weight of an edge from its data
                 # This function is passed a dict with the data for the edge.
                 return edge_data[edge_weight_attribute_name]
@@ -1938,7 +1987,7 @@ class Graph:
 
         return spanning_graph
 
-    def neighbors(self, node_id: Any) -> Sequence[Any]:
+    def neighbors(self, node_id: Hashable) -> Sequence[Hashable]:
         """Return a sequence of neighbor node_ids.
 
         Return a sequence of the node_ids of the nodes that are neighbors of the given node - that
@@ -1950,13 +1999,13 @@ class Graph:
         list on every call. Callers that need list methods should wrap it in ``list()``.
 
         Args:
-            node_id (Any): The ID of a node
+            node_id (Hashable): A node ID.
 
         Returns:
-            Sequence[Any]: A sequence of neighbor node_ids
+            Sequence[Hashable]: The neighboring node IDs.
         """
         if self._rx_graph is not None:
-            return self._rx_graph.neighbors(node_id)
+            return self._rx_graph.neighbors(cast(int, node_id))
         elif self._nx_graph is not None:
             # NX returns a single-pass iterator, so it must be materialized here;
             # callers (and the FrozenGraph.neighbors lru_cache) expect a re-iterable result.
@@ -1967,20 +2016,20 @@ class Graph:
                 "a networkx-based graph nor a rustworkx-based graph"
             )
 
-    def degree(self, node_id: Any) -> int:
+    def degree(self, node_id: Hashable) -> int:
         """Return the degree of the given node, that is, the number of other nodes directly.
 
         This method returns the degree of the given node, that is, the number of other nodes
         directly. It returns number of nodes directly connected to the given node.
 
         Args:
-            node_id (Any): The ID of a node
+            node_id (Hashable): A node ID.
 
         Returns:
             int: Number of nodes directly connected to the given node
         """
         if self._rx_graph is not None:
-            return self._rx_graph.degree(node_id)
+            return self._rx_graph.degree(cast(int, node_id))
         elif self._nx_graph is not None:
             return self._nx_graph.degree(node_id)
         else:
@@ -1989,7 +2038,7 @@ class Graph:
                 "a networkx-based graph nor a rustworkx-based graph"
             )
 
-    def node_data(self, node_id: Any) -> dict[Any, Any]:
+    def node_data(self, node_id: Hashable) -> _AttributeDict:
         """Return the data dictionary that contains the given node's data.
 
         As docmented elsewhere, in GerryChain code before the conversion to RustworkX, users could
@@ -2007,14 +2056,14 @@ class Graph:
         graph.node_data(node_id)[attribute_name]
 
         Args:
-            node_id (Any): The ID of a node
+            node_id (Hashable): A node ID.
 
         Returns:
-            dict[Any, Any]: Data dictionary containing the given node's data.
+            dict[str, Any]: The node's data.
         """
 
         if self._rx_graph is not None:
-            return self._rx_graph[node_id]
+            return self._rx_graph[cast(int, node_id)]
         elif self._nx_graph is not None:
             return self._nx_graph.nodes[node_id]
         else:
@@ -2023,24 +2072,23 @@ class Graph:
                 "a networkx-based graph nor a rustworkx-based graph"
             )
 
-    def edge_data(self, edge_id: Any) -> dict[Any, Any]:
+    def edge_data(self, edge_id: Hashable) -> _AttributeDict:
         """Return the data dictionary that contains the data for the given edge.
 
         Note that in NetworkX an edge_id can be almost anything, for instance, a string or even a
-        tuple. However, in RustworkX, an edge_id is an integer. This code handles both kinds of
-        edge_ids - hence the type, Any.
+        tuple. However, in RustworkX, an edge_id is an integer. This method handles both kinds.
 
         Args:
-            edge_id (Any): The ID of the edge
+            edge_id (Hashable): An edge ID.
 
         Returns:
-            dict[Any, Any]: The data dictionary for the given edge's data
+            dict[str, Any]: The edge's data.
         """
 
         if self._rx_graph is not None:
-            return self._rx_graph.get_edge_data_by_index(edge_id)
+            return self._rx_graph.get_edge_data_by_index(cast(int, edge_id))
         elif self._nx_graph is not None:
-            return self._nx_graph.edges[edge_id]
+            return self._nx_graph.edges[cast(tuple[Hashable, Hashable], edge_id)]
         else:
             raise TypeError(
                 "Graph passed to 'edge_data()' is neither "
@@ -2072,7 +2120,7 @@ class Graph:
         """
         # A local "gc" (as in GerryChain) version of the laplacian matrix
 
-        if self.is_rx_graph():
+        if self._rx_graph is not None:
             rx_graph = self._rx_graph
             # 1. Get the adjacency matrix
             adj_matrix = rustworkx.adjacency_matrix(rx_graph)
@@ -2082,7 +2130,7 @@ class Graph:
             np_laplacian_matrix = degree_matrix - adj_matrix
             # 4.  Convert the NumPy array to a scipy.sparse array
             laplacian_matrix = scipy.sparse.csr_array(np_laplacian_matrix)
-        elif self.is_nx_graph():
+        elif self._nx_graph is not None:
             nx_graph = self._nx_graph
             laplacian_matrix = networkx.laplacian_matrix(nx_graph)
         else:
@@ -2093,7 +2141,7 @@ class Graph:
 
         return laplacian_matrix
 
-    def normalized_laplacian_matrix(self) -> scipy.sparse.dia_array:
+    def normalized_laplacian_matrix(self) -> scipy.sparse.csr_array:
         """Return a SciPy sparse array containing the normalized Laplacian matrix for the given.
 
         graph. For more details on the normalized Graph Laplacian matrix, please refer to -
@@ -2101,11 +2149,11 @@ class Graph:
         https://en.wikipedia.org/wiki/Laplacian_matrix#Laplacian_matrix_normalization_2
 
         Returns:
-            scipy.sparse.dia_array: A SciPy sparse diagonal array containing the Laplacian matrix
+            scipy.sparse.csr_array: A SciPy sparse array containing the normalized Laplacian matrix
         """
 
         def create_scipy_sparse_array_from_rx_graph(
-            rx_graph: rustworkx.PyGraph,
+            rx_graph: rustworkx.PyGraph[_AttributeDict, _AttributeDict],
         ) -> scipy.sparse.coo_matrix:
             """Create a scippy.sparce.coo_matrix from the given RX graph.
 
@@ -2143,7 +2191,7 @@ class Graph:
 
             return sparse_array
 
-        if self.is_rx_graph():
+        if self._rx_graph is not None:
             rx_graph = self._rx_graph
             """
             The following is code copied from the networkx linalg file, laplacianmatrix.py
@@ -2185,7 +2233,7 @@ class Graph:
             normalized_laplacian = DH @ (L @ DH)
             return normalized_laplacian
 
-        elif self.is_nx_graph():
+        elif self._nx_graph is not None:
             nx_graph = self._nx_graph
             laplacian_matrix = networkx.normalized_laplacian_matrix(nx_graph)
         else:
@@ -2196,7 +2244,7 @@ class Graph:
 
         return laplacian_matrix
 
-    def is_connected(self):
+    def is_connected(self) -> bool:
         """Return whether the (undirected) graph is connected.
 
         Delegates to the backend's native connectivity routine - ``rustworkx.is_connected`` for an
@@ -2224,7 +2272,7 @@ class Graph:
                 "rustworkx-based graph."
             )
 
-    def is_node_set_connected(self, nodes: Iterable[Any]) -> bool:
+    def is_node_set_connected(self, nodes: Iterable[Hashable]) -> bool:
         """Return whether the given set of nodes induces a connected subgraph of this graph.
 
         This is a fast path for connectivity checks. It hands the node set straight to the
@@ -2235,7 +2283,7 @@ class Graph:
         A set of 0 or 1 nodes is treated as trivially connected, mirroring ``is_connected()``.
 
         Args:
-            nodes (Iterable[Any]): The node_ids of the nodes to check.
+            nodes (Iterable[Hashable]): Node IDs to check.
 
         Returns:
             bool: True if the nodes induce a connected subgraph (or there are at most one
@@ -2247,7 +2295,7 @@ class Graph:
             return True
 
         if self._rx_graph is not None:
-            return rustworkx.is_connected(self._rx_graph.subgraph(nodes))
+            return rustworkx.is_connected(self._rx_graph.subgraph(cast(list[int], nodes)))
         elif self._nx_graph is not None:
             return networkx.is_connected(self._nx_graph.subgraph(nodes))
         else:
@@ -2267,14 +2315,14 @@ class Graph:
         includes it as a subset.
 
         Returns:
-            list["Graph"]: A list of "maximal" subgraphs each of which contains nodes that are
+            list['Graph']: A list of "maximal" subgraphs each of which contains nodes that are
                 connected.
         """
 
-        if self.is_rx_graph():
+        if self._rx_graph is not None:
             rx_graph = self.get_rx_graph()
             subgraphs = [self.subgraph(nodes) for nodes in rustworkx.connected_components(rx_graph)]
-        elif self.is_nx_graph():
+        elif self._nx_graph is not None:
             nx_graph = self.get_nx_graph()
             subgraphs = [self.subgraph(nodes) for nodes in networkx.connected_components(nx_graph)]
         else:
@@ -2308,10 +2356,10 @@ class Graph:
         # So - should be a simple issue of trying it and running tests, but
         # I will do that another day...
 
-        if self.is_rx_graph():
+        if self._rx_graph is not None:
             rx_graph = self.get_rx_graph()
             connected_components = rustworkx.connected_components(rx_graph)
-        elif self.is_nx_graph():
+        elif self._nx_graph is not None:
             nx_graph = self.get_nx_graph()
             connected_components = list(networkx.connected_components(nx_graph))
         else:
@@ -2337,7 +2385,7 @@ class Graph:
         #
         # However, it does no harm, and it might be useful, perhaps...
 
-        if self.is_rx_graph():
+        if self._rx_graph is not None:
             rx_graph = self.get_rx_graph()
             num_nodes = rx_graph.num_nodes()
             num_edges = rx_graph.num_edges()
@@ -2356,7 +2404,7 @@ class Graph:
                 return False
 
             return True
-        elif self.is_nx_graph():
+        elif self._nx_graph is not None:
             nx_graph = self.get_nx_graph()
             return networkx.is_tree(nx_graph)
         else:
@@ -2366,7 +2414,10 @@ class Graph:
             )
 
 
-def _add_boundary_perimeters_to_nx_graph(nx_graph: networkx.Graph, geometries: pd.Series) -> None:
+def _add_boundary_perimeters_to_nx_graph(
+    nx_graph: networkx.Graph[Hashable, _AttributeDict, _AttributeDict],
+    geometries: gp.GeoSeries,
+) -> None:
     """Computes the "boundary perimeter" which is a measure of how much of the node's perimeter is.
 
     Computes the "boundary perimeter" which is a measure of how much of the node's perimeter is on
@@ -2388,8 +2439,8 @@ def _add_boundary_perimeters_to_nx_graph(nx_graph: networkx.Graph, geometries: p
     get_nx_graph().
 
     Args:
-        graph (Graph): NetworkX graph
-        geometries (Series): GeoSeries containing geometry
+        nx_graph (networkx.Graph): NetworkX graph
+        geometries (gp.GeoSeries): GeoSeries containing geometry
             information.
 
     """
@@ -2401,12 +2452,15 @@ def _add_boundary_perimeters_to_nx_graph(nx_graph: networkx.Graph, geometries: p
 
     prepared_boundary = prep(unary_union(geometries).boundary)
 
-    boundary_nodes = geometries.boundary.apply(prepared_boundary.intersects)
+    boundaries = cast(gp.GeoSeries, geometries.boundary)
+    boundary_nodes = boundaries.apply(prepared_boundary.intersects)
 
     for node in nx_graph:
-        nx_graph.nodes[node]["boundary_node"] = bool(boundary_nodes[node])
-        if boundary_nodes[node]:
-            total_perimeter = geometries[node].boundary.length
+        is_boundary = bool(boundary_nodes.loc[node])
+        nx_graph.nodes[node]["boundary_node"] = is_boundary
+        if is_boundary:
+            geometry = cast(BaseGeometry, geometries.loc[node])
+            total_perimeter = geometry.boundary.length
             shared_perimeter = sum(
                 neighbor_data["shared_perim"] for neighbor_data in nx_graph[node].values()
             )
@@ -2427,14 +2481,14 @@ def check_dataframe(df: pd.DataFrame) -> None:
             warnings.warn(f"NA values found in column {column}!")
 
 
-def remove_geometries(data: networkx.Graph) -> None:
+def remove_geometries(data: _AdjacencyData) -> None:
     """Remove geometry attributes from NetworkX adjacency data because they are not serializable.
 
     Note:
         Mutates the ``data`` object. Does nothing if no geometry attributes are found.
 
     Args:
-        data (networkx.Graph): an adjacency data object (returned by
+        data (_AdjacencyData): an adjacency data object (returned by
             `networkx.readwrite.json_graph.adjacency_data`)
 
     """
@@ -2449,14 +2503,14 @@ def remove_geometries(data: networkx.Graph) -> None:
             del node[key]
 
 
-def convert_geometries_to_geojson(data: networkx.Graph) -> None:
+def convert_geometries_to_geojson(data: _AdjacencyData) -> None:
     """Convert geometry attributes in a NetworkX adjacency data to GeoJSON for serialization.
 
     Note:
         Mutates the ``data`` object and does nothing if no geometry attributes are found.
 
     Args:
-        data (networkx.Graph): an adjacency data object (returned by
+        data (_AdjacencyData): an adjacency data object (returned by
             `networkx.readwrite.json_graph.adjacency_data`)
 
     """
@@ -2468,7 +2522,7 @@ def convert_geometries_to_geojson(data: networkx.Graph) -> None:
                 # The ``__geo_interface__`` property is essentially GeoJSON.
                 # This is what `geopandas.GeoSeries.to_json` uses under
                 # the hood.
-                node[key] = node[key].__geo_interface__
+                node[key] = cast(_GeoInterface, node[key]).__geo_interface__
 
 
 class FrozenGraph:
@@ -2512,8 +2566,8 @@ class FrozenGraph:
         """
 
         self.graph = graph
-        self._node_indices = None
-        self._edge_indices = None
+        self._node_indices: frozenset[Hashable] | None = None
+        self._edge_indices: frozenset[Hashable] | None = None
 
         all_node_ids = self.graph.node_indices
         self.size = len(all_node_ids)
@@ -2552,18 +2606,18 @@ class FrozenGraph:
             raise AttributeError(__name)
         return getattr(object.__getattribute__(self, "graph"), __name)
 
-    def __getitem__(self, __name: str) -> Any:
-        return self.graph[__name]
+    def __getitem__(self, node_id: Hashable) -> Mapping[Hashable, _AttributeDict]:
+        return self.graph[node_id]
 
-    def __iter__(self) -> Iterable[Any]:
+    def __iter__(self) -> Iterator[Hashable]:
         yield from self.node_indices
 
     @functools.lru_cache(16384)
-    def neighbors(self, n: Any) -> Sequence[Any]:
+    def neighbors(self, n: Hashable) -> Sequence[Hashable]:
         return self.graph.neighbors(n)
 
     @property
-    def node_indices(self) -> frozenset[Any]:
+    def node_indices(self) -> frozenset[Hashable]:
         # Cached into a slot (see __slots__ note) since the graph is immutable. Store a
         # frozenset so a caller can't mutate the shared cached object in place (e.g. via `-=`).
         if self._node_indices is None:
@@ -2571,14 +2625,14 @@ class FrozenGraph:
         return self._node_indices
 
     @property
-    def edge_indices(self) -> frozenset[Any]:
+    def edge_indices(self) -> frozenset[Hashable]:
         if self._edge_indices is None:
             self._edge_indices = frozenset(self.graph.edge_indices)
         return self._edge_indices
 
     @functools.lru_cache(16384)
-    def degree(self, n: Any) -> int:
+    def degree(self, n: Hashable) -> int:
         return self.graph.degree(n)
 
-    def subgraph(self, nodes: Iterable[Any]) -> FrozenGraph:
+    def subgraph(self, nodes: Iterable[Hashable]) -> FrozenGraph:
         return FrozenGraph(self.graph.subgraph(nodes))

--- a/gerrychain/grid.py
+++ b/gerrychain/grid.py
@@ -12,11 +12,14 @@ Dependencies:
 - typing: Used for type hints.
 """
 
+from __future__ import annotations
+
 import math
-from collections.abc import Callable
-from typing import Optional
+from collections.abc import Callable, Hashable
+from typing import Any, cast
 
 import networkx
+from networkx.generators.lattice import grid_2d_graph
 
 from gerrychain.graph import Graph
 from gerrychain.metrics import polsby_popper
@@ -89,22 +92,22 @@ class Grid(Partition):
         self,
         dimensions: tuple[int, int] | None = None,
         with_diagonals: bool = False,
-        assignment: dict | None = None,
-        updaters: dict[str, Callable] | None = None,
-        parent: Optional["Grid"] = None,
+        assignment: dict[tuple[int, int], int] | None = None,
+        updaters: dict[str, Callable[[Partition], object]] | None = None,
+        parent: Grid | None = None,
         flips: dict[tuple[int, int], int] | None = None,
     ) -> None:
         """Initialize a Grid instance.
 
         Args:
-            dimensions (Tuple[int, int], optional): The grid dimensions (rows, columns), defaults
+            dimensions (tuple[int, int], optional): The grid dimensions (rows, columns), defaults
                 to None.
             with_diagonals (bool, optional): If True, includes diagonal connections, defaults to
                 False.
-            assignment (Dict, optional): Node-to-district assignments, defaults to None.
-            updaters (Dict[str, Callable], optional): Custom updater functions, defaults to None.
+            assignment (dict, optional): Node-to-district assignments, defaults to None.
+            updaters (dict[str, Callable], optional): Custom updater functions, defaults to None.
             parent (Grid, optional): Parent Grid object for inheritance, defaults to None.
-            flips (Dict[Tuple[int, int], int], optional): Node flips for partition changes,
+            flips (dict[tuple[int, int], int], optional): Node flips for partition changes,
                 defaults to None. Note that flips are a dict of the form: {node_id: part}. In the
                 case of a Grid, a node_id is a tuple indicating its position in the grid, so for a
                 Grid the flips look like: {(row_node_id, col_node_id): part}
@@ -120,9 +123,14 @@ class Grid(Partition):
             graph = _create_grid_nx_graph(dimensions, with_diagonals)
 
             if not assignment:
-                thresholds = tuple(math.floor(n / 2) for n in self.dimensions)
+                thresholds = (
+                    math.floor(self.dimensions[0] / 2),
+                    math.floor(self.dimensions[1] / 2),
+                )
                 assignment = {
-                    node_id: _color_quadrants(node_id, thresholds)  # type: ignore
+                    cast(tuple[int, int], node_id): _color_quadrants(
+                        cast(tuple[int, int], node_id), thresholds
+                    )
                     for node_id in graph.node_indices
                 }
 
@@ -154,10 +162,10 @@ class Grid(Partition):
         assigned district of the node in position (i,j) on the grid.
 
         Returns:
-            List[List[int]]: List of lists representing the grid.
+            list[list[int]]: List of lists representing the grid.
         """
         m, n = self.dimensions
-        return [[self.assignment.mapping[(i, j)] for i in range(m)] for j in range(n)]
+        return [[cast(int, self.assignment.mapping[(i, j)]) for i in range(m)] for j in range(n)]
 
 
 def _create_grid_nx_graph(dimensions: tuple[int, ...], with_diagonals: bool) -> Graph:
@@ -175,7 +183,7 @@ def _create_grid_nx_graph(dimensions: tuple[int, ...], with_diagonals: bool) -> 
         * "shared_perim" set to 1 except for diagonal edges (if any)
 
     Args:
-        dimensions (Tuple[int, int]): The grid dimensions (rows, columns).
+        dimensions (tuple[int, int]): The grid dimensions (rows, columns).
         with_diagonals (bool): If True, includes diagonal connections.
 
     Returns:
@@ -187,10 +195,11 @@ def _create_grid_nx_graph(dimensions: tuple[int, ...], with_diagonals: bool) -> 
     if len(dimensions) != 2:
         raise ValueError("Expected two dimensions.")
     m, n = dimensions
-    nx_graph = networkx.generators.lattice.grid_2d_graph(m, n)
+    nx_graph = cast("networkx.Graph[Hashable, dict[str, Any], dict[str, Any]]", grid_2d_graph(m, n))
 
     # In a grid graph the shared perimeter with every other node is 1
-    networkx.set_edge_attributes(nx_graph, 1, "shared_perim")
+    for edge in nx_graph.edges:
+        nx_graph.edges[edge]["shared_perim"] = 1
 
     # if "with_diagonals" then create edges between nodes on diagonals
     if with_diagonals:
@@ -202,23 +211,27 @@ def _create_grid_nx_graph(dimensions: tuple[int, ...], with_diagonals: bool) -> 
             # diagonals meet at a point, hence shared perimeter is zero
             nx_graph.edges[edge]["shared_perim"] = 0
 
-    networkx.set_node_attributes(nx_graph, 1, "population")
-    networkx.set_node_attributes(nx_graph, 1, "area")
+    for node in nx_graph.nodes:
+        nx_graph.nodes[node]["population"] = 1
+        nx_graph.nodes[node]["area"] = 1
 
     _tag_boundary_nodes(nx_graph, dimensions)
 
     return Graph.from_networkx(nx_graph)
 
 
-def _tag_boundary_nodes(nx_graph: networkx.Graph, dimensions: tuple[int, int]) -> None:
+def _tag_boundary_nodes(
+    nx_graph: networkx.Graph[Hashable, dict[str, Any], dict[str, Any]],
+    dimensions: tuple[int, int],
+) -> None:
     """Adds the boolean attribute ``boundary_node`` to each node in the graph.
 
     If the node is on the boundary of the grid, that node also gets the attribute
     ``boundary_perim`` which is determined by the function `_get_boundary_perim`.
 
     Args:
-        graph (Graph): The graph to modify.
-        dimensions (Tuple[int, int]): The dimensions of the grid.
+        nx_graph (networkx.Graph): The graph to modify.
+        dimensions (tuple[int, int]): The dimensions of the grid.
 
     """
 
@@ -230,9 +243,10 @@ def _tag_boundary_nodes(nx_graph: networkx.Graph, dimensions: tuple[int, int]) -
 
     m, n = dimensions
     for node_id in nx_graph.nodes:
-        if node_id[0] in [0, m - 1] or node_id[1] in [0, n - 1]:
+        grid_node = cast(tuple[int, int], node_id)
+        if grid_node[0] in [0, m - 1] or grid_node[1] in [0, n - 1]:
             nx_graph.nodes[node_id]["boundary_node"] = True
-            nx_graph.nodes[node_id]["boundary_perim"] = _get_boundary_perim(node_id, dimensions)
+            nx_graph.nodes[node_id]["boundary_perim"] = _get_boundary_perim(grid_node, dimensions)
         else:
             nx_graph.nodes[node_id]["boundary_node"] = False
 
@@ -241,10 +255,10 @@ def _get_boundary_perim(node_id: tuple[int, int], dimensions: tuple[int, int]) -
     """Determines the boundary perimeter of a node on the grid.
 
     Args:
-        node_id (Tuple[int, int]): The ID of the node to check. Note that the node_id is a tuple of
+        node_id (tuple[int, int]): The ID of the node to check. Note that the node_id is a tuple of
             the form (row, col) so that node_id[0] denotes the row a node is in and node_id[1]
             denotes its column.
-        dimensions (Tuple[int, int]): The dimensions of the grid.
+        dimensions (tuple[int, int]): The dimensions of the grid.
 
     Returns:
         int: The boundary perimeter of the node.
@@ -266,7 +280,7 @@ def color_half(node: tuple[int, int], threshold: int) -> int:
     an x-coordinate greater than the threshold are assigned another.
 
     Args:
-        node (Tuple[int, int]): The node to color, represented as a tuple of coordinates (x, y).
+        node (tuple[int, int]): The node to color, represented as a tuple of coordinates (x, y).
         threshold (int): The x-coordinate value that determines the color assignment.
 
     Returns:
@@ -288,8 +302,8 @@ def _color_quadrants(node: tuple[int, int], thresholds: tuple[int, int]) -> int:
     color.
 
     Args:
-        node (Tuple[int, int]): The node to color, represented as a tuple of coordinates (x, y).
-        thresholds (Tuple[int, int]): A tuple of two integers representing the threshold
+        node (tuple[int, int]): The node to color, represented as a tuple of coordinates (x, y).
+        thresholds (tuple[int, int]): A tuple of two integers representing the threshold
             coordinates (x_threshold, y_threshold).
 
     Returns:

--- a/gerrychain/meta/diversity.py
+++ b/gerrychain/meta/diversity.py
@@ -2,8 +2,8 @@
 Simple tooling to collect diversity stats on chain runs
 """
 
+from collections.abc import Hashable, Iterable, Iterator
 from dataclasses import dataclass
-from typing import Iterable, Tuple
 
 from gerrychain.partition import Partition
 
@@ -29,7 +29,7 @@ class DiversityStats:
 
 def collect_diversity_stats(
     chain: Iterable[Partition],
-) -> Iterable[Tuple[Partition, DiversityStats]]:
+) -> Iterator[tuple[Partition, DiversityStats]]:
     """Report the diversity of the chain being run, live, as a drop-in wrapper.
 
     Requires the cut_edges updater on each `Partition` object. Plans/districts are considered
@@ -44,10 +44,10 @@ def collect_diversity_stats(
         chain (Iterable[Partition]): A chain object to collect stats on.
 
     Returns:
-        Iterable[Tuple[Partition, DiversityStats]]: An iterable of `(partition, DiversityStat)`.
+        Iterator[tuple[Partition, DiversityStats]]: Pairs of partitions and cumulative statistics.
     """
-    seen_plans = {}
-    seen_districts = {}
+    seen_plans: set[frozenset[frozenset[Hashable]]] = set()
+    seen_districts: set[frozenset[Hashable]] = set()
 
     unique_plans = 0
     unique_districts = 0
@@ -57,16 +57,16 @@ def collect_diversity_stats(
         steps_taken += 1
 
         for _, nodes in partition.assignment.parts.items():
-            hashable_nodes = tuple(sorted(list(nodes)))
+            hashable_nodes = frozenset(nodes)
             if hashable_nodes not in seen_districts:
                 unique_districts += 1
-                seen_districts[hashable_nodes] = 1
+                seen_districts.add(hashable_nodes)
 
         cut_edges = partition["cut_edges"]
-        hashable_cut_edges = tuple(sorted(list(cut_edges)))
+        hashable_cut_edges = frozenset(frozenset(edge) for edge in cut_edges)
         if hashable_cut_edges not in seen_plans:
             unique_plans += 1
-            seen_plans[hashable_cut_edges] = 1
+            seen_plans.add(hashable_cut_edges)
 
         stats = DiversityStats(
             unique_plans=unique_plans,

--- a/gerrychain/metagraph.py
+++ b/gerrychain/metagraph.py
@@ -12,14 +12,18 @@ Last Updated: 11 Jan 2024
 """
 
 from itertools import product
-from typing import Callable, Dict, Iterable, Iterator, Union
+from collections.abc import Callable, Hashable, Iterable, Iterator
+from typing import cast
 
 from gerrychain.partition import Partition
 
 from .constraints import Validator
 
 
-def all_cut_edge_flips(partition: Partition) -> Iterator[Dict]:
+Constraint = Callable[[Partition], bool]
+
+
+def all_cut_edge_flips(partition: Partition) -> Iterator[dict[Hashable, Hashable]]:
     """Generate all possible flips of cut edges in a partition without any constraints.
 
     This routine finds all edges on the boundary of districts - those that are "cut edges" where
@@ -30,7 +34,8 @@ def all_cut_edge_flips(partition: Partition) -> Iterator[Dict]:
         partition (Partition): The partition object.
 
     Returns:
-        Iterator[Dict]: An iterator that yields dictionaries representing the flipped edges.
+        Iterator[dict[Hashable, Hashable]]: An iterator that yields dictionaries representing
+            the flipped edges.
     """
 
     for edge, index in product(partition["cut_edges"], (0, 1)):
@@ -38,7 +43,7 @@ def all_cut_edge_flips(partition: Partition) -> Iterator[Dict]:
 
 
 def all_valid_states_one_flip_away(
-    partition: Partition, constraints: Union[Iterable[Callable], Callable]
+    partition: Partition, constraints: Iterable[Constraint] | Validator | Constraint
 ) -> Iterator[Partition]:
     """Generates all valid Partitions that differ from the given partition by one flip.
 
@@ -48,15 +53,17 @@ def all_valid_states_one_flip_away(
 
     Args:
         partition (Partition): The initial partition.
-        constraints (Union[Iterable[Callable], Callable]): Constraints to determine the validity of
-            a partition. It can be a single callable or an iterable of callables.
+        constraints (Iterable[Constraint] | Validator | Constraint): Constraints determining
+            whether a partition is valid.
 
     Returns:
         Iterator[Partition]: An iterator that yields all valid partitions that differ from the
             given partition by one flip.
     """
-    if callable(constraints):
+    if isinstance(constraints, Validator):
         is_valid = constraints
+    elif callable(constraints):
+        is_valid = cast(Constraint, constraints)
     else:
         is_valid = Validator(constraints)
 
@@ -67,8 +74,8 @@ def all_valid_states_one_flip_away(
 
 
 def all_valid_flips(
-    partition: Partition, constraints: Union[Iterable[Callable], Callable]
-) -> Iterator[Dict]:
+    partition: Partition, constraints: Iterable[Constraint] | Validator | Constraint
+) -> Iterator[dict[Hashable, Hashable]]:
     """Generate all valid flips for a given partition subject to the prescribed constraints.
 
     This function generates all valid flips for a given partition subject to the prescribed
@@ -76,17 +83,21 @@ def all_valid_flips(
 
     Args:
         partition (Partition): The initial partition.
-        constraints (Union[Iterable[Callable], Callable]): The constraints to be satisfied. Can be
-            a single constraint or an iterable of constraints.
+        constraints (Iterable[Constraint] | Validator | Constraint): Constraints determining
+            whether a partition is valid.
 
     Returns:
-        Iterator[Dict]: An iterator that yields dictionaries representing valid flips.
+        Iterator[dict[Hashable, Hashable]]: An iterator that yields dictionaries representing
+            valid flips.
     """
     for state in all_valid_states_one_flip_away(partition, constraints):
+        assert state.flips is not None
         yield state.flips
 
 
-def metagraph_degree(partition: Partition, constraints: Union[Iterable[Callable], Callable]) -> int:
+def metagraph_degree(
+    partition: Partition, constraints: Iterable[Constraint] | Validator | Constraint
+) -> int:
     """Calculate the degree of the node in the metagraph of the given partition.
 
     That is to say, compute how many possible valid states are reachable from the state given by
@@ -94,8 +105,8 @@ def metagraph_degree(partition: Partition, constraints: Union[Iterable[Callable]
 
     Args:
         partition (Partition): The partition object representing the current state.
-        constraints (Union[Iterable[Callable], Callable]): The constraints to be applied to the
-            partition. It can be a single constraint or an iterable of constraints.
+        constraints (Iterable[Constraint] | Validator | Constraint): Constraints determining
+            whether a partition is valid.
 
     Returns:
         int: The degree of the partition node in the metagraph.

--- a/gerrychain/metrics/compactness.py
+++ b/gerrychain/metrics/compactness.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import math
+from collections.abc import Hashable
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -23,9 +24,7 @@ def compute_polsby_popper(area: float, perimeter: float) -> float:
         return math.nan
 
 
-# Partition type hint left out due to circular import
-# def polsby_popper(partition: Partition) -> Dict[int, float]:
-def polsby_popper(partition: Partition) -> dict[int, float]:
+def polsby_popper(partition: Partition) -> dict[Hashable, float]:
     """Computes Polsby-Popper compactness scores for each district in the partition.
 
     This function computes Polsby-Popper compactness scores for each district in the partition. It
@@ -35,7 +34,7 @@ def polsby_popper(partition: Partition) -> dict[int, float]:
         partition (Partition): The partition to compute scores for
 
     Returns:
-        Dict[int, float]: A dictionary mapping each district ID to its Polsby-Popper score
+        dict[Hashable, float]: A dictionary mapping each district ID to its Polsby-Popper score
     """
     return {
         part: compute_polsby_popper(partition["area"][part], partition["perimeter"][part])

--- a/gerrychain/metrics/partisan.py
+++ b/gerrychain/metrics/partisan.py
@@ -31,7 +31,7 @@ def mean_median(election_results: ElectionResults) -> float:
     first_party = election_results.election.parties[0]
     data = election_results.percents(first_party)
 
-    return numpy.median(data) - numpy.mean(data)
+    return float(numpy.median(data) - numpy.mean(data))
 
 
 def mean_thirdian(election_results: ElectionResults) -> float:
@@ -55,7 +55,7 @@ def mean_thirdian(election_results: ElectionResults) -> float:
     thirdian_index = round(len(data) / 3)
     thirdian = sorted(data)[thirdian_index]
 
-    return thirdian - numpy.mean(data)
+    return float(thirdian - numpy.mean(data))
 
 
 def efficiency_gap(election_results: ElectionResults) -> float:
@@ -77,18 +77,18 @@ def efficiency_gap(election_results: ElectionResults) -> float:
     return numerator / total_votes
 
 
-def wasted_votes(party1_votes: int, party2_votes: int) -> tuple[int, int]:
+def wasted_votes(party1_votes: float, party2_votes: float) -> tuple[float, float]:
     """Computes the wasted votes for each party in the given race.
 
     This function computes the wasted votes for each party in the given race. It returns a tuple of
     the wasted votes for each party.
 
     Args:
-        party1_votes (int): the number of votes party1 received in the race
-        party2_votes (int): the number of votes party2 received in the race
+        party1_votes (float): the number of votes party1 received in the race
+        party2_votes (float): the number of votes party2 received in the race
 
     Returns:
-        Tuple[int, int]: a tuple of the wasted votes for each party
+        tuple[float, float]: A tuple of the wasted votes for each party.
     """
     total_votes = party1_votes + party2_votes
     if party1_votes > party2_votes:

--- a/gerrychain/optimization/gingleator.py
+++ b/gerrychain/optimization/gingleator.py
@@ -1,14 +1,20 @@
 import random
 import warnings
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Hashable, Iterable
 from functools import partial
+from typing import Protocol
 
 import numpy as np
 
-from gerrychain.constraints import Bounds, Validator
+from gerrychain.constraints import Validator
 from gerrychain.partition import Partition
+from gerrychain.proposals import ProposalFn
 
 from .optimization import SingleMetricOptimizer
+
+
+class GingleScoreFn(Protocol):
+    def __call__(self, part: Partition, *, minority_perc_col: str, threshold: float) -> float: ...
 
 
 class Gingleator(SingleMetricOptimizer):
@@ -23,12 +29,14 @@ class Gingleator(SingleMetricOptimizer):
 
     def __init__(
         self,
-        proposal: Callable,
-        constraints: Iterable[Callable] | Validator | Iterable[Bounds] | Callable,
+        proposal: ProposalFn,
+        constraints: Iterable[Callable[[Partition], bool]]
+        | Validator
+        | Callable[[Partition], bool],
         initial_state: Partition,
         minority_perc_col: str | None = None,
         threshold: float = 0.5,
-        score_function: Callable | None = None,
+        score_function: GingleScoreFn | None = None,
         minority_pop_col: str | None = None,
         total_pop_col: str = "TOTPOP",
         min_perc_column_name: str = "_gingleator_auxiliary_helper_updater_min_perc_col",
@@ -39,29 +47,27 @@ class Gingleator(SingleMetricOptimizer):
 
         Args:
             proposal (Callable): Function proposing the next state from the current state.
-            constraints (Union[Iterable[Callable], Validator, Iterable[Bounds], Callable]): A
-                function with signature ``Partition -> bool`` determining whether the proposed next
-                state is valid (passes all binary constraints). Usually this is a
-                Validator class instance.
+            constraints (Iterable[Callable[[Partition], bool]] | Validator |
+                Callable[[Partition], bool]): A function with signature ``Partition -> bool``
+                determining whether the proposed next state is valid (passes all binary
+                constraints). Usually this is a Validator class instance.
             initial_state (Partition): Initial Partition class.
-            minority_perc_col (Optional[str]): The name of the updater mapping of district ids to
+            minority_perc_col (str | None): The name of the updater mapping of district ids to
                 the fraction of minority population within that district. If no updater is
                 specified, one is made according to the ``min_perc_column_name`` parameter.
                 Defaults to None.
             threshold (float, optional): Fraction beyond which to consider something a "Gingles"
                 (or opportunity) district. Defaults to 0.5.
-            score_function (Optional[Callable]): The function to use during optimization. Should
-                have the signature ``Partition * str (minority_perc_col) * float (threshold) -> 'a
-                where 'a is Comparable``. This class implements a few potential choices as class
-                methods. Defaults to None.
-            minority_pop_col (Optional[str]): If minority_perc_col is not defined, the minority
+            score_function (GingleScoreFn | None): The function to use during optimization. This
+                class provides several compatible class methods. Defaults to ``None``.
+            minority_pop_col (str | None): If minority_perc_col is not defined, the minority
                 population column with which to compute percentage. Defaults to None.
             total_pop_col (str, optional): If minority_perc_col is defined, the total population
                 column with which to compute percentage. Defaults to "TOTPOP".
             min_perc_column_name (str, optional): If minority_perc_col is not defined, the name to
                 give the created percentage updater. Defaults to
                 "_gingleator_auxiliary_helper_updater_min_perc_col".
-            rng (Union[random.Random, int, None], optional): Source of randomness for the
+            rng (random.Random | int | None, optional): Source of randomness for the
                 optimizer's internal chains; see
                 :meth:`SingleMetricOptimizer.__init__ <gerrychain.optimization.SingleMetricOptimizer.__init__>`.
                 Defaults to None.
@@ -79,11 +85,16 @@ class Gingleator(SingleMetricOptimizer):
         score_function = self.num_opportunity_dists if score_function is None else score_function
 
         if minority_perc_col is None:
-            perc_up = {
-                min_perc_column_name: lambda part: {
-                    k: part[minority_pop_col][k] / part[total_pop_col][k] for k in part.parts.keys()
+            assert minority_pop_col is not None
+            minority_population_column = minority_pop_col
+
+            def minority_percentages(part: Partition) -> dict[Hashable, float]:
+                return {
+                    key: part[minority_population_column][key] / part[total_pop_col][key]
+                    for key in part.parts
                 }
-            }
+
+            perc_up = {min_perc_column_name: minority_percentages}
             initial_state.updaters.update(perc_up)
             minority_perc_col = min_perc_column_name
 
@@ -212,4 +223,4 @@ class Gingleator(SingleMetricOptimizer):
         else:
             num_opportunity_dists = len(opport_dists)
             avg_opportunity_dist = np.mean(opport_dists)
-            return num_opportunity_dists + (1 - avg_opportunity_dist) / (1 - threshold)
+            return float(num_opportunity_dists + (1 - avg_opportunity_dist) / (1 - threshold))

--- a/gerrychain/optimization/optimization.py
+++ b/gerrychain/optimization/optimization.py
@@ -1,13 +1,13 @@
 import math
 import random
-from collections.abc import Callable, Generator
-from typing import Any
+from collections.abc import Callable, Generator, Iterable
 
 from tqdm import tqdm
 
 from .._rng import make_rng
 from ..accept import AcceptFn, always_accept
 from ..chain import MarkovChain
+from ..constraints import Validator
 from ..partition import Partition
 from ..proposals import ProposalFn
 
@@ -38,9 +38,11 @@ class SingleMetricOptimizer:
     def __init__(
         self,
         proposal: ProposalFn,
-        constraints: Callable[[Partition], bool] | list[Callable[[Partition], bool]],
+        constraints: Iterable[Callable[[Partition], bool]]
+        | Validator
+        | Callable[[Partition], bool],
         initial_state: Partition,
-        optimization_metric: Callable[[Partition], Any],
+        optimization_metric: Callable[[Partition], float],
         maximize: bool = True,
         step_indexer: str = "step",
         *,
@@ -50,20 +52,18 @@ class SingleMetricOptimizer:
 
         Args:
             proposal (Callable): Function proposing the next state from the current state.
-            constraints (Union[Callable[[Partition], bool], List[Callable[[Partition], bool]]]): A
-                function, or lists of functions, determining whether the proposed next state is
-                valid (passes all binary constraints). Usually this is a
-                Validator class instance.
+            constraints (Iterable[Callable[[Partition], bool]] | Validator |
+                Callable[[Partition], bool]): One or more functions determining whether the
+                proposed state is valid.
             initial_state (Partition): Initial state of the optimizer.
-            optimization_metric (Callable[[Partition], Any]): The score function with which to
-                optimize over. This should have the signature: ``Partition -> 'a`` where 'a is
-                comparable.
+            optimization_metric (Callable[[Partition], float]): Numeric score function to
+                optimize.
             maximize (bool, optional): Boolean indicating whether to maximize or minimize the
                 function. Defaults to True for maximize.
             step_indexer (str, optional): Name of the updater tracking the partitions step in the
                 chain. If not implemented on the partition the constructor creates and adds it.
                 Defaults to "step".
-            rng (Union[random.Random, int, None], optional): Source of randomness for the
+            rng (random.Random | int | None, optional): Source of randomness for the
                 optimizer's internal chains. An int seeds a fresh ``random.Random`` once, here;
                 every optimization run then continues that one stream (consecutive short bursts
                 do not restart it). This means re-running an optimization method on the same
@@ -71,8 +71,6 @@ class SingleMetricOptimizer:
                 reproduce a run. ``None`` (the default) creates an independent RNG from system
                 entropy.
 
-        Returns:
-            SingleMetricOptimizer: A SingleMetricOptimizer object
         """
         self._initial_part = initial_state
         self._proposal = proposal
@@ -92,29 +90,29 @@ class SingleMetricOptimizer:
             self._initial_part.updaters[self._step_indexer] = step_updater
 
     @property
-    def best_part(self) -> Partition:
+    def best_part(self) -> Partition | None:
         """Partition object corresponding to best scoring plan observed over the current run.
 
         Returns:
-            Partition: Partition object with the best score.
+            Partition | None: The best partition, or ``None`` before an optimization run.
         """
         return self._best_part
 
     @property
-    def best_score(self) -> Any:
+    def best_score(self) -> float | None:
         """Return Value of the best score observed over the current run.
 
         Returns:
-            Any: Value of the best score.
+            float | None: The best score, or ``None`` before an optimization run.
         """
         return self._best_score
 
     @property
-    def score(self) -> Callable[[Partition], Any]:
+    def score(self) -> Callable[[Partition], float]:
         """Return score function used for optimization.
 
         Returns:
-            Callable[[Partition], Any]: The score function.
+            Callable[[Partition], float]: The score function.
         """
         return self._score
 
@@ -133,22 +131,22 @@ class SingleMetricOptimizer:
         else:
             return new_score <= old_score
 
-    def _tilted_acceptance_function(self, p: float) -> Callable[[Partition], bool]:
+    def _tilted_acceptance_function(self, p: float) -> AcceptFn:
         """Function factory that binds and returns a tilted acceptance function.
 
         Args:
             p (float): The probability of accepting a worse score.
 
         Returns:
-            Callable[[Partition], bool]: An acceptance function for tilted chains.
+            AcceptFn: An acceptance function for tilted chains.
         """
 
-        def tilted_acceptance_function(part: Partition, *, rng: random.Random) -> bool:
-            if part.parent is None:
+        def tilted_acceptance_function(partition: Partition, *, rng: random.Random) -> bool:
+            if partition.parent is None:
                 return True
 
-            part_score = self.score(part)
-            prev_score = self.score(part.parent)
+            part_score = self.score(partition)
+            prev_score = self.score(partition.parent)
 
             if self._is_improvement(part_score, prev_score):
                 return True
@@ -159,7 +157,7 @@ class SingleMetricOptimizer:
 
     def _simulated_annealing_acceptance_function(
         self, beta_function: Callable[[int], float], beta_magnitude: float
-    ) -> Callable[[Partition], bool]:
+    ) -> AcceptFn:
         """Function factory that binds and returns a simulated annealing acceptance function.
 
         Args:
@@ -170,14 +168,16 @@ class SingleMetricOptimizer:
             beta_magnitude (float): Scaling parameter for how much to weight changes in score.
 
         Returns:
-            Callable[[Partition], bool]: A acceptance function for simulated annealing runs.
+            AcceptFn: An acceptance function for simulated annealing runs.
         """
 
-        def simulated_annealing_acceptance_function(part: Partition, *, rng: random.Random) -> bool:
-            if part.parent is None:
+        def simulated_annealing_acceptance_function(
+            partition: Partition, *, rng: random.Random
+        ) -> bool:
+            if partition.parent is None:
                 return True
-            score_delta = self.score(part) - self.score(part.parent)
-            beta = beta_function(part[self._step_indexer])
+            score_delta = self.score(partition) - self.score(partition.parent)
+            beta = beta_function(partition[self._step_indexer])
             if self._maximize:
                 score_delta *= -1
             return rng.random() < math.exp(-beta * beta_magnitude * score_delta)

--- a/gerrychain/partition/assignment.py
+++ b/gerrychain/partition/assignment.py
@@ -1,14 +1,18 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from collections.abc import Hashable, Iterator, Mapping
+from collections.abc import Callable, Hashable, Iterable, Iterator, Mapping
+from typing import TypeVar, cast
 
 import pandas
 
-from ..graph import Graph
+from ..graph import FrozenGraph, Graph
+
+NodeT = TypeVar("NodeT", bound=Hashable)
+PartT = TypeVar("PartT", bound=Hashable)
 
 
-class Assignment(Mapping):
+class Assignment(Mapping[Hashable, Hashable]):
     """
     An assignment of nodes into parts.
 
@@ -21,13 +25,20 @@ class Assignment(Mapping):
     """
 
     __slots__ = ["parts", "mapping"]
+    parts: dict[Hashable, frozenset[Hashable]]
+    mapping: dict[Hashable, Hashable]
 
-    def __init__(self, parts: dict, mapping: dict | None = None, validate: bool = True) -> None:
+    def __init__(
+        self,
+        parts: Mapping[PartT, frozenset[NodeT]],
+        mapping: Mapping[NodeT, PartT] | None = None,
+        validate: bool = True,
+    ) -> None:
         """Initialize a Assignment instance.
 
         Args:
-            parts (Dict): Dictionary mapping partition assignments frozensets of nodes.
-            mapping (Optional[Dict], optional): Dictionary mapping nodes to partition assignments.
+            parts (dict): Dictionary mapping partition assignments frozensets of nodes.
+            mapping (dict | None, optional): Dictionary mapping nodes to partition assignments.
                 Default is None.
             validate (bool, optional): Whether to validate the assignment. Default is True.
 
@@ -43,21 +54,23 @@ class Assignment(Mapping):
                 raise ValueError("Keys must have unique assignments.")
             if not all(isinstance(keys, frozenset) for keys in parts.values()):
                 raise TypeError("Level sets must be frozensets")
-        self.parts = parts
+        self.parts: dict[Hashable, frozenset[Hashable]] = {
+            part: frozenset(nodes) for part, nodes in parts.items()
+        }
 
         if not mapping:
-            self.mapping = {}
+            self.mapping: dict[Hashable, Hashable] = {}
             for part, nodes in self.parts.items():
                 for node in nodes:
                     self.mapping[node] = part
         else:
-            self.mapping = mapping
+            self.mapping = {node: part for node, part in mapping.items()}
 
     def __repr__(self) -> str:
         return f"<Assignment [{len(self)} keys, {len(self.parts)} parts]>"
 
     def __iter__(self) -> Iterator[Hashable]:
-        return self.keys()
+        return iter(self.mapping)
 
     def __len__(self) -> int:
         return sum(len(keys) for keys in self.parts.values())
@@ -83,7 +96,7 @@ class Assignment(Mapping):
 
 
         Args:
-            flows (Dict): A dictionary mapping partition assignments to dictionaries with "in" and
+            flows (dict): A dictionary mapping partition assignments to dictionaries with "in" and
                 "out" keys, where the value of "in" is a set of nodes flowing into the partition
                 and the value of "out" is a set of nodes flowing out of the partition.
         """
@@ -103,21 +116,11 @@ class Assignment(Mapping):
             for node in flow["in"]:
                 self.mapping[node] = part
 
-    def items(self) -> Iterator[tuple[Hashable, Hashable]]:
-        """Iterate over ``(node, part)`` tuples, where ``node`` is assigned to ``part``."""
-        yield from self.mapping.items()
-
-    def keys(self) -> Iterator[Hashable]:
-        yield from self.mapping.keys()
-
-    def values(self) -> Iterator[Hashable]:
-        yield from self.mapping.values()
-
-    def update_parts(self, new_parts: dict) -> None:
+    def update_parts(self, new_parts: Mapping[Hashable, Iterable[Hashable]]) -> None:
         """Update some parts of the assignment.
 
         Args:
-            new_parts (Dict): dictionary mapping (some) parts to their new sets or frozensets of
+            new_parts (dict): dictionary mapping (some) parts to their new sets or frozensets of
                 nodes
 
         """
@@ -136,39 +139,42 @@ class Assignment(Mapping):
         groups = [pandas.Series(data=part, index=nodes) for part, nodes in self.parts.items()]
         return pandas.concat(groups)
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> dict[Hashable, Hashable]:
         """Convert to dict.
 
         Returns:
-            Dict: The assignment as a ``{node: part}`` dictionary.
+            dict: The assignment as a ``{node: part}`` dictionary.
         """
         return self.mapping
 
     @classmethod
-    def from_dict(cls, nodes_to_parts: dict | pandas.Series) -> Assignment:
+    def from_dict(cls, nodes_to_parts: Mapping[NodeT, PartT] | pandas.Series) -> Assignment:
         """Create an Assignment from a dictionary.
 
         Args:
-            nodes_to_parts (Dict): dictionary mapping nodes to partition assignments
+            nodes_to_parts (Mapping[Hashable, Hashable] | pandas.Series): mapping (a dict-like
+                or a ``pandas.Series``) from nodes to partition assignments
 
         Returns:
             Assignment: A new instance of Assignment with the same assignments as the
                 passed-in dictionary.
         """
 
-        parts = {part: frozenset(keys) for part, keys in level_sets(nodes_to_parts).items()}
-
-        # If a pandas.Series was passed in then convert it to be a dict
         if isinstance(nodes_to_parts, pandas.Series):
-            nodes_to_parts = nodes_to_parts.to_dict()
+            raw_mapping = nodes_to_parts.to_dict()
+            if not all(
+                isinstance(node, Hashable) and isinstance(part, Hashable)
+                for node, part in raw_mapping.items()
+            ):
+                raise TypeError("Assignment keys and part labels must be hashable")
+            return cls.from_dict(cast(dict[Hashable, Hashable], raw_mapping))
 
-        return cls(
-            parts,  # Commented out because __init__() croaks if the nodes_to_parts
-            nodes_to_parts,  # is a pandas series instead of a dict...
-        )
+        mapping = dict(nodes_to_parts)
+        parts = {part: frozenset(keys) for part, keys in level_sets(mapping).items()}
+        return cls(parts, mapping)
 
     def new_assignment_convert_old_node_ids_to_new_node_ids(
-        self, node_id_mapping: dict
+        self, node_id_mapping: Mapping[Hashable, Hashable]
     ) -> Assignment:
         """Create a new Assignment object from the one passed in, where the node_ids are changed.
 
@@ -192,32 +198,29 @@ class Assignment(Mapping):
             for old_node_id, part in old_assignment_mapping.items()
         }
         # Now upate the parts dict that has a frozenset of all the nodes in each part (district)
-        new_parts = {}
+        new_parts: dict[Hashable, set[Hashable]] = {}
         for cur_node_id, cur_part in new_assignment_mapping.items():
             if cur_part not in new_parts:
                 new_parts[cur_part] = set()
             new_parts[cur_part].add(cur_node_id)
-        for cur_part, set_of_nodes in new_parts.items():
-            new_parts[cur_part] = frozenset(set_of_nodes)
-
-        #  pandas.Series(data=part, index=nodes) for part, nodes in self.parts.items()
-
-        new_assignment = Assignment(new_parts, new_assignment_mapping)
+        frozen_parts = {part: frozenset(nodes) for part, nodes in new_parts.items()}
+        new_assignment = Assignment(frozen_parts, new_assignment_mapping)
 
         return new_assignment
 
 
 def get_assignment(
-    part_assignment: str | dict | Assignment, graph: Graph | None = None
+    part_assignment: str | Mapping[NodeT, PartT] | pandas.Series | Assignment,
+    graph: Graph | FrozenGraph | None = None,
 ) -> Assignment:
     """Either extracts an Assignment object from the input graph using the provided key or
     attempts to convert part_assignment into an Assignment object.
 
     Args:
-        part_assignment (str): A node attribute key, dictionary, or Assignment object
-            corresponding to the desired assignment.
-        graph (Optional[Graph], optional): The graph from which to extract the assignment. Default
-            is None.
+        part_assignment (str | Mapping[NodeT, PartT] | pandas.Series | Assignment): A node
+            attribute key, mapping, pandas Series, or Assignment object.
+        graph (Graph | FrozenGraph | None, optional): The graph from which to extract the
+            assignment. Defaults to None.
 
     Returns:
         Assignment: An Assignment object containing the assignment corresponding to the
@@ -237,24 +240,27 @@ def get_assignment(
         return Assignment.from_dict(
             {node: graph.node_data(node)[part_assignment] for node in graph}
         )
-    # Check if assignment is a dict or a mapping type
-    elif callable(getattr(part_assignment, "items", None)):
-        return Assignment.from_dict(part_assignment)
-    elif isinstance(part_assignment, Assignment):
+    if isinstance(part_assignment, Assignment):
         return part_assignment
-    else:
-        raise TypeError("Assignment must be a dict or a node attribute key")
+    if isinstance(part_assignment, pandas.Series):
+        return Assignment.from_dict(part_assignment)
+    if isinstance(part_assignment, Mapping):
+        return Assignment.from_dict(part_assignment)
+    raise TypeError("Assignment must be a mapping or a node attribute key")
 
 
-def level_sets(mapping: dict, container: type[set] = set) -> defaultdict:
+def level_sets(
+    mapping: Mapping[NodeT, PartT],
+    container: Callable[[], set[NodeT]] = set,
+) -> defaultdict[PartT, set[NodeT]]:
     """Inverts a dictionary.
 
     ``{key: value}`` becomes ``{value: <container of keys that map to value>}``.
 
     Args:
-        mapping (Dict): A dictionary to invert. Keys and values can be of any type.
-        container (Type[Set], optional): A container type used to collect keys that map to the same
-            value. By default, the container type is ``set``.
+        mapping (dict): A dictionary to invert. Keys and values can be of any type.
+        container (Callable[[], set], optional): A zero-argument callable returning a container used
+            to collect keys that map to the same value. By default, this is ``set``.
 
     Returns:
         DefaultDict: A dictionary where each key is a value from the original dictionary, and the
@@ -267,7 +273,7 @@ def level_sets(mapping: dict, container: type[set] = set) -> defaultdict:
         >>> level_sets({'a': 1, 'b': 1, 'c': 2})
         defaultdict(<class 'set'>, {1: {'a', 'b'}, 2: {'c'}})
     """
-    sets: dict = defaultdict(container)
+    sets: defaultdict[PartT, set[NodeT]] = defaultdict(container)
     for source, target in mapping.items():
         sets[target].add(source)
     return sets

--- a/gerrychain/partition/initial_partition_generators.py
+++ b/gerrychain/partition/initial_partition_generators.py
@@ -37,36 +37,29 @@ schema, it's a lot harder to make a snake-y patchwork of districts.
 """
 
 import random
+from collections.abc import Callable, Hashable, Sequence, Set as AbstractSet
 from functools import partial
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    List,
-    Optional,
-    Sequence,
-    Set,
-    Union,
-)
 
 from .._rng import make_rng
 
 # frm:  import the new Graph object which encapsulates NX and RX Graph...
 from ..graph import Graph
-from ..tree import BalanceError, PopulationBalanceError, bipartition_tree
+from ..tree import PopulationBalanceError, bipartition_tree
 
 
 def recursive_tree_part(
     graph: Graph,
-    parts: Sequence,
-    pop_target: Union[float, int],
+    parts: Sequence[Hashable],
+    pop_target: float | int,
     pop_col: str,
     epsilon: float,
     node_repeats: int = 0,
-    bipartition_tree_fn: Callable = partial(bipartition_tree, max_attempts=100000),
+    bipartition_tree_fn: Callable[..., AbstractSet[Hashable]] = partial(
+        bipartition_tree, max_attempts=100000
+    ),
     *,
     rng: random.Random | int | None = None,
-) -> Dict:
+) -> dict[Hashable, Hashable]:
     """Return new assignments for the nodes of ``graph``.
 
     Uses ``gerrychain.tree.bipartition_tree`` recursively to partition a tree into
@@ -79,7 +72,7 @@ def recursive_tree_part(
         graph (Graph): The graph to partition into ``len(parts)`` :math:`\\varepsilon`-balanced
             parts.
         parts (Sequence): Iterable of part (district) labels (like ``[0,1,2]`` or ``range(4)``).
-        pop_target (Union[float, int]): Target population for each part of the partition.
+        pop_target (float | int): Target population for each part of the partition.
         pop_col (str): Node attribute key holding population data.
         epsilon (float): How far (as a percentage of ``pop_target``) from ``pop_target`` the parts
             of the partition can be.
@@ -87,7 +80,7 @@ def recursive_tree_part(
             drawing a new tree. Defaults to 0.
         bipartition_tree_fn (Callable, optional): The partition method to use. Defaults to
             ``partial(bipartition_tree, max_attempts=100000)``.
-        rng (Union[random.Random, int, None], optional): Source of randomness. Pass a shared
+        rng (random.Random | int | None, optional): Source of randomness. Pass a shared
             ``Random`` for repeated standalone calls; an integer restarts the stream each call.
 
     Returns:
@@ -105,7 +98,7 @@ def recursive_tree_part(
     # For instance, if district n's population exceeds the target by 2%
     # with a +/-2% epsilon, then district n+1's population should be between
     # 98% of the target population and the target population.
-    debt: Union[int, float] = 0
+    debt: int | float = 0
 
     lb_pop = pop_target * (1 - epsilon)
     ub_pop = pop_target * (1 + epsilon)
@@ -139,9 +132,6 @@ def recursive_tree_part(
         except Exception:
             raise
 
-        if node_ids is None:
-            raise BalanceError()
-
         part_pop = 0
         for node_id in node_ids:
             flips[node_id] = part
@@ -169,9 +159,6 @@ def recursive_tree_part(
         rng=rng,
     )
 
-    if node_ids is None:
-        raise BalanceError()
-
     part_pop = 0
     for node_id in node_ids:
         flips[node_id] = parts[-2]
@@ -198,14 +185,16 @@ def _get_seed_chunks(
     graph: Graph,
     num_chunks: int,
     num_dists: int,
-    pop_target: Union[int, float],
+    pop_target: int | float,
     pop_col: str,
     epsilon: float,
     node_repeats: int = 0,
-    bipartition_tree_fn: Callable = partial(bipartition_tree, max_attempts=100000),
+    bipartition_tree_fn: Callable[..., AbstractSet[Hashable]] = partial(
+        bipartition_tree, max_attempts=100000
+    ),
     *,
     rng: random.Random,
-) -> List[List[int]]:
+) -> list[list[Hashable]]:
     """Helper function for recursive_seed_part.
 
     Partitions the graph into ``num_chunks`` chunks, balanced within new_epsilon <= ``epsilon`` of
@@ -217,7 +206,7 @@ def _get_seed_chunks(
         graph (Graph): The graph
         num_chunks (int): The number of chunks to partition the graph into
         num_dists (int): The number of districts
-        pop_target (Union[int, float]): The target population of the districts (not of the chunks)
+        pop_target (int | float): The target population of the districts (not of the chunks)
         pop_col (str): Node attribute key holding population data
         epsilon (float): How far (as a percentage of ``pop_target``) from ``pop_target`` the parts
             of the partition can be
@@ -225,9 +214,10 @@ def _get_seed_chunks(
             drawing a new tree. Defaults to 0.
         bipartition_tree_fn (Callable, optional): The method to use for bipartitioning the graph.
             Defaults to `gerrychain.tree.bipartition_tree`
+        rng (random.Random): Random number generator for the operation.
 
     Returns:
-        List[List[int]]: New assignments for the nodes of ``graph``.
+        list[list[Hashable]]: New assignments for the nodes of ``graph``.
     """
 
     if num_dists % num_chunks != 0:
@@ -305,9 +295,6 @@ def _get_seed_chunks(
                 rng=rng,
             )
 
-            if nodes is None:
-                raise BalanceError()
-
             for node in nodes:
                 flips[node] = part
             remaining_nodes -= nodes
@@ -341,7 +328,7 @@ def _get_seed_chunks(
         else:
             break
 
-    chunks: Dict[Any, List] = {}
+    chunks: dict[Hashable, list[Hashable]] = {}
     for key in flips.keys():
         if flips[key] not in chunks.keys():
             chunks[flips[key]] = []
@@ -352,7 +339,7 @@ def _get_seed_chunks(
 
 # frm: only used in this file
 #       But maybe this is intended to be used externally...
-def get_max_prime_factor_less_than(n: int, ceil: int) -> Optional[int]:
+def get_max_prime_factor_less_than(n: int, ceil: int) -> int | None:
     """Helper function for _recursive_seed_part_inner.
 
     Returns the largest prime factor of ``n`` less than ``ceil``, or None if all are greater than
@@ -363,7 +350,7 @@ def get_max_prime_factor_less_than(n: int, ceil: int) -> Optional[int]:
         ceil (int): The upper limit for the largest prime factor.
 
     Returns:
-        Optional[int]: The largest prime factor of ``n`` less than ``ceil``, or None if all are
+        int | None: The largest prime factor of ``n`` less than ``ceil``, or None if all are
             greater than ceil.
     """
     if n <= 1 or ceil <= 1:
@@ -391,16 +378,18 @@ def get_max_prime_factor_less_than(n: int, ceil: int) -> Optional[int]:
 def _recursive_seed_part_inner(
     graph: Graph,
     num_dists: int,
-    pop_target: Union[float, int],
+    pop_target: float | int,
     pop_col: str,
     epsilon: float,
-    bipartition_tree_fn: Callable = partial(bipartition_tree, max_attempts=100000),
+    bipartition_tree_fn: Callable[..., AbstractSet[Hashable]] = partial(
+        bipartition_tree, max_attempts=100000
+    ),
     node_repeats: int = 0,
-    n: Optional[int] = None,
-    ceil: Optional[int] = None,
+    n: int | None = None,
+    ceil: int | None = None,
     *,
     rng: random.Random,
-) -> List[Set]:
+) -> list[set[Hashable]]:
     """Inner function for recursive_seed_part.
 
     Returns a list of sets of nodes with ``num_dists`` districts balanced within ``epsilon`` of
@@ -428,7 +417,7 @@ def _recursive_seed_part_inner(
     Args:
         graph (Graph): The underlying graph structure.
         num_dists (int): number of districts to partition the graph into
-        pop_target (Union[float, int]): Target population for each part of the partition
+        pop_target (float | int): Target population for each part of the partition
         pop_col (str): Node attribute key holding population data
         epsilon (float): How far (as a percentage of ``pop_target``) from ``pop_target`` the parts
             of the partition can be
@@ -436,19 +425,19 @@ def _recursive_seed_part_inner(
             2-district level. Defaults to `gerrychain.tree.bipartition_tree`
         node_repeats (int, optional): Additional roots to try on each spanning tree before
             drawing a new tree. Defaults to 0.
-        n (Optional[int], optional): Either a positive integer (greater than 1) or None. If n is a
+        n (int | None, optional): Either a positive integer (greater than 1) or None. If n is a
             positive integer, this function will recursively create a seed plan by either biting
             off districts from graph or dividing graph into n chunks and recursing into each of
             these. If n is None, this function prime factors ``num_dists = n_1*n_2*...*n_k`` (n_1 >
             n_2 > ... n_k) and recursively partitions graph into n_1 chunks. Defaults to None.
-        ceil (Optional[int], optional): Either a positive integer (at least 2) or None. Relevant
+        ceil (int | None, optional): Either a positive integer (at least 2) or None. Relevant
             only if n is None. If ``ceil`` is a positive integer then finds the largest factor of
             ``num_dists`` less than or equal to ``ceil``, and recursively splits graph into that
             number of chunks, or bites off a district if that number is 1. Defaults to None.
         rng (random.Random): The RNG supplied by the owning operation.
 
     Returns:
-        List of sets, each set is a district: New assignments for the nodes of ``graph``.
+        list[set[Hashable]]: Districts represented as sets of nodes.
     """
 
     # Chooses num_chunks
@@ -584,17 +573,19 @@ def _recursive_seed_part_inner(
 
 def recursive_seed_part(
     graph: Graph,
-    parts: Sequence,
-    pop_target: Union[float, int],
+    parts: Sequence[Hashable],
+    pop_target: float | int,
     pop_col: str,
     epsilon: float,
-    bipartition_tree_fn: Callable = partial(bipartition_tree, max_attempts=100000),
+    bipartition_tree_fn: Callable[..., AbstractSet[Hashable]] = partial(
+        bipartition_tree, max_attempts=100000
+    ),
     node_repeats: int = 0,
-    n: Optional[int] = None,
-    ceil: Optional[int] = None,
+    n: int | None = None,
+    ceil: int | None = None,
     *,
     rng: random.Random | int | None = None,
-) -> Dict:
+) -> dict[Hashable, Hashable]:
     """Returns an assignment dictionary with ``num_dists`` districts balanced within ``epsilon``.
 
     Returns an assignment dictionary with ``num_dists`` districts balanced within ``epsilon`` of.
@@ -603,7 +594,7 @@ def recursive_seed_part(
     Args:
         graph (Graph): The graph
         parts (Sequence): Iterable of part labels (like ``[0,1,2]`` or ``range(4)``).
-        pop_target (Union[float, int]): Target population for each part of the partition
+        pop_target (float | int): Target population for each part of the partition
         pop_col (str): Node attribute key holding population data
         epsilon (float): How far (as a percentage of ``pop_target``) from ``pop_target`` the parts
             of the partition can be
@@ -611,16 +602,16 @@ def recursive_seed_part(
             2-district level. Defaults to ``gerrychain.tree.bipartition_tree``.
         node_repeats (int, optional): Additional roots to try on each spanning tree before
             drawing a new tree. Defaults to 0.
-        n (Optional[int], optional): Either a positive integer (greater than 1) or None. If n is a
+        n (int | None, optional): Either a positive integer (greater than 1) or None. If n is a
             positive integer, this function will recursively create a seed plan by either biting
             off districts from graph or dividing graph into n chunks and recursing into each of
             these. If n is None, this function prime factors ``num_dists = n_1*n_2*...*n_k`` (n_1 >
             n_2 > ... n_k) and recursively partitions graph into n_1 chunks. Defaults to None.
-        ceil (Optional[int], optional): Either a positive integer (at least 2) or None. Relevant
+        ceil (int | None, optional): Either a positive integer (at least 2) or None. Relevant
             only if n is None. If ``ceil`` is a positive integer then finds the largest factor of
             ``num_dists`` less than or equal to ``ceil``, and recursively splits graph into that
             number of chunks, or bites off a district if that number is 1. Defaults to None.
-        rng (Union[random.Random, int, None], optional): Source of randomness. Pass a shared
+        rng (random.Random | int | None, optional): Source of randomness. Pass a shared
             ``Random`` for repeated standalone calls; an integer restarts the stream each call.
 
     Returns:

--- a/gerrychain/partition/partition.py
+++ b/gerrychain/partition/partition.py
@@ -78,8 +78,8 @@ from __future__ import annotations
 
 import json
 import random
-from collections.abc import Callable, KeysView
-from typing import Any
+from collections.abc import Callable, Hashable, KeysView, Mapping
+from typing import TYPE_CHECKING, Any, TypeVar
 
 # frm:  Only used in _first_time() inside __init__() to allow for creating
 #       a Partition from a NetworkX Graph object:
@@ -87,6 +87,7 @@ from typing import Any
 #           elif isinstance(graph, networkx.Graph):
 #               graph = Graph.from_networkx(graph)
 #               self.graph = FrozenGraph(graph)
+import geopandas
 import networkx
 
 from gerrychain.graph.graph import FrozenGraph, Graph
@@ -96,6 +97,12 @@ from ..updaters import compute_edge_flows, cut_edges, flows_from_changes
 from .assignment import Assignment, get_assignment
 from .initial_partition_generators import recursive_tree_part
 from .subgraphs import SubgraphView
+
+if TYPE_CHECKING:
+    import matplotlib.axes
+
+NodeT = TypeVar("NodeT", bound=Hashable)
+PartT = TypeVar("PartT", bound=Hashable)
 
 
 class Partition:
@@ -137,8 +144,9 @@ class Partition:
     Attributes:
         graph (Graph): The underlying graph.
         assignment (Assignment): Maps node IDs to district IDs.
-        parts (Dict): Maps district IDs to the set of nodes in that district.
-        subgraphs (Dict): Maps district IDs to the induced subgraph of that district.
+        parts (dict[Hashable, frozenset[Hashable]]): Maps district IDs to the set of nodes in that
+            district.
+        subgraphs (SubgraphView): Maps district IDs to the induced subgraph of that district.
     """
 
     __slots__ = (
@@ -153,25 +161,44 @@ class Partition:
         "_cache",
     )
 
-    default_updaters = {"cut_edges": cut_edges}
+    graph: FrozenGraph
+    assignment: Assignment
+    updaters: dict[str, Callable[[Partition], Any]]
+    parent: Partition | None
+    flips: dict[Hashable, Hashable] | None
+    flows: dict[Hashable, dict[str, set[Hashable]]] | None
+    edge_flows: dict[Hashable, dict[str, set[tuple[int, int]]]] | None
+    _cache: dict[str, Any]
+
+    default_updaters: dict[str, Callable[[Partition], Any]] = {"cut_edges": cut_edges}
 
     def __init__(
         self,
-        graph: Graph | FrozenGraph | networkx.Graph | None = None,
-        assignment: dict | Assignment | str | None = None,
-        updaters: dict[str, Callable] | None = None,
+        graph: Graph
+        | FrozenGraph
+        | networkx.Graph[NodeT, dict[str, Any], dict[str, Any]]
+        | None = None,
+        assignment: Mapping[NodeT, PartT] | Assignment | str | None = None,
+        updaters: Mapping[str, Callable[[Partition], Any]] | None = None,
         parent: Partition | None = None,
-        flips: dict | None = None,
+        flips: Mapping[NodeT, PartT] | None = None,
         use_default_updaters: bool = True,
     ) -> None:
         """Initialize a Partition instance.
 
         Args:
-            graph (Any): Underlying graph.
-            assignment (Any): Dictionary assigning nodes to districts.
-            updaters (Any): Dictionary of functions to track data about the partition. The keys are
-                stored as attributes on the partition class, which the functions compute.
-            use_default_updaters (Any): If `False`, do not include default updaters.
+            graph (Graph | FrozenGraph | networkx.Graph | None, optional): Underlying graph.
+                Required for a root partition. Defaults to ``None``.
+            assignment (Mapping[Hashable, Hashable] | Assignment | str | None, optional): Node to
+                district assignment, or a node attribute containing it. Defaults to ``None``.
+            updaters (Mapping[str, Callable[[Partition], Any]] | None, optional): Named updater
+                functions. Their result types vary by updater. Defaults to ``None``.
+            parent (Partition | None, optional): Parent partition for a child. Defaults to
+                ``None``.
+            flips (Mapping[Hashable, Hashable] | None, optional): Reassignments relative to the
+                parent. Defaults to ``None``.
+            use_default_updaters (bool, optional): Whether to include default updaters. Defaults
+                to ``True``.
         """
 
         if parent is None:
@@ -180,9 +207,11 @@ class Partition:
 
             self._first_time(graph, assignment, updaters, use_default_updaters)
         else:
+            if flips is None:
+                raise TypeError("A child partition requires flips")
             self._from_parent(parent, flips)
 
-        self._cache = dict()
+        self._cache = {}
 
         # SubgraphView provides cached access to subgraphs for each of the
         # partition's districts.  It is important that we asign subgraphs AFTER
@@ -200,9 +229,9 @@ class Partition:
         n_parts: int,
         epsilon: float,
         pop_col: str,
-        updaters: dict[str, Callable] | None = None,
+        updaters: Mapping[str, Callable[[Partition], Any]] | None = None,
         use_default_updaters: bool = True,
-        method: Callable = recursive_tree_part,
+        method: Callable[..., dict[Hashable, Hashable]] = recursive_tree_part,
         *,
         rng: random.Random | int | None = None,
     ) -> Partition:
@@ -216,13 +245,13 @@ class Partition:
             n_parts (int): The number of districts to divide the nodes into.
             epsilon (float): The maximum relative population deviation from the ideal
             pop_col (str): The column of the graph's node data that holds the population data.
-            updaters (Optional[Dict[str, Callable]], optional): Dictionary of updaters
+            updaters (Mapping[str, Callable] | None, optional): Dictionary of updaters.
             use_default_updaters (bool, optional): If `False`, do not include default updaters.
             method (Callable, optional): The function to use to partition the graph into
                 ``n_parts``. The method is called with this method's normalized ``rng``, which
                 takes precedence over an ``rng`` partially bound to the ``method`` parameter.
                 Defaults to `gerrychain.tree.recursive_tree_part`.
-            rng (Union[random.Random, int, None], optional): Source of randomness. An integer
+            rng (random.Random | int | None, optional): Source of randomness. An integer
                 creates a reproducible RNG; ``None`` creates an independent RNG from system
                 entropy.
 
@@ -251,9 +280,9 @@ class Partition:
 
     def _first_time(
         self,
-        graph: Graph | FrozenGraph | networkx.Graph,
-        assignment: dict | Assignment | str | None,
-        updaters: dict[str, Callable] | None,
+        graph: Graph | FrozenGraph | networkx.Graph[NodeT, dict[str, Any], dict[str, Any]],
+        assignment: Mapping[NodeT, PartT] | Assignment | str | None,
+        updaters: Mapping[str, Callable[[Partition], Any]] | None,
         use_default_updaters: bool,
     ) -> None:
         # Make sure that the embedded graph for the Partition is based on
@@ -269,6 +298,9 @@ class Partition:
         # convert to RX - both for legacy compatibility, but also because NX provides
         # a really nice and easy way to create graphs.
         #
+
+        if assignment is None:
+            raise TypeError("A new partition requires an assignment")
 
         # If a NX.Graph, create a Graph object based on NX
         if isinstance(graph, networkx.Graph):
@@ -355,9 +387,9 @@ class Partition:
     #               That is, is there any reason why anyone might ever
     #               call this except __init__()?
 
-    def _from_parent(self, parent: Partition, flips: dict) -> None:
+    def _from_parent(self, parent: Partition, flips: Mapping[NodeT, PartT]) -> None:
         self.parent = parent
-        self.flips = flips
+        self.flips = {node: part for node, part in flips.items()}
 
         self.graph = parent.graph
         self.updaters = parent.updaters
@@ -379,7 +411,9 @@ class Partition:
         return len(self.parts)
 
     def flip(
-        self, flips: dict, flips_passed_in_use_original_nx_node_ids: bool = False
+        self,
+        flips: Mapping[NodeT, PartT],
+        flips_passed_in_use_original_nx_node_ids: bool = False,
     ) -> Partition:
         """Returns the new partition obtained by performing the given `flips` on this partition.
 
@@ -387,7 +421,7 @@ class Partition:
         partition. It returns new Partition.
 
         Args:
-            flips (Dict): dictionary assigning nodes of the graph to their new districts
+            flips (dict): dictionary assigning nodes of the graph to their new districts
             flips_passed_in_use_original_nx_node_ids (bool): Denotes whether the node_ids in the
                 flips are original NX node_ids or whether they are internal RX node_ids. The only
                 time this is set to True is for testing when the test wants to provide explicit
@@ -409,14 +443,14 @@ class Partition:
 
         return self.__class__(parent=self, flips=flips)
 
-    def crosses_parts(self, edge: tuple) -> bool:
+    def crosses_parts(self, edge: tuple[Hashable, Hashable]) -> bool:
         """Return True if the edge crosses from one part of the partition to another.
 
         This method returns True if the edge crosses from one part of the partition to another. It
         returns true if the edge crosses from one part of the partition to another.
 
         Args:
-            edge (Tuple): tuple of node IDs
+            edge (tuple): tuple of node IDs
 
         Returns:
             bool: True if the edge crosses from one part of the partition to another
@@ -484,10 +518,14 @@ class Partition:
         return self.updaters.keys()
 
     @property
-    def parts(self) -> dict:
+    def parts(self) -> dict[Hashable, frozenset[Hashable]]:
         return self.assignment.parts
 
-    def plot(self, geometries: object | None = None, **kwargs: object) -> object:
+    def plot(
+        self,
+        geometries: geopandas.GeoDataFrame | geopandas.GeoSeries | None = None,
+        **kwargs: Any,
+    ) -> "matplotlib.axes.Axes":
         #
         # frm ???:  I think that this plots districts on a map that is defined
         #           by the geometries parameter (presumably polygons or something similar).
@@ -507,19 +545,17 @@ class Partition:
                 GeoDataFrame or GeoSeries holding the
                 geometries to use for plotting. Its Index should match the node
                 labels of the partition's underlying Graph.
-            `**kwargs` (Any): Additional arguments to pass to `geopandas.GeoDataFrame.plot`
+            **kwargs (Any): Additional arguments to pass to `geopandas.GeoDataFrame.plot`
                 to adjust the plot.
 
         Returns:
             matplotlib.axes.Axes: The matplotlib axes object. Which plots the Partition.
         """
-        import geopandas
-
         if geometries is None:
-            if hasattr(self.graph, "geometry"):
-                geometries = self.graph.geometry
-            else:
+            graph_geometries = getattr(self.graph, "geometry", None)
+            if not isinstance(graph_geometries, (geopandas.GeoDataFrame, geopandas.GeoSeries)):
                 raise Exception("Partition.plot: graph has no geometry data")
+            geometries = graph_geometries
 
         if set(geometries.index) != self.graph.node_indices:
             raise TypeError("The provided geometries do not match the nodes of the graph.")
@@ -534,7 +570,7 @@ class Partition:
         cls,
         graph: Graph,
         districtr_file: str,
-        updaters: dict[str, Callable] | None = None,
+        updaters: Mapping[str, Callable[[Partition], Any]] | None = None,
     ) -> Partition:
         """Return partition created from the Districtr file.
 
@@ -552,7 +588,7 @@ class Partition:
         Args:
             graph (Graph): The graph to create the Partition from
             districtr_file (str): the path to the ``.json`` file exported from Districtr
-            updaters (Optional[Dict[str, Callable]], optional): dictionary of updaters
+            updaters (Mapping[str, Callable] | None, optional): Dictionary of updaters.
 
         Returns:
             Partition: The partition created from the Districtr file

--- a/gerrychain/partition/subgraphs.py
+++ b/gerrychain/partition/subgraphs.py
@@ -1,6 +1,6 @@
-from typing import Any, List, Tuple
+from collections.abc import Hashable, Iterable, Iterator, Mapping
 
-from ..graph import Graph
+from ..graph import FrozenGraph, Graph
 
 
 class SubgraphView:
@@ -13,47 +13,47 @@ class SubgraphView:
 
     Attributes:
         graph (Graph): The parent graph from which subgraphs are derived.
-        parts (List[List[Any]]): A list-of-lists dictionary (so a dict with key values indicated by
-            the list index) mapping keys to subsets of nodes in the graph.
-        subgraphs_cache (Dict): Cache to store subgraph views for quick access.
+        parts (Mapping[Hashable, Iterable[Hashable]]): Parts mapped to their nodes.
+        subgraphs_cache (dict[Hashable, Graph | FrozenGraph]): Cached subgraphs by part.
     """
 
     __slots__ = ["graph", "parts", "subgraphs_cache"]
 
-    def __init__(self, graph: Graph, parts: List[List[Any]]) -> None:
+    def __init__(
+        self, graph: Graph | FrozenGraph, parts: Mapping[Hashable, Iterable[Hashable]]
+    ) -> None:
         """Initialize a SubgraphView instance.
 
         Args:
-            graph (Graph): The parent graph from which subgraphs are derived.
-            parts (List[List[Any]]): A list of lists of nodes corresponding the different parts of
-                the partition of the graph.
+            graph (Graph | FrozenGraph): The parent graph from which subgraphs are derived.
+            parts (Mapping[Hashable, Iterable[Hashable]]): Parts mapped to their nodes.
 
         """
         self.graph = graph
         self.parts = parts
-        self.subgraphs_cache = {}
+        self.subgraphs_cache: dict[Hashable, Graph | FrozenGraph] = {}
 
-    def __getitem__(self, part: int) -> Graph:
+    def __getitem__(self, part: Hashable) -> Graph | FrozenGraph:
         """Return the item for the given key.
 
         This method returns the item for the given key. It returns subgraph of the parent graph
         corresponding to the partition with id `part`.
 
         Args:
-            part (int): The the id of the partition to return the subgraph for.
+            part (Hashable): The the id of the partition to return the subgraph for.
 
         Returns:
-            Graph: The subgraph of the parent graph corresponding to the partition with id `part`.
+            Graph | FrozenGraph: The subgraph corresponding to the part ID.
         """
         if part not in self.subgraphs_cache:
             self.subgraphs_cache[part] = self.graph.subgraph(self.parts[part])
         return self.subgraphs_cache[part]
 
-    def __iter__(self) -> Graph:
+    def __iter__(self) -> Iterator[Graph | FrozenGraph]:
         for part in self.parts:
             yield self[part]
 
-    def items(self) -> Tuple[int, Graph]:
+    def items(self) -> Iterator[tuple[Hashable, Graph | FrozenGraph]]:
         for part in self.parts:
             yield part, self[part]
 

--- a/gerrychain/proposals/proposals.py
+++ b/gerrychain/proposals/proposals.py
@@ -33,7 +33,7 @@ from ..partition import Partition
 # a new partition.
 #
 class ProposalFn(Protocol):
-    def __call__(self, x: Partition, *, rng: random.Random) -> Partition: ...
+    def __call__(self, partition: Partition, *, rng: random.Random) -> Partition: ...
 
 
 def propose_any_node_flip(
@@ -46,7 +46,7 @@ def propose_any_node_flip(
 
     Args:
         partition (Partition): The current partition to propose a flip from.
-        rng (Union[random.Random, int, None], optional): Source of randomness. Pass a shared
+        rng (random.Random | int | None, optional): Source of randomness. Pass a shared
             ``Random`` for repeated standalone calls; an integer restarts the stream each call.
 
     Returns:
@@ -75,7 +75,7 @@ def propose_flip_every_district(
 
     Args:
         partition (Partition): The current partition to propose the flips from.
-        rng (Union[random.Random, int, None], optional): Source of randomness. Pass a shared
+        rng (random.Random | int | None, optional): Source of randomness. Pass a shared
             ``Random`` for repeated standalone calls; an integer restarts the stream each call.
 
     Returns:
@@ -111,7 +111,7 @@ def propose_chunk_flip(
 
     Args:
         partition (Partition): The current partition to propose a flip from.
-        rng (Union[random.Random, int, None], optional): Source of randomness. Pass a shared
+        rng (random.Random | int | None, optional): Source of randomness. Pass a shared
             ``Random`` for repeated standalone calls; an integer restarts the stream each call.
 
     Returns:
@@ -152,7 +152,7 @@ def propose_random_flip(
 
     Args:
         partition (Partition): The current partition to propose a flip from.
-        rng (Union[random.Random, int, None], optional): Source of randomness. Pass a shared
+        rng (random.Random | int | None, optional): Source of randomness. Pass a shared
             ``Random`` for repeated standalone calls; an integer restarts the stream each call.
 
     Returns:
@@ -184,7 +184,7 @@ def slow_reversible_propose_bi(
 
     Args:
         partition (Partition): The current partition to propose a flip from.
-        rng (Union[random.Random, int, None], optional): Source of randomness. Pass a shared
+        rng (random.Random | int | None, optional): Source of randomness. Pass a shared
             ``Random`` for repeated standalone calls; an integer restarts the stream each call.
 
     Returns:
@@ -223,7 +223,7 @@ def slow_reversible_propose(
 
     Args:
         partition (Partition): The current partition to propose a flip from.
-        rng (Union[random.Random, int, None], optional): Source of randomness. Pass a shared
+        rng (random.Random | int | None, optional): Source of randomness. Pass a shared
             ``Random`` for repeated standalone calls; an integer restarts the stream each call.
 
     Returns:

--- a/gerrychain/proposals/spectral_proposals.py
+++ b/gerrychain/proposals/spectral_proposals.py
@@ -1,24 +1,25 @@
 import random
+from collections.abc import Hashable, Sequence
 from functools import partial
-from typing import Dict, Optional
+from typing import cast
 
 from numpy import linalg as LA
 
 from .._rng import make_rng
-from ..graph import Graph
+from ..graph import FrozenGraph, Graph
 from ..partition import Partition
 from ..proposals import ProposalFn
 
 
 # frm: only ever used in this file - but maybe it is used externally?
 def spectral_cut(
-    subgraph: Graph,
-    part_labels: Dict,
-    weight_type: str,
+    subgraph: Graph | FrozenGraph,
+    part_labels: Sequence[Hashable],
+    weight_type: str | None,
     lap_type: str,
     *,
     rng: random.Random | int | None = None,
-) -> Dict:
+) -> dict[Hashable, Hashable]:
     """Spectral cut function.
 
     Original templates and work from Daryl DeFord:
@@ -31,14 +32,15 @@ def spectral_cut(
 
     Args:
         subgraph (Graph): The subgraph to be partitioned.
-        part_labels (Dict): The current partition of the subgraph.
-        weight_type (str): The type of weight to be used in the Laplacian.
+        part_labels (Sequence[Hashable]): The current partition of the subgraph.
+        weight_type (str | None): The type of weight to be used in the Laplacian.
         lap_type (str): The type of Laplacian to be used.
-        rng (Union[random.Random, int, None], optional): Source of randomness. Pass a shared
+        rng (random.Random | int | None, optional): Source of randomness. Pass a shared
             ``Random`` for repeated standalone calls; an integer restarts the stream each call.
 
     Returns:
-        Dict: A dictionary assigning nodes of the subgraph to their new districts.
+        dict[Hashable, Hashable]: A dictionary assigning nodes of the subgraph to their new
+            districts.
     """
 
     rng = make_rng(rng)
@@ -104,7 +106,7 @@ def spectral_cut(
 # frm: only ever used in this file - but maybe it is used externally?
 def spectral_recom(
     partition: Partition,
-    weight_type: Optional[str] = None,
+    weight_type: str | None = None,
     lap_type: str = "normalized",
     *,
     rng: random.Random | int | None = None,
@@ -127,10 +129,10 @@ def spectral_recom(
 
     Args:
         partition (Partition): The initial partition.
-        weight_type (Optional[str], optional): The type of weight to be used in the Laplacian.
+        weight_type (str | None, optional): The type of weight to be used in the Laplacian.
             Default is None.
         lap_type (str, optional): The type of Laplacian to be used. Default is "normalized".
-        rng (Union[random.Random, int, None], optional): Source of randomness. Pass a shared
+        rng (random.Random | int | None, optional): Source of randomness. Pass a shared
             ``Random`` for repeated standalone calls; an integer restarts the stream each call.
 
     Returns:
@@ -164,8 +166,8 @@ def spectral_recom(
 
 # Define a ProposalFn version to make purpose of the function clear
 def build_spectral_recom_proposal_fn(
-    weight_type: Optional[str] = None,
+    weight_type: str | None = None,
     lap_type: str = "normalized",
 ) -> ProposalFn:
     proposal_fn = partial(spectral_recom, weight_type=weight_type, lap_type=lap_type)
-    return proposal_fn
+    return cast(ProposalFn, proposal_fn)

--- a/gerrychain/proposals/tree_proposals.py
+++ b/gerrychain/proposals/tree_proposals.py
@@ -1,13 +1,13 @@
 import random
-from collections.abc import Callable, Hashable, Sequence
+from collections.abc import Callable, Hashable, Sequence, Set as AbstractSet
 from functools import partial
+from typing import cast
 
 from gerrychain._rng import make_rng
 from gerrychain.partition import Partition
 
-from ..graph import Graph
+from ..graph import FrozenGraph, Graph
 from ..tree import (  # epsilon_tree_bipartition,
-    BalanceError,
     PopulationBalanceError,
     ReselectException,
     bipartition_tree,
@@ -44,22 +44,25 @@ class ValueWarning(UserWarning):
 
 
 def epsilon_tree_bipartition(
-    subgraph_to_split: Graph,
-    parts: Sequence,
+    subgraph_to_split: Graph | FrozenGraph,
+    parts: Sequence[Hashable],
     pop_target: float | int,
     pop_col: str,
     epsilon: float,
     node_repeats: int = 0,
-    bipartition_tree_fn: Callable = partial(bipartition_tree, max_attempts=100000),
+    bipartition_tree_fn: Callable[..., AbstractSet[Hashable]] = partial(
+        bipartition_tree, max_attempts=100000
+    ),
     *,
     rng: random.Random,
-) -> dict:
+) -> dict[Hashable, Hashable]:
     """Bipartition a tree into two :math:`\\varepsilon`-balanced parts.
 
     Args:
-        graph (Graph): The graph to partition into two :math:`\\varepsilon`-balanced parts.
+        subgraph_to_split (Graph | FrozenGraph): The graph to partition into two
+            :math:`\\varepsilon`-balanced parts.
         parts (Sequence): Iterable of part (district) labels (like ``[0,1,2]`` or ``range(4)``).
-        pop_target (Union[float, int]): Target population for each part of the partition.
+        pop_target (float | int): Target population for each part of the partition.
         pop_col (str): Node attribute key holding population data.
         epsilon (float): How far (as a percentage of ``pop_target``) from ``pop_target`` the parts
             of the partition can be.
@@ -95,9 +98,6 @@ def epsilon_tree_bipartition(
         one_sided_cut=False,
         rng=rng,
     )
-
-    if nodes is None:
-        raise BalanceError()
 
     # Calculate the total population for the two districts based on the
     # results of the "bipartition_tree_fn()" partitioning.
@@ -135,8 +135,8 @@ def recom(
     pop_target: int | float,
     epsilon: float,
     node_repeats: int = 0,
-    region_surcharge: dict | None = None,
-    bipartition_tree_fn: Callable = bipartition_tree,
+    region_surcharge: dict[str, float] | None = None,
+    bipartition_tree_fn: Callable[..., AbstractSet[Hashable]] = bipartition_tree,
     *,
     rng: random.Random | int | None = None,
 ) -> Partition:
@@ -166,20 +166,20 @@ def recom(
     Args:
         partition (Partition): The initial partition.
         pop_col (str): The name of the population column.
-        pop_target (Union[int,float]): The target population for each district.
+        pop_target (int | float): The target population for each district.
         epsilon (float): The epsilon value for population deviation as a percentage of the target
             population.
         node_repeats (int, optional): Additional roots to try on each spanning tree before
             drawing a new tree. Defaults to 0. Positive values are useful with contraction or
             custom cut-edge finders, but not with the default memoized finder.
-        region_surcharge (Optional[Dict], optional): The surcharge dictionary for the graph used
+        region_surcharge (dict | None, optional): The surcharge dictionary for the graph used
             for region-aware partitioning of the grid. Default is None.
         bipartition_tree_fn (Callable, optional): The method used for bipartitioning the tree.
             Default is `gerrychain.tree.bipartition_tree`. To configure the bipartition or
             spanning-tree step (e.g. ``max_attempts``, or ``spanning_tree_fn_kwargs`` for
             spanning-tree options), pass a pre-bound function, e.g.
             ``partial(bipartition_tree, spanning_tree_fn_kwargs={...})``.
-        rng (Union[random.Random, int, None], optional): Source of randomness. Pass a shared
+        rng (random.Random | int | None, optional): Source of randomness. Pass a shared
             ``Random`` for repeated standalone calls; an integer restarts the stream each call.
 
     Returns:
@@ -263,8 +263,8 @@ def build_recom_proposal_fn(
     pop_target: int | float,
     epsilon: float,
     node_repeats: int = 0,
-    region_surcharge: dict | None = None,
-    bipartition_tree_fn: Callable = bipartition_tree,
+    region_surcharge: dict[str, float] | None = None,
+    bipartition_tree_fn: Callable[..., AbstractSet[Hashable]] = bipartition_tree,
 ) -> ProposalFn:
     proposal_fn = partial(
         recom,
@@ -275,7 +275,7 @@ def build_recom_proposal_fn(
         region_surcharge=region_surcharge,
         bipartition_tree_fn=bipartition_tree_fn,
     )
-    return proposal_fn
+    return cast(ProposalFn, proposal_fn)
 
 
 def reversible_recom(
@@ -299,15 +299,16 @@ def reversible_recom(
     Args:
         partition (Partition): The initial partition.
         pop_col (str): The name of the population column.
-        pop_target (Union[int,float]): The target population for each district.
+        pop_target (int | float): The target population for each district.
         epsilon (float): The epsilon value for population deviation as a percentage of the target
             population.
+        max_balanced_edge_cuts (int): The number of balanced edge cuts to draw from the spanning
+            tree before selecting one, used to make the proposal reversible.
         find_balanced_edge_cuts_fn (Callable, optional): The balance edge function. Default is
             find_balanced_edge_cuts_memoization.
-        M (int, optional): The maximum number of balance edges. Default is 1.
         repeat_until_valid (bool, optional): Flag indicating whether to repeat until a valid
             partition is found. Default is False.
-        rng (Union[random.Random, int, None], optional): Source of randomness. Pass a shared
+        rng (random.Random | int | None, optional): Source of randomness. Pass a shared
             ``Random`` for repeated standalone calls; an integer restarts the stream each call.
 
     Returns:
@@ -332,7 +333,7 @@ def reversible_recom(
     def _bounded_find_balanced_edge_cuts_fn(
         h: _PopulatedGraph,
         one_sided_cut: bool = False,
-        rootnode_choice_fn: Callable | None = None,
+        rootnode_choice_fn: Callable[[Sequence[Hashable]], Hashable] | None = None,
         *,
         rng: random.Random,
     ) -> list[_Cut]:
@@ -457,7 +458,7 @@ def build_reversible_recom_proposal_fn(
         find_balanced_edge_cuts_fn=find_balanced_edge_cuts_fn,
         repeat_until_valid=repeat_until_valid,
     )
-    return proposal_fn
+    return cast(ProposalFn, proposal_fn)
 
 
 # frm TODO: Refactoring:  Finish making class ReCom useful...
@@ -583,10 +584,10 @@ def build_reversible_recom_proposal_fn(
 #         def std_recom_proposal(
 #             partition: Partition,
 #             pop_col: str,
-#             pop_target: Union[int, float],
+#             pop_target: int | float,
 #             epsilon: float,
 #             node_repeats: int = 1,
-#             region_surcharge: Optional[Dict] = None,
+#             region_surcharge: dict[str, float] | None = None,
 #             bipartition_tree_fn: Callable = bipartition_tree,
 #         ) -> Partition:
 #             new_proposal = partial(
@@ -634,10 +635,10 @@ def build_reversible_recom_proposal_fn(
 #         def generate_std_recom_proposal(
 #             partition: Partition,
 #             pop_col: str,
-#             pop_target: Union[int, float],
+#             pop_target: int | float,
 #             epsilon: float,
 #             node_repeats: int = 1,
-#             region_surcharge: Optional[Dict] = None,
+#             region_surcharge: dict[str, float] | None = None,
 #             bipartition_tree_fn: Callable = bipartition_tree,
 #         ) -> ProposalFn:
 #             new_proposal = partial(
@@ -677,14 +678,14 @@ class ReCom:
         pop_col: str,
         ideal_pop: int | float,
         epsilon: float,
-        bipartition_tree_fn: Callable = bipartition_tree,
+        bipartition_tree_fn: Callable[..., AbstractSet[Hashable]] = bipartition_tree,
     ) -> None:
         """Initialize a ReCom instance.
 
         Args:
             pop_col (str): The name of the column in the partition that contains the population
                 data.
-            ideal_pop (Union[int,float]): The ideal population for each district.
+            ideal_pop (int | float): The ideal population for each district.
             epsilon (float): The epsilon value for population deviation as a percentage of the
                 target population.
             bipartition_tree_fn (function, optional): The method used for bipartitioning the tree.

--- a/gerrychain/py.typed
+++ b/gerrychain/py.typed
@@ -1,0 +1,1 @@
+# Marker file for PEP 561.

--- a/gerrychain/tree/bipartition_tree.py
+++ b/gerrychain/tree/bipartition_tree.py
@@ -28,14 +28,14 @@ Dependencies:
 import itertools
 import random
 import warnings
-from collections import deque, namedtuple
-from collections.abc import Callable
+from collections import deque
+from collections.abc import Callable, Hashable, Sequence, Set as AbstractSet
 from functools import partial
 from inspect import signature
-from typing import Any, Protocol
+from typing import NamedTuple, Protocol
 
 from .._rng import make_rng
-from ..graph import Graph
+from ..graph import FrozenGraph, Graph
 from .spanning_tree import random_spanning_tree
 
 
@@ -105,6 +105,10 @@ on NetworkX (and RustworkX) from this module.
 """
 
 
+GraphLike = Graph | FrozenGraph
+SpanningTreeFn = Callable[..., Graph]
+
+
 class _PopulatedGraph:
     """
     A class representing a graph with population information.  It is used by
@@ -113,11 +117,11 @@ class _PopulatedGraph:
 
     Attributes:
         graph (Graph): The underlying graph structure.
-        subsets (Dict): A dictionary mapping nodes to their subsets.  This is used
+        subsets (dict): A dictionary mapping nodes to their subsets.  This is used
             as a way to accumulate nodes that "belong together", so it is kind of
             a scratchpad for nodes that hopefully will become a district.
-        population (Dict): A dictionary mapping nodes to the population of the node.
-        tot_pop (Union[int, float]): The total population of the graph.
+        population (dict): A dictionary mapping nodes to the population of the node.
+        tot_pop (int | float): The total population of the graph.
         ideal_pop (float): The ideal population for each district.
         epsilon (float): The tolerance for population deviation from the ideal population within
         each
@@ -126,8 +130,8 @@ class _PopulatedGraph:
 
     def __init__(
         self,
-        graph: Graph,
-        populations: dict,
+        graph: GraphLike,
+        populations: dict[Hashable, int | float],
         ideal_pop: int | float,
         epsilon: float,
     ) -> None:
@@ -135,8 +139,8 @@ class _PopulatedGraph:
 
         Args:
             graph (Graph): The underlying graph structure.
-            populations (Dict): A dictionary mapping nodes to their populations.
-            ideal_pop (Union[int, float]): The ideal population for each district.
+            populations (dict): A dictionary mapping nodes to their populations.
+            ideal_pop (int | float): The ideal population for each district.
             epsilon (float): The tolerance for population deviation as a percentage of the ideal
                 population within each district.
 
@@ -152,25 +156,10 @@ class _PopulatedGraph:
         # when a node is "contracted" - see _contract_node() below.
         self._degrees = {node_id: graph.degree(node_id) for node_id in graph.node_indices}
 
-    def __iter__(self) -> None:
-        # Note: in the pre RustworkX code, this was implemented as:
-        #
-        #     return iter(self.graph)
-        #
-        # But RustworkX does not support __iter__() - it is not iterable.
-        #
-        # The way to do this in the new RustworkX based code is to use
-        # the node_indices() method which is accessed as a property as in:
-        #
-        #     for node_id in graph.node_indices:
-        #         ...do something with the node_id
-        #
-        raise NotImplementedError("Graph is not iterable - use graph.node_indices instead")
-
-    def degree(self, node: Any) -> int:
+    def degree(self, node: Hashable) -> int:
         return self._degrees[node]
 
-    def _contract_node(self, node: Any, parent: Any) -> None:
+    def _contract_node(self, node: Hashable, parent: Hashable) -> None:
         # Merge the population and the subset of nodes from "self"
         # into the parent node, and reduce the degrees of the parent
         # indicating that the "self" node is no longer in the tree.
@@ -180,11 +169,11 @@ class _PopulatedGraph:
 
     # frm: only ever used inside this file
     #       But maybe this is intended to be used externally...
-    def has_ideal_population(self, node: Any, one_sided_cut: bool = False) -> bool:
+    def has_ideal_population(self, node: Hashable, one_sided_cut: bool = False) -> bool:
         """Checks if a merged node is within epsilon of the ideal population.
 
         Args:
-            node (Any): The node to check.
+            node (Hashable): The node to check.
             one_sided_cut (bool, optional): Whether or not we are cutting off a single district.
                 When set to False, we check if the node we are cutting and the remaining graph are
                 both within epsilon of the ideal population. When set to True, we only check if the
@@ -232,12 +221,12 @@ class _PopulatedGraph:
 #
 # Note that a _Cut object is only ever used inside this file.
 #
-_Cut = namedtuple("_Cut", "edge weight subset")
-_Cut.__new__.__defaults__ = (None, None, None)
-_Cut.__doc__ = "Represents a cut in a graph."
-_Cut.edge.__doc__ = "The edge where the cut is made. Defaults to None."
-_Cut.weight.__doc__ = "The weight assigned to the edge (if any). Defaults to None."
-_Cut.subset.__doc__ = "The (frozen) subset of nodes on one side of the cut. Defaults to None."
+class _Cut(NamedTuple):
+    """A candidate edge cut and the nodes on one side of it."""
+
+    edge: tuple[Hashable, Hashable]
+    weight: float
+    subset: frozenset[Hashable]
 
 
 # Define an interface for find_balanced_edge_cut functions
@@ -252,36 +241,15 @@ class FindBalancedEdgeCutsFn(Protocol):
         self,
         h: _PopulatedGraph,
         one_sided_cut: bool = False,
-        rootnode_choice_fn: Callable | None = None,
+        rootnode_choice_fn: Callable[[Sequence[Hashable]], Hashable] | None = None,
         *,
         rng: random.Random,
     ) -> list[_Cut]: ...
 
 
-class SpanningTreeFn(Protocol):
-    """Call signature shared by all spanning-tree functions.
-
-    A spanning-tree function (``random_spanning_tree``, ``uniform_spanning_tree``, or a custom
-    replacement) takes the graph to build a tree from and an optional ``region_surcharge``, and may
-    accept additional, function-specific keyword options. ``bipartition_tree`` forwards those extra
-    options verbatim from its ``spanning_tree_fn_kwargs`` argument, so a custom spanning-tree
-    function can expose its own knobs (e.g. ``random_spanning_tree``'s
-    ``treat_unassigned_as_single_region``) without any change to the bipartition/recom plumbing.
-    """
-
-    def __call__(
-        self,
-        graph: Graph,
-        region_surcharge: dict | None = None,
-        *,
-        rng: random.Random,
-        **kwargs: Any,
-    ) -> Graph: ...
-
-
 def _bfs_predecessors_and_successors_for_tree(
-    tree: Graph, root: Any, build_successors: bool = False
-) -> tuple[dict[Any, Any], dict[Any, list[Any]] | None]:
+    tree: GraphLike, root: Hashable, build_successors: bool = False
+) -> tuple[dict[Hashable, Hashable], dict[Hashable, list[Hashable]] | None]:
     """Return ``(pred, succ)`` parent/child maps for the tree ``graph`` rooted at ``root``.
 
     ``pred`` maps every non-root node to its parent (the neighbor on the path toward
@@ -301,18 +269,18 @@ def _bfs_predecessors_and_successors_for_tree(
 
     Args:
         tree (Graph): The tree for which to compute predecessors and successors.
-        root (Any): The root node of the tree.
+        root (Hashable): The root node of the tree.
         build_successors (bool, optional): Whether to build the successors map. Defaults to False.
 
     Returns:
-        Tuple[Dict[Any, Any], Dict[Any, List[Any]] | None]: A tuple containing the predecessors
+        tuple[dict[Hashable, Hashable], dict[Hashable, list[Hashable]] | None]: A tuple containing the predecessors
         map and the successors map (or None if not built).
     """
     # TODO: Technically, you can run this on a graph and it should be fine, but there is an implicit
     # assumption that the passed graph is a tree, and we should probably check this somewhere
     # if there is a cheap way to do it.
-    pred: dict[Any, Any] = {}
-    succ: dict[Any, list[Any]] | None = {} if build_successors else None
+    pred: dict[Hashable, Hashable] = {}
+    succ: dict[Hashable, list[Hashable]] | None = {} if build_successors else None
     seen = {root}
     queue = deque([root])
     while queue:
@@ -324,6 +292,7 @@ def _bfs_predecessors_and_successors_for_tree(
                 pred[neighbor] = node
                 queue.append(neighbor)
                 if build_successors:
+                    assert succ is not None
                     if children is None:
                         children = succ[node] = []
                     children.append(neighbor)
@@ -333,7 +302,7 @@ def _bfs_predecessors_and_successors_for_tree(
 def find_balanced_edge_cuts_contraction(
     h: _PopulatedGraph,
     one_sided_cut: bool = False,
-    rootnode_choice_fn: Callable | None = None,
+    rootnode_choice_fn: Callable[[Sequence[Hashable]], Hashable] | None = None,
     *,
     rng: random.Random | int | None = None,
 ) -> list[_Cut]:
@@ -346,13 +315,13 @@ def find_balanced_edge_cuts_contraction(
             set to False, we check if the node we are cutting and the remaining graph are both
             within epsilon of the ideal population. When set to True, we only check if the node we
             are cutting is within epsilon of the ideal population. Defaults to False.
-        rootnode_choice_fn (Optional[Callable]): The function used to select the root node_id.
+        rootnode_choice_fn (Callable | None): The function used to select the root node_id.
             Defaults to the supplied RNG's ``choice``.
-        rng (Union[random.Random, int, None], optional): Source of randomness. Pass a shared
+        rng (random.Random | int | None, optional): Source of randomness. Pass a shared
             ``Random`` for repeated standalone calls; an integer restarts the stream each call.
 
     Returns:
-        List[_Cut]: A list of balanced edge cuts.
+        list[_Cut]: A list of balanced edge cuts.
     """
     rng = make_rng(rng)
     if rootnode_choice_fn is None:
@@ -412,16 +381,18 @@ def find_balanced_edge_cuts_contraction(
     return cuts
 
 
-def _calc_pops(succ: dict[Any, list[Any]], root: Any, h: _PopulatedGraph) -> dict[Any, int | float]:
+def _calc_pops(
+    succ: dict[Hashable, list[Hashable]], root: Hashable, h: _PopulatedGraph
+) -> dict[Hashable, int | float]:
     """Return A dictionary mapping nodes to their subtree populations.
 
     Args:
-        succ (Dict): The successors of the graph.
-        root (Any): The root node of the graph.
+        succ (dict): The successors of the graph.
+        root (Hashable): The root node of the graph.
         h (_PopulatedGraph): The populated graph.
 
     Returns:
-        Dict: A dictionary mapping nodes to their subtree populations.
+        dict: A dictionary mapping nodes to their subtree populations.
     """
     # frm:  This took me a while to sort out what was going on.
     # Conceptually it is easy - given a tree anchored in a root node,
@@ -435,7 +406,7 @@ def _calc_pops(succ: dict[Any, list[Any]], root: Any, h: _PopulatedGraph) -> dic
     # For this to work, you just need to have a list of nodes with
     # their successors associated with them...
     #
-    subtree_pops: dict[Any, int | float] = {}
+    subtree_pops: dict[Hashable, int | float] = {}
     stack = deque(n for n in succ[root])
     while stack:
         next_node = stack.pop()
@@ -456,16 +427,16 @@ def _calc_pops(succ: dict[Any, list[Any]], root: Any, h: _PopulatedGraph) -> dic
     return subtree_pops
 
 
-def _nodes_in_subtree(start: Any, succ: dict[Any, list[Any]]) -> set[Any]:
+def _nodes_in_subtree(start: Hashable, succ: dict[Hashable, list[Hashable]]) -> set[Hashable]:
     """
     Collects the nodes in a subtree that are rooted in the "start" node.
 
     Args:
-        start (Any): The start node.
-        succ (Dict): The successors of the graph.
+        start (Hashable): The start node.
+        succ (dict): The successors of the graph.
 
     Returns:
-        Set: A set of nodes for a particular district (only one side of the cut).
+        set: A set of nodes for a particular district (only one side of the cut).
     """
 
     """
@@ -513,7 +484,7 @@ def _nodes_in_subtree(start: Any, succ: dict[Any, list[Any]]) -> set[Any]:
 def find_balanced_edge_cuts_memoization(
     h: _PopulatedGraph,
     one_sided_cut: bool = False,
-    rootnode_choice_fn: Callable | None = None,
+    rootnode_choice_fn: Callable[[Sequence[Hashable]], Hashable] | None = None,
     *,
     rng: random.Random | int | None = None,
 ) -> list[_Cut]:
@@ -530,13 +501,13 @@ def find_balanced_edge_cuts_memoization(
             set to False, we check if the node we are cutting and the remaining graph are both
             within epsilon of the ideal population. When set to True, we only check if the node we
             are cutting is within epsilon of the ideal population. Defaults to False.
-        rootnode_choice_fn (Optional[Callable]): The choice function used to select the root
+        rootnode_choice_fn (Callable | None): The choice function used to select the root
             node_id. Defaults to the supplied RNG's ``choice``.
-        rng (Union[random.Random, int, None], optional): Source of randomness. Pass a shared
+        rng (random.Random | int | None, optional): Source of randomness. Pass a shared
             ``Random`` for repeated standalone calls; an integer restarts the stream each call.
 
     Returns:
-        List[_Cut]: A list of balanced edge cuts.
+        list[_Cut]: A list of balanced edge cuts.
     """
 
     """
@@ -575,6 +546,7 @@ def find_balanced_edge_cuts_memoization(
     # unique parent, so `pred` is identical to the old map; the order of children within
     # succ[node] may differ, which does not affect the set of cuts found.
     pred, succ = _bfs_predecessors_and_successors_for_tree(h.graph, root, build_successors=True)
+    assert succ is not None
     total_pop = h.tot_pop
 
     # Calculate the population of each subtree in the "succ" tree
@@ -676,8 +648,9 @@ def _max_weight_choice(cut_edge_list: list[_Cut], *, rng: random.Random) -> _Cut
     make the weight assigned to a particular type of cut higher than another.
 
     Args:
-        cut_edge_list (List[_Cut]): A list of _Cut objects. Each object has an edge, a weight, and a
+        cut_edge_list (list[_Cut]): A list of _Cut objects. Each object has an edge, a weight, and a
             subset attribute.
+        rng (random.Random): Random number generator used for fallback selection.
 
     Returns:
         _Cut: The cut with the highest random weight.
@@ -702,14 +675,16 @@ def _random_choice(cut_edge_list: list[_Cut], *, rng: random.Random) -> _Cut:
     return rng.choice(cut_edge_list)
 
 
-def _power_set_sorted_by_size_then_sum(region_surcharge_dict: dict) -> list[tuple[Any, ...]]:
+def _power_set_sorted_by_size_then_sum(
+    region_surcharge_dict: dict[str, float],
+) -> list[tuple[str, ...]]:
     """Power set sorted by size then sum.
 
     This function computes the power set of regions that are listed in the region_surcharge_dict,.
     and then sorts that power set by size and then sum.
 
     Args:
-        region_surcharge_dict (Dict): Description
+        region_surcharge_dict (dict): Description
     """
     num_regions = len(region_surcharge_dict)
     power_set = [
@@ -734,7 +709,7 @@ def _power_set_sorted_by_size_then_sum(region_surcharge_dict: dict) -> list[tupl
 def _region_preferred_max_weight_choice(
     cut_edge_list: list[_Cut],
     populated_graph: _PopulatedGraph,
-    region_surcharge: dict,
+    region_surcharge: dict[str, float],
     *,
     rng: random.Random,
 ) -> _Cut:
@@ -760,9 +735,10 @@ def _region_preferred_max_weight_choice(
 
     Args:
         populated_graph (_PopulatedGraph): The populated graph.
-        region_surcharge (Dict): A dictionary of surcharges for the spanning tree algorithm.
-        cut_edge_list (List[_Cut]): A list of _Cut objects. Each object has an edge, a weight, and a
+        region_surcharge (dict): A dictionary of surcharges for the spanning tree algorithm.
+        cut_edge_list (list[_Cut]): A list of _Cut objects. Each object has an edge, a weight, and a
             subset attribute.
+        rng (random.Random): Random number generator used for selection.
 
     Returns:
         _Cut: A random _Cut from the set of possible _Cuts with the highest surcharge.
@@ -828,26 +804,26 @@ def _region_preferred_max_weight_choice(
 
 
 def _internal_bipartition_tree(
-    subgraph_to_split: Graph,
+    subgraph_to_split: GraphLike,
     pop_col: str,
     pop_target: int | float,
     epsilon: float,
     node_repeats: int = 0,
-    spanning_tree: Graph | None = None,
+    spanning_tree: GraphLike | None = None,
     spanning_tree_fn: SpanningTreeFn = random_spanning_tree,
-    region_surcharge: dict | None = None,
-    spanning_tree_fn_kwargs: dict | None = None,
-    find_balanced_edge_cuts_fn: Callable = find_balanced_edge_cuts_memoization,
+    region_surcharge: dict[str, float] | None = None,
+    spanning_tree_fn_kwargs: dict[str, object] | None = None,
+    find_balanced_edge_cuts_fn: Callable[..., list[_Cut]] = find_balanced_edge_cuts_memoization,
     one_sided_cut: bool = False,
-    rootnode_choice_fn: Callable | None = None,
+    rootnode_choice_fn: Callable[[Sequence[Hashable]], Hashable] | None = None,
     max_attempts: int = 100000,
     warn_attempts: int = 1000,
     allow_pair_reselection: bool = False,
     repeat_until_valid: bool = True,  # frm: TODO: Have this NOT default...
-    cut_choice_fn: Callable = _region_preferred_max_weight_choice,
+    cut_choice_fn: Callable[..., _Cut] = _region_preferred_max_weight_choice,
     *,
     rng: random.Random,
-) -> set[Any] | None:
+) -> tuple[int, AbstractSet[Hashable]]:
     """Find a population-balanced connected subset of nodes.
 
     The returned subset induces a connected subgraph, and its complement forms the other part of
@@ -863,21 +839,21 @@ def _internal_bipartition_tree(
     pop_target`` away from ``pop_target``.
 
     Args:
-        graph (Graph): The graph to partition.
+        subgraph_to_split (Graph | FrozenGraph): The graph to partition.
         pop_col (str): The node attribute holding the population of each node.
-        pop_target (Union[int, float]): The target population for the returned subset of nodes.
+        pop_target (int | float): The target population for the returned subset of nodes.
         epsilon (float): The allowable deviation from ``pop_target`` (as a percentage of
             ``pop_target``) for the subgraph's population.
         node_repeats (int, optional): Additional roots to try on each spanning tree before
             drawing a new tree. Defaults to 0. Positive values are useful with contraction or
             custom cut-edge finders, but not with the default memoized finder.
-        spanning_tree (Optional[Graph], optional): The spanning tree for the algorithm to use (used
+        spanning_tree (Graph | None, optional): The spanning tree for the algorithm to use (used
             when the algorithm chooses a new root and for testing).
         spanning_tree_fn (Callable, optional): The random spanning tree algorithm to use if a
             spanning tree is not provided. Defaults to `random_spanning_tree`.
-        region_surcharge (Optional[Dict], optional): A dictionary of surcharges for the spanning
+        region_surcharge (dict | None, optional): A dictionary of surcharges for the spanning
             tree algorithm. Defaults to None.
-        spanning_tree_fn_kwargs (Optional[Dict], optional): Extra keyword arguments forwarded
+        spanning_tree_fn_kwargs (dict | None, optional): Extra keyword arguments forwarded
             verbatim to ``spanning_tree_fn``. Use this to set function-specific options that are
             not named here, e.g. ``{"treat_unassigned_as_single_region": True}`` for
             ``random_spanning_tree``. Defaults to None.
@@ -888,7 +864,9 @@ def _internal_bipartition_tree(
             set to False, we check if the node we are cutting and the remaining graph are both
             within epsilon of the ideal population. When set to True, we only check if the node we
             are cutting is within epsilon of the ideal population. Defaults to False.
-        rootnode_choice_fn (Optional[Callable]): The function to make a random choice of root node
+        repeat_until_valid (bool, optional): Whether to keep drawing trees until a valid cut is
+            found. Defaults to ``True``.
+        rootnode_choice_fn (Callable | None): The function to make a random choice of root node
             for the population tree. Passed to ``find_balanced_edge_cuts_fn``. Can be substituted
             for testing. Defaults to the supplied RNG's ``choice``.
         max_attempts (int): The maximum number of attempts that should be made
@@ -906,8 +884,8 @@ def _internal_bipartition_tree(
         rng (random.Random): The RNG supplied by the owning operation.
 
     Returns:
-        Set: A subset of nodes of ``graph`` (whose induced subgraph is connected). The other part
-            of the partition is the complement of this subset.
+        tuple[int, AbstractSet[Hashable]]: The number of possible cuts and the selected connected
+            subset of nodes.
 
     Raises:
         BipartitionWarning: If a possible cut cannot be found after 1000 attempts.
@@ -1029,26 +1007,26 @@ def _internal_bipartition_tree(
 
 
 def bipartition_tree(
-    subgraph_to_split: Graph,
+    subgraph_to_split: GraphLike,
     pop_col: str,
     pop_target: int | float,
     epsilon: float,
     node_repeats: int = 0,
-    spanning_tree: Graph | None = None,
+    spanning_tree: GraphLike | None = None,
     spanning_tree_fn: SpanningTreeFn = random_spanning_tree,
-    region_surcharge: dict | None = None,
-    spanning_tree_fn_kwargs: dict | None = None,
-    find_balanced_edge_cuts_fn: Callable = find_balanced_edge_cuts_memoization,
+    region_surcharge: dict[str, float] | None = None,
+    spanning_tree_fn_kwargs: dict[str, object] | None = None,
+    find_balanced_edge_cuts_fn: Callable[..., list[_Cut]] = find_balanced_edge_cuts_memoization,
     one_sided_cut: bool = False,
-    rootnode_choice_fn: Callable | None = None,
+    rootnode_choice_fn: Callable[[Sequence[Hashable]], Hashable] | None = None,
     repeat_until_valid: bool = True,
-    max_attempts: int | None = 100000,
+    max_attempts: int = 100000,
     warn_attempts: int = 1000,
     allow_pair_reselection: bool = False,
-    cut_choice_fn: Callable = _region_preferred_max_weight_choice,
+    cut_choice_fn: Callable[..., _Cut] = _region_preferred_max_weight_choice,
     *,
     rng: random.Random | int | None = None,
-) -> set:
+) -> AbstractSet[Hashable]:
     """Find a population-balanced connected subset of nodes.
 
     The returned subset induces a connected subgraph, and its complement forms the other part of
@@ -1064,21 +1042,21 @@ def bipartition_tree(
     pop_target`` away from ``pop_target``.
 
     Args:
-        graph (Graph): The graph to partition.
+        subgraph_to_split (Graph | FrozenGraph): The graph to partition.
         pop_col (str): The node attribute holding the population of each node.
-        pop_target (Union[int, float]): The target population for the returned subset of nodes.
+        pop_target (int | float): The target population for the returned subset of nodes.
         epsilon (float): The allowable deviation from ``pop_target`` (as a percentage of
             ``pop_target``) for the subgraph's population.
         node_repeats (int, optional): Additional roots to try on each spanning tree before
             drawing a new tree. Defaults to 0. Positive values are useful with contraction or
             custom cut-edge finders, but not with the default memoized finder.
-        spanning_tree (Optional[Graph], optional): The spanning tree for the algorithm to use (used
+        spanning_tree (Graph | None, optional): The spanning tree for the algorithm to use (used
             when the algorithm chooses a new root and for testing).
         spanning_tree_fn (Callable, optional): The random spanning tree algorithm to use if a
             spanning tree is not provided. Defaults to `random_spanning_tree`.
-        region_surcharge (Optional[Dict], optional): A dictionary of surcharges for the spanning
+        region_surcharge (dict | None, optional): A dictionary of surcharges for the spanning
             tree algorithm. Defaults to None.
-        spanning_tree_fn_kwargs (Optional[Dict], optional): Extra keyword arguments forwarded verbatim
+        spanning_tree_fn_kwargs (dict | None, optional): Extra keyword arguments forwarded verbatim
             to ``spanning_tree_fn``. Use this to set function-specific options that are not named
             here, e.g. ``{"treat_unassigned_as_single_region": True}`` for ``random_spanning_tree``.
             Defaults to None.
@@ -1089,10 +1067,12 @@ def bipartition_tree(
             set to False, we check if the node we are cutting and the remaining graph are both
             within epsilon of the ideal population. When set to True, we only check if the node we
             are cutting is within epsilon of the ideal population. Defaults to False.
-        rootnode_choice_fn (Optional[Callable]): The function to make a random choice of root node
+        repeat_until_valid (bool, optional): Whether to keep drawing trees until a valid cut is
+            found. Defaults to ``True``.
+        rootnode_choice_fn (Callable | None): The function to make a random choice of root node
             for the population tree. Passed to ``find_balanced_edge_cuts_fn``. Can be substituted
             for testing. Defaults to the supplied RNG's ``choice``.
-        max_attempts (Optional[int], optional): The maximum number of attempts that should be made
+        max_attempts (int, optional): The maximum number of attempts that should be made
             to bipartition. Defaults to 100000.
         warn_attempts (int, optional): The number of attempts after which a warning is issued if a
             balanced cut cannot be found. Defaults to 1000.
@@ -1104,12 +1084,12 @@ def bipartition_tree(
             Note that this function should gracefully handle the case when the edges in the list of
             possible balanced cuts do not have edge weights - in this case, it should default to
             a uniform random choice.
-        rng (Union[random.Random, int, None], optional): Source of randomness. Pass a shared
+        rng (random.Random | int | None, optional): Source of randomness. Pass a shared
             ``Random`` for repeated standalone calls; an integer restarts the stream each call.
 
     Returns:
-        Set: A subset of nodes of ``graph`` (whose induced subgraph is connected). The other part
-            of the partition is the complement of this subset.
+        set[Hashable] | frozenset[Hashable]: A subset of nodes whose induced subgraph is connected.
+            The other part of the partition is the complement of this subset.
 
     Raises:
         BipartitionWarning: If a possible cut cannot be found after 1000 attempts.
@@ -1162,15 +1142,15 @@ def _get_possible_edge_cuts_and_populated_graph(
     # which node_ids to translate, so we leave both the selection of which edge_cut to cut and
     # the translation of node_ids to the caller.
     #
-    graph_to_split: Graph,
+    graph_to_split: GraphLike,
     pop_col: str,
     pop_target: int | float,
     epsilon: float,
     node_repeats: int = 0,
-    spanning_tree: Graph | None = None,
+    spanning_tree: GraphLike | None = None,
     spanning_tree_fn: SpanningTreeFn = random_spanning_tree,
-    find_balanced_edge_cuts_fn: Callable = find_balanced_edge_cuts_memoization,
-    rootnode_choice_fn: Callable | None = None,
+    find_balanced_edge_cuts_fn: Callable[..., list[_Cut]] = find_balanced_edge_cuts_memoization,
+    rootnode_choice_fn: Callable[[Sequence[Hashable]], Hashable] | None = None,
     repeat_until_valid: bool = True,
     warn_attempts: int = 1000,
     max_attempts: int = 100000,
@@ -1181,29 +1161,32 @@ def _get_possible_edge_cuts_and_populated_graph(
     frm: TODO: Documentation: Peter: Please review the changes I have made to the docstrings...
 
     Args:
-        graph (Graph): The input graph.
+        graph_to_split (Graph | FrozenGraph): The input graph.
         pop_col (str): The name of the column in the graph nodes that contains the population data.
-        pop_target (Union[int, float]): The target population for each subgraph.
+        pop_target (int | float): The target population for each subgraph.
         epsilon (float): The allowed deviation from the target population as a percentage of
             pop_target.
         node_repeats (int, optional): Additional roots to try on each spanning tree before
             drawing a new tree. Defaults to 0.
         repeat_until_valid (bool, optional): Whether to repeat the bipartitioning process until a
             valid bipartition is found. Defaults to True.
-        spanning_tree (Optional[Graph], optional): The spanning tree to use for bipartitioning. If
+        spanning_tree (Graph | None, optional): The spanning tree to use for bipartitioning. If
             None, a random spanning tree will be generated. Defaults to None.
         spanning_tree_fn (Callable, optional): The function to generate a spanning tree. Defaults
             to random_spanning_tree.
         find_balanced_edge_cuts_fn (Callable, optional): The function to find balanced edge cuts.
             Defaults to find_balanced_edge_cuts_memoization.
-        rootnode_choice_fn (Optional[Callable]): The function to choose a random element from a
+        rootnode_choice_fn (Callable | None): The function to choose a random element from a
             list. Defaults to the supplied RNG's ``choice``.
         max_attempts (int, optional): The maximum number of attempts to find a valid
             bipartition.  Defaults to 100000.
+        warn_attempts (int, optional): Number of attempts after which to issue a warning. Defaults
+            to 1000.
+        allow_pair_reselection (bool, optional): Whether to request a different district pair when
+            no valid cut is found. Defaults to ``False``.
 
     Returns:
-        tuple[List[tuple[Hashable, Hashable]], _PopulatedGraph]: A tuple with a list of possible
-            cuts that bipartition the tree into two subgraphs and the _PopulatedGraph the cuts were
+        tuple[list[_Cut], _PopulatedGraph]: The possible cuts and the populated graph they were
             obtained from.
 
     Raises:
@@ -1303,22 +1286,22 @@ def _get_possible_edge_cuts_and_populated_graph(
 
 
 def bipartition_tree_random_with_num_cuts(
-    subgraph_to_split: Graph,
+    subgraph_to_split: GraphLike,
     pop_col: str,
     pop_target: int | float,
     epsilon: float,
     node_repeats: int = 0,
     repeat_until_valid: bool = True,
-    spanning_tree: Graph | None = None,
+    spanning_tree: GraphLike | None = None,
     spanning_tree_fn: SpanningTreeFn = random_spanning_tree,
-    find_balanced_edge_cuts_fn: Callable = find_balanced_edge_cuts_memoization,
+    find_balanced_edge_cuts_fn: Callable[..., list[_Cut]] = find_balanced_edge_cuts_memoization,
     one_sided_cut: bool = False,
-    rootnode_choice_fn: Callable | None = None,
+    rootnode_choice_fn: Callable[[Sequence[Hashable]], Hashable] | None = None,
     max_attempts: int = 100000,
-    cut_choice_fn: Callable | None = None,
+    cut_choice_fn: Callable[..., _Cut] | None = None,
     *,
     rng: random.Random | int | None = None,
-) -> tuple[int, set[Any]]:
+) -> tuple[int, AbstractSet[Hashable]]:
     """This is like `bipartition_tree` except it always chooses a random balanced cut.
 
     This function finds a balanced 2 partition of a graph by drawing a spanning tree and finding an
@@ -1332,16 +1315,16 @@ def bipartition_tree_random_with_num_cuts(
     Args:
         subgraph_to_split (Graph): The graph to partition.
         pop_col (str): The node attribute holding the population of each node.
-        pop_target (Union[int, float]): The target population for the returned subset of nodes.
+        pop_target (int | float): The target population for the returned subset of nodes.
         epsilon (float): The allowable deviation from ``pop_target`` (as a percentage of
             ``pop_target``) for the subgraph's population.
         node_repeats (int): Additional roots to try on each spanning tree before drawing a new
             tree. Defaults to 0.
         repeat_until_valid (bool, optional): Determines whether to keep drawing spanning trees
             until a tree with a balanced cut is found. If `True`, a set of nodes will always be
-            returned; if `False`, `None` will be returned if a valid spanning tree is not found on
-            the first try. Defaults to True.
-        spanning_tree (Optional[Graph], optional): The spanning tree for the algorithm to use (used
+            returned; if `False`, an empty set is returned when no valid cut is found on the first
+            try. Defaults to True.
+        spanning_tree (Graph | None, optional): The spanning tree for the algorithm to use (used
             when the algorithm chooses a new root and for testing). Defaults to None.
         spanning_tree_fn (Callable, optional): The random spanning tree algorithm to use if a
             spanning tree is not provided. Defaults to `random_spanning_tree`.
@@ -1352,18 +1335,18 @@ def bipartition_tree_random_with_num_cuts(
             set to False, we check if the node we are cutting and the remaining graph are both
             within epsilon of the ideal population. When set to True, we only check if the node we
             are cutting is within epsilon of the ideal population. Defaults to False.
-        rootnode_choice_fn (Optional[Callable]): The random choice function. Can be substituted for
+        rootnode_choice_fn (Callable | None): The random choice function. Can be substituted for
             testing. Defaults to the supplied RNG's ``choice``.
         max_attempts (int): The max number of attempts that should be made to
             bipartition. Defaults to 100,000.
-        cut_choice_fn (Optional[Callable]): Function with signature ``(cuts, *, rng)`` used to
+        cut_choice_fn (Callable | None): Function with signature ``(cuts, *, rng)`` used to
             select a cut. Defaults to the supplied RNG's ``choice``.
-        rng (Union[random.Random, int, None], optional): Source of randomness. Pass a shared
+        rng (random.Random | int | None, optional): Source of randomness. Pass a shared
             ``Random`` for repeated standalone calls; an integer restarts the stream each call.
 
     Returns:
-        tuple[int, Set[Any]]: A subset of nodes of ``graph`` (whose induced subgraph is connected)
-            or None if a valid spanning tree is not found.
+        tuple[int, AbstractSet[Hashable]]: The number of possible cuts and the selected connected
+            subset of nodes.
     """
 
     # Note: This routine is only used in one place in the GerryChain code.
@@ -1382,7 +1365,7 @@ def bipartition_tree_random_with_num_cuts(
         node_repeats=node_repeats,
         spanning_tree=spanning_tree,
         spanning_tree_fn=spanning_tree_fn,
-        # region_surcharge: Optional[Dict] = None,
+        # region_surcharge: dict[str, float] | None = None,
         find_balanced_edge_cuts_fn=find_balanced_edge_cuts_fn,
         one_sided_cut=one_sided_cut,
         rootnode_choice_fn=rootnode_choice_fn,

--- a/gerrychain/tree/spanning_tree.py
+++ b/gerrychain/tree/spanning_tree.py
@@ -69,13 +69,10 @@ Dependencies:
 """
 
 import random
-from typing import (
-    Dict,
-    Optional,
-)
+from collections.abc import Hashable, Iterator
 
 from .._rng import make_rng
-from ..graph import Graph
+from ..graph import FrozenGraph, Graph
 
 
 """
@@ -96,7 +93,7 @@ node_ids for this function and all will be well...
 # not stable when working with NX-backed graphs in (esp. when using
 # `Partition().from_random_assignment`, and so I added this function to yield the edges in a stable
 # order for the sake of reproducibility.
-def _ordered_edge_ids(graph: Graph):
+def _ordered_edge_ids(graph: Graph | FrozenGraph) -> Iterator[Hashable]:
     """Yield stable edge ids without changing established RX trajectories."""
     if graph.is_rx_graph():
         yield from graph.edge_indices
@@ -111,8 +108,8 @@ def _ordered_edge_ids(graph: Graph):
 
 
 def random_spanning_tree(
-    graph: Graph,
-    region_surcharge: Optional[Dict] = None,
+    graph: Graph | FrozenGraph,
+    region_surcharge: dict[str, float] | None = None,
     treat_unassigned_as_single_region: bool = False,
     *,
     rng: random.Random | int | None = None,
@@ -181,7 +178,7 @@ def random_spanning_tree(
 
     Args:
         graph (Graph): The input graph to build the spanning tree from.
-        region_surcharge (Optional[Dict], optional): Dictionary mapping a node-attribute name to the
+        region_surcharge (dict | None, optional): Dictionary mapping a node-attribute name to the
             numeric surcharge added to the random weight of edges that cross a boundary for that
             attribute. Defaults to None (no surcharge - an ordinary random spanning tree).
         treat_unassigned_as_single_region (bool, optional): How to treat edges between two nodes that
@@ -189,7 +186,7 @@ def random_spanning_tree(
             surcharged, so the region-less ("unassigned") area may be split freely. When True, such
             edges are not surcharged, so the region-less area is biased to be kept whole, like any
             other region. Has no effect when ``region_surcharge`` is empty or every node has a value.
-        rng (Union[random.Random, int, None], optional): Source of randomness. Pass a shared
+        rng (random.Random | int | None, optional): Source of randomness. Pass a shared
             ``Random`` for repeated standalone calls; an integer restarts the stream each call.
 
     Returns:
@@ -268,8 +265,8 @@ def random_spanning_tree(
 
 
 def uniform_spanning_tree(
-    graph: Graph,
-    region_surcharge: dict = None,  # accepted for API compatibility, but unused
+    graph: Graph | FrozenGraph,
+    region_surcharge: dict[str, float] | None = None,  # accepted but unused
     *,
     rng: random.Random | int | None = None,
 ) -> Graph:
@@ -297,10 +294,10 @@ def uniform_spanning_tree(
 
     Args:
         graph (Graph): The graph from which to sample a spanning tree.
-        region_surcharge (Optional[Dict], optional): Not used in this function.  It exists
+        region_surcharge (dict | None, optional): Not used in this function.  It exists
             in the function signature so that all spanning tree functions will share the
             same signature.
-        rng (Union[random.Random, int, None], optional): Source of randomness. Pass a shared
+        rng (random.Random | int | None, optional): Source of randomness. Pass a shared
             ``Random`` for repeated standalone calls; an integer restarts the stream each call.
 
     Returns:
@@ -318,7 +315,7 @@ def uniform_spanning_tree(
 
     # Initiallize the tree to contain the root_node (with no parent)
     tree_nodes = set([root_id])
-    parent_node_id = {root_id: None}
+    parent_node_id: dict[Hashable, Hashable | None] = {root_id: None}
 
     for node_id in nodes:
         # Random walk (perhaps with cycles) that records the

--- a/gerrychain/updaters/compactness.py
+++ b/gerrychain/updaters/compactness.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import collections
+from collections.abc import Hashable
 from typing import TYPE_CHECKING
 
 from .cut_edges import on_edge_flow
@@ -10,7 +11,7 @@ if TYPE_CHECKING:
     from ..partition.partition import Partition
 
 
-def boundary_nodes(partition: Partition, alias: str = "boundary_nodes") -> set[int]:
+def boundary_nodes(partition: Partition, alias: str = "boundary_nodes") -> set[Hashable]:
     """Return set of nodes in the partition that are on the boundary.
 
     Args:
@@ -19,7 +20,7 @@ def boundary_nodes(partition: Partition, alias: str = "boundary_nodes") -> set[i
             Default is 'boundary_nodes'.
 
     Returns:
-        Set: The set of nodes in the partition that are on the boundary.
+        set: The set of nodes in the partition that are on the boundary.
     """
 
     # Note that the "alias" parameter is used as the attribute name
@@ -37,17 +38,16 @@ def boundary_nodes(partition: Partition, alias: str = "boundary_nodes") -> set[i
         return result
 
 
-def initialize_exterior_boundaries_as_a_set(partition: Partition) -> dict[int, set[int]]:
+def initialize_exterior_boundaries_as_a_set(partition: Partition) -> dict[Hashable, set[Hashable]]:
     """Return exterior boundary nodes for each part in the partition.
 
     Args:
         partition (Partition): A partition of a Graph
 
     Returns:
-        Dict[int, Set]: A dictionary mapping each part of a partition to the set of nodes in that
-            part that are on the boundary.
+        dict[Hashable, set[Hashable]]: Parts mapped to their exterior boundary nodes.
     """
-    part_boundaries = collections.defaultdict(set)
+    part_boundaries: collections.defaultdict[Hashable, set[Hashable]] = collections.defaultdict(set)
     for node in partition["boundary_nodes"]:
         part_boundaries[partition.assignment.mapping[node]].add(node)
 
@@ -56,19 +56,21 @@ def initialize_exterior_boundaries_as_a_set(partition: Partition) -> dict[int, s
 
 @on_flow(initialize_exterior_boundaries_as_a_set, alias="exterior_boundaries_as_a_set")
 def exterior_boundaries_as_a_set(
-    partition: Partition, previous: set[int], inflow: set[int], outflow: set[int]
-) -> set[int]:
+    partition: Partition,
+    previous: set[Hashable],
+    inflow: set[Hashable],
+    outflow: set[Hashable],
+) -> set[Hashable]:
     """Updater function that responds to the flow of nodes between different partitions.
 
     Args:
         partition (Partition): A partition of a Graph
-        previous (Set): The previous set of exterior boundary nodes for a fixed part of the given
-            partition.
-        inflow (Set): The set of nodes that have flowed into the given part of the partition.
-        outflow (Set): The set of nodes that have flowed out of the given part of the partition.
+        previous (set[Hashable]): Previous exterior boundary nodes for a fixed part.
+        inflow (set[Hashable]): Nodes that flowed into the part.
+        outflow (set[Hashable]): Nodes that flowed out of the part.
 
     Returns:
-        Set: The new set of exterior boundary nodes for the given part of the partition.
+        set[Hashable]: The updated exterior boundary nodes for the part.
     """
     # Compute the new set of boundary nodes for the partition.
     #
@@ -84,18 +86,17 @@ def exterior_boundaries_as_a_set(
     return (previous | (inflow & graph_boundary)) - outflow
 
 
-def initialize_exterior_boundaries(partition: Partition) -> dict[int, float]:
+def initialize_exterior_boundaries(partition: Partition) -> dict[Hashable, float]:
     """Return A dictionary mapping each part of a partition to the total perimeter of the boundary.
 
     Args:
         partition (Partition): A partition of a Graph
 
     Returns:
-        Dict[int, float]: A dictionary mapping each part of a partition to the total perimeter of
-            the boundary nodes in that part.
+        dict[Hashable, float]: Parts mapped to their exterior boundary perimeter.
     """
     graph_boundary = partition["boundary_nodes"]
-    boundaries = collections.defaultdict(lambda: 0)
+    boundaries: collections.defaultdict[Hashable, float] = collections.defaultdict(float)
     for node in graph_boundary:
         part = partition.assignment.mapping[node]
         boundaries[part] += partition.graph.node_data(node)["boundary_perim"]
@@ -104,19 +105,21 @@ def initialize_exterior_boundaries(partition: Partition) -> dict[int, float]:
 
 @on_flow(initialize_exterior_boundaries, alias="exterior_boundaries")
 def exterior_boundaries(
-    partition: Partition, previous: float, inflow: set[int], outflow: set[int]
+    partition: Partition,
+    previous: float,
+    inflow: set[Hashable],
+    outflow: set[Hashable],
 ) -> float:
     """Computes the total perimeter of the boundary nodes in each part of the partition.
 
     Args:
         partition (Partition): A partition of a Graph
-        previous (Set): The previous set of exterior boundary nodes for a fixed part of the given
-            partition.
-        inflow (Set): The set of nodes that have flowed into the given part of the partition.
-        outflow (Set): The set of nodes that have flowed out of the given part of the partition.
+        previous (float): Previous exterior boundary perimeter for the part.
+        inflow (set[Hashable]): Nodes that flowed into the part.
+        outflow (set[Hashable]): Nodes that flowed out of the part.
 
     Returns:
-        Dict: A dict mapping each part of the partition to the new exterior boundary of that part.
+        float: The updated exterior boundary perimeter for the part.
     """
     graph_boundary = partition["boundary_nodes"]
     added_perimeter = sum(
@@ -128,15 +131,14 @@ def exterior_boundaries(
     return previous + added_perimeter - removed_perimeter
 
 
-def initialize_interior_boundaries(partition: Partition) -> dict[int, float]:
+def initialize_interior_boundaries(partition: Partition) -> dict[Hashable, float]:
     """Return A dictionary mapping each part of a partition to the total perimeter the given part.
 
     Args:
         partition (Partition): A partition of a Graph
 
     Returns:
-        Dict[int, float]: A dictionary mapping each part of a partition to the total perimeter the
-            given part shares with other parts.
+        dict[Hashable, float]: Parts mapped to the perimeter shared with other parts.
     """
 
     # RustworkX Note:
@@ -157,9 +159,11 @@ def initialize_interior_boundaries(partition: Partition) -> dict[int, float]:
 
     # Compute length of the shared perimeter of each part
     shared_perimeters_for_part = {
-        part: sum(
-            partition.graph.edge_data(edge_id)["shared_perim"]
-            for edge_id in edge_ids_for_part[part]
+        part: float(
+            sum(
+                partition.graph.edge_data(edge_id)["shared_perim"]
+                for edge_id in edge_ids_for_part[part]
+            )
         )
         for part in partition.parts
     }
@@ -178,13 +182,12 @@ def interior_boundaries(
 
     Args:
         partition (Partition): A partition of a Graph
-        previous (Set): The previous set of exterior boundary nodes for a fixed part of the given
-            partition.
-        new_edges (Set): The set of edges that have flowed into the given part of the partition.
-        old_edges (Set): The set of edges that have flowed out of the given part of the partition.
+        previous (float): Previous interior boundary perimeter for the part.
+        new_edges (set[tuple[int, int]]): Edges that flowed into the part.
+        old_edges (set[tuple[int, int]]): Edges that flowed out of the part.
 
     Returns:
-        Dict: A dict mapping each part of the partition to the new interior boundary of that part.
+        float: The updated interior boundary perimeter for the part.
     """
 
     added_perimeter = sum(
@@ -198,7 +201,7 @@ def interior_boundaries(
     return previous + added_perimeter - removed_perimeter
 
 
-def perimeter_of_part(partition: Partition, part: int) -> float:
+def perimeter_of_part(partition: Partition, part: Hashable) -> float:
     """Totals up the perimeter of the part in the partition.
 
     .. Warning::
@@ -208,7 +211,7 @@ def perimeter_of_part(partition: Partition, part: int) -> float:
 
     Args:
         partition (Partition): A partition of a Graph
-        part (int): The id of the part of the partition whose perimeter we want to compute.
+        part (Hashable): The part whose perimeter to compute.
 
     Returns:
         float: The perimeter of the desired part.
@@ -222,13 +225,13 @@ def perimeter_of_part(partition: Partition, part: int) -> float:
     return exterior_perimeter + interior_perimeter
 
 
-def perimeter(partition: Partition) -> dict[int, float]:
+def perimeter(partition: Partition) -> dict[Hashable, float]:
     """Computes the perimeter of each part in the partition.
 
     Args:
         partition (Partition): A partition of a Graph
 
     Returns:
-        Dict[int, float]: A dictionary mapping each part of a partition to its perimeter.
+        dict[Hashable, float]: Parts mapped to their perimeter.
     """
     return {part: perimeter_of_part(partition, part) for part in partition.parts}

--- a/gerrychain/updaters/county_splits.py
+++ b/gerrychain/updaters/county_splits.py
@@ -1,23 +1,11 @@
 from __future__ import annotations
 
-import collections
-from collections.abc import Callable
+from collections.abc import Callable, Hashable, Sequence
 from enum import Enum
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, NamedTuple
 
 if TYPE_CHECKING:
     from ..partition.partition import Partition
-
-CountyInfo = collections.namedtuple("CountyInfo", "split nodes contains")
-"""
-A named tuple to store county split information.
-
-Args:
-    split (int): The county split status. Makes use of
-        CountySplit enum to compute.
-    nodes (List): The nodes that are contained in the county.
-    contains (Set): The assignment IDs that are contained in the county.
-"""
 
 
 class CountySplit(Enum):
@@ -25,9 +13,9 @@ class CountySplit(Enum):
     Enum to track county splits in a partition.
 
     Attributes:
-        NOT_SPLIT (Any): The county is not split.
-        NEW_SPLIT (Any): The county is split in the current partition.
-        OLD_SPLIT (Any): The county is split in the parent partition.
+        NOT_SPLIT (CountySplit): The county is not split.
+        NEW_SPLIT (CountySplit): The county is split in the current partition.
+        OLD_SPLIT (CountySplit): The county is split in the parent partition.
     """
 
     NOT_SPLIT = 0
@@ -35,7 +23,17 @@ class CountySplit(Enum):
     OLD_SPLIT = 2
 
 
-def county_splits(partition_name: str, county_field_name: str) -> Callable:
+class CountyInfo(NamedTuple):
+    """Information about how a county intersects a partition."""
+
+    split: CountySplit
+    nodes: list[Hashable]
+    contains: set[Hashable]
+
+
+def county_splits(
+    partition_name: str, county_field_name: str
+) -> Callable[[Partition], dict[Hashable, CountyInfo]]:
     """An updater for tracking the number of counties that are split in a partition.
 
     Args:
@@ -43,13 +41,13 @@ def county_splits(partition_name: str, county_field_name: str) -> Callable:
         county_field_name (str): Name of county ID field on the graph.
 
     Returns:
-        Callable: The tracked data is a dictionary keyed on the county ID. The stored values are
-            tuples of the form `(split, nodes, seen)`. `split` is a CountySplit enum,
-            `nodes` is a list of node IDs, and `seen` is a list of assignment IDs that are
-            contained in the county.
+        Callable: The tracked data is a ``dict[Hashable, CountyInfo]`` keyed on the county ID. Each
+            ``CountyInfo`` is a named tuple with fields `split` (a CountySplit enum), `nodes` (a
+            list of node IDs in the county), and `contains` (a ``set[Hashable]`` of the assignment
+            IDs the county intersects).
     """
 
-    def _get_county_splits(partition: Partition) -> dict[str, CountyInfo]:
+    def _get_county_splits(partition: Partition) -> dict[Hashable, CountyInfo]:
         return compute_county_splits(partition, county_field_name, partition_name)
 
     return _get_county_splits
@@ -57,7 +55,7 @@ def county_splits(partition_name: str, county_field_name: str) -> Callable:
 
 def compute_county_splits(
     partition: Partition, county_field: str, partition_field: str
-) -> dict[str, CountyInfo]:
+) -> dict[Hashable, CountyInfo]:
     """Computes the number of counties that are split in a partition.
 
     Args:
@@ -69,14 +67,14 @@ def compute_county_splits(
             division of the graph.
 
     Returns:
-        Dict[str, CountyInfo]: A dict containing the information on how counties changed between
-            the parent and child partitions. If there is no parent partition, then only the
-            OLD_SPLIT and NOT_SPLIT values will be used.
+        dict[Hashable, CountyInfo]: Information on how counties changed between the parent and
+            child partitions. If there is no parent partition, only ``OLD_SPLIT`` and
+            ``NOT_SPLIT`` are used.
     """
 
     # Create the initial county data containers.
     if not partition.parent:
-        county_dict = dict()
+        county_dict: dict[Hashable, CountyInfo] = {}
 
         for node_id in partition.graph.node_indices:
             # First figure get current status of the county's information
@@ -101,7 +99,7 @@ def compute_county_splits(
 
         return county_dict
 
-    new_county_dict = dict()
+    new_county_dict: dict[Hashable, CountyInfo] = {}
 
     parent = partition.parent
     for county, county_info in parent[partition_field].items():
@@ -120,7 +118,7 @@ def compute_county_splits(
     return new_county_dict
 
 
-def tally_region_splits(region_attr_lst: list[str]) -> Callable:
+def tally_region_splits(region_attr_lst: Sequence[str]) -> Callable[[Partition], dict[str, int]]:
     """A naive updater for tallying the number of times a region attribute is split.
 
     Here "region" is the generic term for an administrative unit you would prefer not to split
@@ -129,7 +127,7 @@ def tally_region_splits(region_attr_lst: list[str]) -> Callable:
     just specific instances of this region concept.
 
     Args:
-        region_attr_lst (List[str]): A list of region attribute names to tally splits for.
+        region_attr_lst (Sequence[str]): Region attribute names to tally splits for.
 
     Returns:
         Callable: A function that takes a partition and returns a dictionary which maps the region
@@ -137,7 +135,6 @@ def tally_region_splits(region_attr_lst: list[str]) -> Callable:
     """
 
     def _get_splits(partition: Partition) -> dict[str, int]:
-        nonlocal region_attr_lst
         if "cut_edges" not in partition.updaters:
             raise ValueError("The cut_edges updater must be attached to the partition")
         return {

--- a/gerrychain/updaters/cut_edges.py
+++ b/gerrychain/updaters/cut_edges.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import collections
-from collections.abc import Iterable
+from collections.abc import Hashable, Iterable
 from typing import TYPE_CHECKING
 
 from .flows import neighbor_flips, on_edge_flow
@@ -13,19 +13,19 @@ if TYPE_CHECKING:
 
 def _put_edges_into_parts(
     cut_edges: Iterable[tuple[int, int]], assignment: Assignment
-) -> dict[int, set[tuple[int, int]]]:
+) -> dict[Hashable, set[tuple[int, int]]]:
     """Return A dictionary mapping each part of a partition to the set of cut_edges in that part.
 
     Args:
-        cut_edges (List): A list of cut_edges in a graph which are to be separated into their
+        cut_edges (list): A list of cut_edges in a graph which are to be separated into their
             respective parts within the partition according to the given assignment.
-        assignment (Dict): A dictionary mapping nodes to their respective parts within the
+        assignment (dict): A dictionary mapping nodes to their respective parts within the
             partition.
 
     Returns:
-        Dict: A dictionary mapping each part of a partition to the set of cut_edges in that part.
+        dict: A dictionary mapping each part of a partition to the set of cut_edges in that part.
     """
-    by_part = collections.defaultdict(set)
+    by_part: collections.defaultdict[Hashable, set[tuple[int, int]]] = collections.defaultdict(set)
     for edge in cut_edges:
         # add edge to the sets corresponding to the parts it touches
         by_part[assignment.mapping[edge[0]]].add(edge)
@@ -40,7 +40,7 @@ def _new_cuts(partition: Partition) -> set[tuple[int, int]]:
         partition (Partition): A partition of a Graph
 
     Returns:
-        Set[Tuple]: The set of edges that were not cut, but now are.
+        set[tuple]: The set of edges that were not cut, but now are.
     """
     return {
         (node, neighbor)
@@ -56,8 +56,9 @@ def _obsolete_cuts(partition: Partition) -> set[tuple[int, int]]:
         partition (Partition): A partition of a Graph
 
     Returns:
-        Set[Tuple]: The set of edges that were cut, but now are not.
+        set[tuple]: The set of edges that were cut, but now are not.
     """
+    assert partition.parent is not None
     return {
         (node, neighbor)
         for node, neighbor in neighbor_flips(partition)
@@ -66,14 +67,14 @@ def _obsolete_cuts(partition: Partition) -> set[tuple[int, int]]:
     }
 
 
-def initialize_cut_edges(partition: Partition) -> dict[int, set[tuple[int, int]]]:
+def initialize_cut_edges(partition: Partition) -> dict[Hashable, set[tuple[int, int]]]:
     """A dictionary mapping each part of a partition to the set of cut edges in that part.
 
     Args:
         partition (Partition): A partition of a Graph
 
     Returns:
-        Dict: A dictionary mapping each part of a partition to the set of cut edges in that part.
+        dict: A dictionary mapping each part of a partition to the set of cut edges in that part.
     """
 
     # Compute the set of edges that are "cut_edges" - that is, edges that go from
@@ -105,13 +106,13 @@ def cut_edges_by_part(
 
     Args:
         partition (Partition): A partition of a Graph
-        previous (Set[Tuple]): The previous set of edges for a fixed part of the given partition.
-        new_edges (Set[Tuple]): The set of edges that have flowed into the given part of the
+        previous (set[tuple]): The previous set of edges for a fixed part of the given partition.
+        new_edges (set[tuple]): The set of edges that have flowed into the given part of the
             partition.
-        old_edges (Set[Tuple]): The set of cut edges in the previous partition.
+        old_edges (set[tuple]): The set of cut edges in the previous partition.
 
     Returns:
-        Set: The new set of cut edges for the newly generated partition.
+        set: The new set of cut edges for the newly generated partition.
     """
     return (previous | new_edges) - old_edges
 
@@ -123,7 +124,7 @@ def cut_edges(partition: Partition) -> set[tuple[int, int]]:
         partition (Partition): A partition of a Graph
 
     Returns:
-        Set[Tuple]: The set of edges that are cut by the given partition.
+        set[tuple]: The set of edges that are cut by the given partition.
     """
     parent = partition.parent
 

--- a/gerrychain/updaters/election.py
+++ b/gerrychain/updaters/election.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import math
+from collections.abc import Hashable, Iterable, Mapping
 from typing import TYPE_CHECKING
 
 import gerrychain.metrics.partisan as pm
@@ -52,14 +53,14 @@ class Election:
 
     Attributes:
         name (str): The name of the election. (e.g. "2008 Presidential")
-        parties (List[str]): A list of the names of the parties in the election.
-        node_attribute_names (List[str]): A list of the node_attribute_names in the graph's node
+        parties (list[str]): A list of the names of the parties in the election.
+        node_attribute_names (list[str]): A list of the node_attribute_names in the graph's node
         data that
             hold the vote totals for each party.
-        party_names_to_node_attribute_names (Dict[str, str]): A dictionary mapping party names to
+        party_names_to_node_attribute_names (dict[str, str]): A dictionary mapping party names to
         the
             node_attribute_names in the graph's node data that hold the vote totals for that party.
-        tallies (Dict[str, DataTally]): A dictionary mapping party names to DataTally
+        tallies (dict[str, DataTally]): A dictionary mapping party names to DataTally
         objects
             that manage the vote totals for that party.
         updater (ElectionUpdater): An ElectionUpdater object that manages the tallies
@@ -71,14 +72,14 @@ class Election:
     def __init__(
         self,
         name: str,
-        party_names_to_node_attribute_names: dict | list,
+        party_names_to_node_attribute_names: dict[str, str] | list[str],
         alias: str | None = None,
     ) -> None:
         """Initialize a Election instance.
 
         Args:
             name (str): The name of the election. (e.g. "2008 Presidential")
-            party_names_to_node_attribute_names (Union[Dict, List]): A mapping from the name of a
+            party_names_to_node_attribute_names (dict | list): A mapping from the name of a
                 party to the name of an attribute of a node that contains the vote totals for that
                 party. This parameter can be either a list or a dict. If a list, then the name of
                 the party and the name of the node attribute are the same, for instance: ["Dem",
@@ -89,8 +90,8 @@ class Election:
                 actual node_attribute_names (list-like, indexed by nodes) or as string keys for the
                 node attributes that hold the party's vote totals. Or, a list of strings which will
                 serve as both the party names and the node attribute keys.
-            alias (Optional[str], optional): Alias that the election is registered under in the
-                Partition's dictionary of updaters.
+            alias (str | None, optional): Alias that the election is registered under in the
+                Partition's dictionary of updaters. Defaults to ``None``, which uses ``name``.
 
         """
 
@@ -178,7 +179,9 @@ class ElectionUpdater:
 
         return ElectionResults(self.election, counts, regions=partition.parts)
 
-    def get_previous_values(self, partition: Partition) -> dict[str, dict[int, float] | None]:
+    def get_previous_values(
+        self, partition: Partition
+    ) -> Mapping[str, dict[Hashable, float] | None]:
         """Returns a dictionary mapping party names to the vote totals that party received in each.
 
         Args:
@@ -186,29 +189,35 @@ class ElectionUpdater:
                 previous vote totals from.
 
         Returns:
-            Dict[str, Dict[int, float]]: A dictionary mapping party names to the vote totals that
-                party received in each part of the parent of the current partition.
+            Mapping[str, dict[Hashable, float] | None]: A dictionary mapping party names to the
+                vote totals that party received in each part of the parent of the current
+                partition.
         """
         parent = partition.parent
         if parent is None:
             previous_totals_for_party = {party: None for party in self.election.parties}
         else:
-            previous_totals_for_party = partition.parent[self.election.alias].totals_for_party
+            previous_results = parent[self.election.alias]
+            if not isinstance(previous_results, ElectionResults):
+                raise TypeError(f"Updater {self.election.alias!r} must return ElectionResults")
+            previous_totals_for_party = previous_results.totals_for_party
         return previous_totals_for_party
 
 
-def get_percents(counts: dict, totals: dict) -> dict:
+def get_percents(
+    counts: Mapping[Hashable, float], totals: Mapping[Hashable, float]
+) -> dict[Hashable, float]:
     """Returns a dictionary mapping each part in a partition to the percentage of votes that a
     party received in that part.
 
     Args:
-        counts (Dict): A dictionary mapping each part in a partition to the count of the number of
+        counts (dict): A dictionary mapping each part in a partition to the count of the number of
             votes that a party received in that part.
-        totals (Dict): A dictionary mapping each part in a partition to the total number of votes
+        totals (dict): A dictionary mapping each part in a partition to the total number of votes
             cast in that part.
 
     Returns:
-        Dict: A dictionary mapping each part in a partition to the percentage
+        dict: A dictionary mapping each part in a partition to the percentage
     """
     return {part: counts[part] / totals[part] if totals[part] > 0 else math.nan for part in totals}
 
@@ -220,15 +229,12 @@ class ElectionResults:
 
     Attributes:
         election (Election): The Election object that these results are associated with.
-        totals_for_party (Dict[str, Dict[int, float]]): A dictionary mapping party names to the
-        total number of votes
-            that party received in each part of the partition.
-        regions (List[int]): A list of regions that we would like the results for.
-        totals (Dict[int, int]): A dictionary mapping each part of the partition to the total number
-            of votes cast in that part.
-        percents_for_party (Dict[str, Dict[int, float]]): A dictionary mapping party names to the
-        percentage of votes
-            that party received in each part of the partition.
+        totals_for_party (dict[str, dict[Hashable, float]]): Party names mapped to their vote
+            totals in each part.
+        regions (tuple[Hashable, ...]): Regions included in the results.
+        totals (dict[Hashable, float]): Parts mapped to their total votes.
+        percents_for_party (dict[str, dict[Hashable, float]]): Party names mapped to their vote
+            percentages in each part.
     .. note::
 
         The variable "regions" is generally called "parts" in other sections of the
@@ -239,23 +245,22 @@ class ElectionResults:
     def __init__(
         self,
         election: Election,
-        counts: dict[str, dict[int, float]],
-        regions: list[int],
+        counts: dict[str, dict[Hashable, float]],
+        regions: Iterable[Hashable],
     ) -> None:
         """Initialize a ElectionResults instance.
 
         Args:
             election (Election): The Election object that these results are associated
                 with.
-            counts (Dict[str, Dict[int, float]]): A dictionary mapping party names to the total
+            counts (dict[str, dict[Hashable, float]]): Party names mapped to the total
                 number of votes that party received in each part of the partition.
-            regions (List[int]): A list of regions that we would like to consider (e.g.
-                congressional districts).
+            regions (Iterable[Hashable]): Regions to consider, such as congressional districts.
 
         """
         self.election = election
         self.totals_for_party = counts
-        self.regions = regions
+        self.regions = tuple(regions)
 
         self.totals = {
             region: sum(counts[party][region] for party in self.election.parties)
@@ -294,7 +299,7 @@ class ElectionResults:
         """
         return self.seats(party)
 
-    def percent(self, party: str, region: int | None = None) -> float:
+    def percent(self, party: str, region: Hashable | None = None) -> float:
         """Return vote share for ``party`` in one region or overall.
 
         If ``region`` is provided, this returns the vote share in that region. Otherwise, it
@@ -302,7 +307,7 @@ class ElectionResults:
 
         Args:
             party (str): Party ID.
-            region (Optional[int], optional): ID of the part of the partition whose votes we want
+            region (Hashable | None, optional): ID of the part of the partition whose votes we want
                 to tally.
 
         Returns:
@@ -314,7 +319,7 @@ class ElectionResults:
             return self.percents_for_party[party][region]
         return sum(self.votes(party)) / sum(self.totals[region] for region in self.regions)
 
-    def percents(self, party: str) -> tuple:
+    def percents(self, party: str) -> tuple[float, ...]:
         """Return vote shares for ``party`` across all regions.
 
         The returned tuple contains one vote-share value per region, in the order of
@@ -324,12 +329,12 @@ class ElectionResults:
             party (str): Party ID
 
         Returns:
-            Tuple: The tuple of the percentage of votes that ``party`` received in each part of the
+            tuple: The tuple of the percentage of votes that ``party`` received in each part of the
                 partition
         """
         return tuple(self.percents_for_party[party][region] for region in self.regions)
 
-    def count(self, party: str, region: str | None = None) -> int:
+    def count(self, party: str, region: Hashable | None = None) -> float:
         """Return vote total for ``party`` in one region or overall.
 
         If ``region`` is provided, this returns the total vote count in that region. Otherwise, it
@@ -337,29 +342,29 @@ class ElectionResults:
 
         Args:
             party (str): Party ID.
-            region (Optional[int], optional): ID of the part of the partition whose votes we want
+            region (Hashable | None, optional): ID of the part of the partition whose votes we want
                 to tally.
 
         Returns:
-            int: The total number of votes that ``party`` received in a given region (part of the
+            float: The total number of votes that ``party`` received in a given region (part of the
                 partition). If ``region`` is omitted, returns the overall vote total of ``party``.
         """
         if region is not None:
             return self.totals_for_party[party][region]
         return sum(self.totals_for_party[party][region] for region in self.regions)
 
-    def counts(self, party: str) -> tuple:
+    def counts(self, party: str) -> tuple[float, ...]:
         """Return tuple of the total votes cast for ``party`` in each part of the partition.
 
         Args:
             party (str): Party ID
 
         Returns:
-            Tuple: tuple of the total votes cast for ``party`` in each part of the partition
+            tuple: tuple of the total votes cast for ``party`` in each part of the partition
         """
         return tuple(self.totals_for_party[party][region] for region in self.regions)
 
-    def votes(self, party: str) -> tuple:
+    def votes(self, party: str) -> tuple[float, ...]:
         """An alias for `counts`.
 
         It returns a tuple of the total votes cast for ``party`` in each part of the partition.
@@ -368,16 +373,16 @@ class ElectionResults:
             party (str): Party ID
 
         Returns:
-            Tuple: tuple of the total votes cast for ``party`` in each part of the partition
+            tuple: tuple of the total votes cast for ``party`` in each part of the partition
         """
         return self.counts(party)
 
-    def won(self, party: str, region: str) -> bool:
+    def won(self, party: str, region: Hashable) -> bool:
         """Determines if ``party`` won in the region given by ``region``?".
 
         Args:
             party (str): Party ID
-            region (str): ID of the part of the partition whose votes we want to tally.
+            region (Hashable): ID of the part of the partition whose votes we want to tally.
 
         Returns:
             bool: Answer to "Did ``party`` win the region in part ``region``?"
@@ -388,11 +393,11 @@ class ElectionResults:
             if opponent != party
         )
 
-    def total_votes(self) -> int:
+    def total_votes(self) -> float:
         """Return total number of votes cast in the election.
 
         Returns:
-            int: The total number of votes cast in the election.
+            float: The total number of votes cast in the election.
         """
         return sum(self.totals.values())
 
@@ -447,14 +452,16 @@ class ElectionResults:
         return pm.partisan_gini(self)
 
 
-def format_part_results(percents_for_party: dict[str, dict[int, float]], part: int) -> str:
+def format_part_results(
+    percents_for_party: Mapping[str, Mapping[Hashable, float]], part: Hashable
+) -> str:
     """Return A formatted string containing the results for the given part of the partition.
 
     Args:
-        percents_for_party (Dict[str, Dict[int, float]]): A dictionary mapping party names to a
+        percents_for_party (Mapping[str, Mapping[Hashable, float]]): Party names mapped to a
             dict containing the percentage of votes that party received in each part of the
             partition.
-        part (int): The part of the partition whose results we want to format.
+        part (Hashable): The part whose results to format.
 
     Returns:
         str: A formatted string containing the results for the given part of the partition.

--- a/gerrychain/updaters/flows.py
+++ b/gerrychain/updaters/flows.py
@@ -49,11 +49,14 @@ from __future__ import annotations
 
 import collections
 import functools
-from collections.abc import Callable
-from typing import TYPE_CHECKING
+from collections.abc import Callable, Hashable
+from typing import TYPE_CHECKING, TypeVar, cast
 
 if TYPE_CHECKING:
     from ..partition.partition import Partition
+
+ValueT = TypeVar("ValueT")
+KeyT = TypeVar("KeyT", bound=Hashable)
 
 
 @functools.lru_cache(maxsize=2)
@@ -64,23 +67,33 @@ def neighbor_flips(partition: Partition) -> set[tuple[int, int]]:
         partition (Partition): A partition of a Graph
 
     Returns:
-        Set[Tuple]: The set of edges that were flipped in the given partition.
+        set[tuple]: The set of edges that were flipped in the given partition.
     """
-    return {
-        tuple(sorted((node, neighbor)))
-        for node in partition.flips
-        for neighbor in partition.graph.neighbors(node)
-    }
+    flips = partition.flips
+    if flips is None:
+        return set()
+    edges: set[tuple[int, int]] = set()
+    for flipped_node in flips:
+        node = cast(int, flipped_node)
+        for neighboring_node in partition.graph.neighbors(node):
+            neighbor = cast(int, neighboring_node)
+            first, second = sorted((node, neighbor))
+            edges.add((first, second))
+    return edges
 
 
-def create_flow() -> dict[str, set]:
+def create_flow() -> dict[str, set[Hashable]]:
+    return {"in": set(), "out": set()}
+
+
+def create_edge_flow() -> dict[str, set[tuple[int, int]]]:
     return {"in": set(), "out": set()}
 
 
 @functools.lru_cache(maxsize=2)
 def flows_from_changes(
     old_partition: Partition, new_partition: Partition
-) -> dict[int, dict[str, set[int]]]:
+) -> dict[Hashable, dict[str, set[Hashable]]]:
     """Return per-part node flow updates between two partitions.
 
     Args:
@@ -90,7 +103,7 @@ def flows_from_changes(
             representing the current step.
 
     Returns:
-        Dict: A dictionary mapping each node that changed assignment between the previous and
+        dict: A dictionary mapping each node that changed assignment between the previous and
             current partitions to a dictionary of the form `{'in': <set of nodes that flowed in>,
             'out': <set of nodes that flowed out>}`.
     """
@@ -101,8 +114,11 @@ def flows_from_changes(
     # was a "flip" that did not in fact change the partition mapping...
     #
 
-    flows = collections.defaultdict(create_flow)
-    for node, target in new_partition.flips.items():
+    flows: dict[Hashable, dict[str, set[Hashable]]] = collections.defaultdict(create_flow)
+    flips = new_partition.flips
+    if flips is None:
+        return flows
+    for node, target in flips.items():
         source = old_partition.assignment.mapping[node]
         if source != target:
             flows[target]["in"].add(node)
@@ -110,7 +126,9 @@ def flows_from_changes(
     return flows
 
 
-def on_flow(initializer: Callable, alias: str) -> Callable:
+def on_flow(
+    initializer: Callable[[Partition], dict[KeyT, ValueT]], alias: str
+) -> Callable[[Callable[..., ValueT]], Callable[..., dict[KeyT, ValueT]]]:
     """A decorator that responds to flows of nodes between parts of the partition.
 
     Use this decorator to create an updater that responds to flows of nodes between parts of the
@@ -171,19 +189,28 @@ def on_flow(initializer: Callable, alias: str) -> Callable:
         updater function ``updater(partition)``.
     """
 
-    def decorator(function: Callable[..., object]) -> Callable:
+    def decorator(
+        function: Callable[..., ValueT],
+    ) -> Callable[..., dict[KeyT, ValueT]]:
         @functools.wraps(function)
-        def wrapped(partition: Partition, previous: dict | None = None) -> dict:
+        def wrapped(
+            partition: Partition, previous: dict[KeyT, ValueT] | None = None
+        ) -> dict[KeyT, ValueT]:
             if partition.parent is None:
                 return initializer(partition)
 
             if previous is None:
-                previous = partition.parent[alias]
+                parent_values = partition.parent[alias]
+                if not isinstance(parent_values, dict):
+                    raise TypeError(f"Updater {alias!r} must return a dictionary")
+                previous = cast(dict[KeyT, ValueT], parent_values)
 
             new_values = previous.copy()
 
+            assert partition.flows is not None
             for part, flow in partition.flows.items():
-                new_values[part] = function(partition, previous[part], flow["in"], flow["out"])
+                key = cast(KeyT, part)
+                new_values[key] = function(partition, previous[key], flow["in"], flow["out"])
 
             return new_values
 
@@ -192,19 +219,24 @@ def on_flow(initializer: Callable, alias: str) -> Callable:
     return decorator
 
 
-def compute_edge_flows(partition: Partition) -> dict[int, dict[str, set[tuple[int, int]]]]:
+def compute_edge_flows(
+    partition: Partition,
+) -> dict[Hashable, dict[str, set[tuple[int, int]]]]:
     """Computes the flow of cut edges between a partition and its parent.
 
     Args:
         partition (Partition): A partition of a Graph
 
     Returns:
-        Dict: A flow dictionary containing the flow from the parent of this partition to this
+        dict: A flow dictionary containing the flow from the parent of this partition to this
             partition. This dictionary is of the form `{part: {'in': <set of edges that flowed in>,
             'out': <set of edges that flowed out>}}`.
     """
-    edge_flows = collections.defaultdict(create_flow)
+    edge_flows: dict[Hashable, dict[str, set[tuple[int, int]]]] = collections.defaultdict(
+        create_edge_flow
+    )
     assignment = partition.assignment
+    assert partition.parent is not None
     old_assignment = partition.parent.assignment
 
     for node, neighbor in neighbor_flips(partition):
@@ -264,7 +296,9 @@ def compute_edge_flows(partition: Partition) -> dict[int, dict[str, set[tuple[in
     return edge_flows
 
 
-def on_edge_flow(initializer: Callable, alias: str) -> Callable:
+def on_edge_flow(
+    initializer: Callable[[Partition], dict[KeyT, ValueT]], alias: str
+) -> Callable[[Callable[..., ValueT]], Callable[[Partition], dict[KeyT, ValueT]]]:
     """A decorator that responds to flows of cut edges between parts of the partition.
 
     Use this decorator to create an updater that responds to flows of cut edges between parts of
@@ -320,19 +354,26 @@ def on_edge_flow(initializer: Callable, alias: str) -> Callable:
         updater function ``updater(partition)``.
     """
 
-    def decorator(f: Callable[..., object]) -> Callable:
+    def decorator(
+        f: Callable[..., ValueT],
+    ) -> Callable[[Partition], dict[KeyT, ValueT]]:
         @functools.wraps(f)
-        def wrapper(partition: Partition) -> dict:
+        def wrapper(partition: Partition) -> dict[KeyT, ValueT]:
             if not partition.parent:
                 return initializer(partition)
             edge_flows = partition.edge_flows
-            previous = partition.parent[alias]
+            assert edge_flows is not None
+            parent_values = partition.parent[alias]
+            if not isinstance(parent_values, dict):
+                raise TypeError(f"Updater {alias!r} must return a dictionary")
+            previous = cast(dict[KeyT, ValueT], parent_values)
 
             new_values = previous.copy()
-            for part in partition.edge_flows:
-                new_values[part] = f(
+            for part in edge_flows:
+                key = cast(KeyT, part)
+                new_values[key] = f(
                     partition,
-                    previous[part],
+                    previous[key],
                     new_edges=edge_flows[part]["in"],
                     old_edges=edge_flows[part]["out"],
                 )

--- a/gerrychain/updaters/locality_split_scores.py
+++ b/gerrychain/updaters/locality_split_scores.py
@@ -1,7 +1,9 @@
-# Imports
+from __future__ import annotations
+
 import math
 from collections import Counter, defaultdict
-from typing import List
+from collections.abc import Hashable, Iterable
+from ..partition import Partition
 
 
 class LocalitySplits:
@@ -42,27 +44,27 @@ class LocalitySplits:
         col_id (str): The name of the column containing the locality
             attribute (i.e. county ids, municipality names, etc.)
         pop_col (str): The name of the column containing population counts.
-        scores_to_compute (List[str]): A list/tuple/set of strings naming the
+        scores_to_compute (list[str]): A list/tuple/set of strings naming the
             score functions to compute at each step. This will generally be
             some subcollection of ```['num_parts', 'num_pieces',
             'naked_boundary', 'shannon_entropy', 'power_entropy',
             'symmetric_entropy', 'num_split_localities']```
         pent_alpha (float): A number between 0 and 1 which is passed as the
             exponent to `LocalitySplits.power_entropy`
-        localities (List[str]): A list containing the unique locality identifiers
+        localities (set[Hashable]): The unique locality identifiers
             (e.g. county names, municipality names, etc.) for the partition.
             This list is populated using the locality data stored on each of
             the nodes in the graph.
-        localitydict (Dict[str, str]): A dictionary mapping node IDs to locality IDs.
+        localitydict (dict[Hashable, Hashable]): A dictionary mapping node IDs to locality IDs.
             This is used to quickly look up the locality of a given node.
-        locality_splits (Dict[int, Counter[str]]): A dictionary mapping district IDs to a counter
+        locality_splits (dict[Hashable, Counter[Hashable]]): District IDs mapped to a counter
             of localities in that district. That is to say, this tells us
             how many nodes in each district are of the given locality type.
-        locality_splits_inv (Dict[str, Dict[int, int]]): The inverted dictionary of locality_splits
-        allowed_pieces (Dict[str, int]): A dictionary that maps each locality to the
+        locality_splits_inv (dict[Hashable, dict[Hashable, int]]): The inverted locality mapping.
+        allowed_pieces (dict[Hashable, int]): A dictionary that maps each locality to the
             minimum number of districts that locality must touch. This is
             computed using the ideal district population. NOT CURRENTLY USED.
-        scores (Dict[str, Any]): A dictionary initialized with the key values from the
+        scores (dict[str, int | float | None]): A dictionary initialized with keys from the
             initializer's scores_to_compute parameter. The initial values are
             set to none and are updated in each call to store the compted
             score value for each metric of interest.
@@ -73,9 +75,9 @@ class LocalitySplits:
         name: str,
         col_id: str,
         pop_col: str,
-        scores_to_compute: List[str] = ["num_parts"],
+        scores_to_compute: Iterable[str] = ("num_parts",),
         pent_alpha: float = 0.05,
-    ):
+    ) -> None:
         """Initialize a LocalitySplits instance.
 
         Args:
@@ -83,7 +85,7 @@ class LocalitySplits:
             col_id (str): The name of the column containing the locality attribute (i.e. county
                 ids, municipality names, etc.)
             pop_col (str): The name of the column containing population counts.
-            scores_to_compute (List[str], optional): A list/tuple/set of strings naming the score
+            scores_to_compute (Iterable[str], optional): Strings naming the score
                 functions to compute at each step. This should be some subcollection of
                 ```['num_parts', 'num_pieces', 'naked_boundary', 'shannon_entropy',
                 'power_entropy', 'symmetric_entropy', 'num_split_localities']```. Default is
@@ -99,10 +101,10 @@ class LocalitySplits:
 
         self.pent_alpha = pent_alpha
 
-        self.localities = []
-        self.localitydict = {}
-        self.locality_splits = {}
-        self.locality_splits_inv = {}
+        self.localities: set[Hashable] = set()
+        self.localitydict: dict[Hashable, Hashable] = {}
+        self.locality_splits: dict[Hashable, Counter[Hashable]] = {}
+        self.locality_splits_inv: dict[Hashable, dict[Hashable, int]] = {}
 
         # A dictionary containing the number minimum number
         # of districts which a locality must touch. I.e. if
@@ -112,33 +114,33 @@ class LocalitySplits:
         # presently used to compute any score functions,
         # but may be useful for future development or
         # certain use cases.
-        self.allowed_pieces = {}
+        self.allowed_pieces: dict[Hashable, int] = {}
 
-        self.scores = dict.fromkeys(scores_to_compute)
+        self.scores: dict[str, int | float | None] = dict.fromkeys(scores_to_compute)
 
-    def __call__(self, partition):
-
-        if self.localities == []:
+    def __call__(self, partition: Partition) -> dict[str, int | float | None]:
+        if not self.localities:
             self.localitydict = {}
             for node_id in partition.graph.node_indices:
                 self.localitydict[node_id] = partition.graph.node_data(node_id)[self.col_id]
 
-            self.localities = set(list(self.localitydict.values()))
+            self.localities = set(self.localitydict.values())
 
-        locality_splits = {
+        locality_splits: dict[Hashable, list[Hashable]] = {
             k: [self.localitydict[v] for v in d] for k, d in partition.assignment.parts.items()
         }
         self.locality_splits = {k: Counter(v) for k, v in locality_splits.items()}
 
-        self.locality_splits_inv = defaultdict(dict)
+        locality_splits_inv: defaultdict[Hashable, dict[Hashable, int]] = defaultdict(dict)
         for k, v in self.locality_splits.items():
             for k2, v2 in v.items():
-                self.locality_splits_inv[k2][k] = v2
+                locality_splits_inv[k2][k] = v2
+        self.locality_splits_inv = locality_splits_inv
 
         if self.allowed_pieces == {}:
-            allowed_pieces = {}
+            allowed_pieces: dict[Hashable, int] = {}
 
-            totpop = 0
+            totpop = 0.0
             for node_id in partition.graph.node_indices:
                 # Note: It would be nice to cache the total population for the partition's
                 # graph since it cannot be changed, but to do so we would need to know the
@@ -153,12 +155,9 @@ class LocalitySplits:
             # Compute the total population for each locality and then the number of
             # "allowed pieces"
             for _ in self.localities:
-
                 # Compute the population associated with each location
                 the_graph = partition.graph
-                locality_population = (
-                    {}
-                )  # dict mapping locality name to population in that locality
+                locality_population: dict[Hashable, float] = {}
                 for node_id in the_graph.node_indices:
                     locality_name = the_graph.node_data(node_id)[self.col_id]
                     locality_pop = the_graph.node_data(node_id)[self.pop_col]
@@ -203,7 +202,7 @@ class LocalitySplits:
 
         return self.scores
 
-    def num_parts(self, partition) -> int:
+    def num_parts(self, partition: Partition) -> int:
         """Calculates the number of unique locality-district pairs.
 
         Args:
@@ -218,7 +217,7 @@ class LocalitySplits:
             counter += len(self.locality_splits[district])
         return counter
 
-    def num_pieces(self, partition) -> int:
+    def num_pieces(self, partition: Partition) -> int:
         """Calculates the number of pieces formed by cutting the graph by both locality and
         district boundaries.
 
@@ -230,7 +229,7 @@ class LocalitySplits:
             int: Number of pieces, where each piece is formed by cutting the graph by both locality
                 and district boundaries.
         """
-        locality_intersections = {}
+        locality_intersections: dict[Hashable, set[Hashable]] = {}
 
         for n in partition.graph.node_indices:
             locality = partition.graph.node_data(n)[self.col_id]
@@ -253,7 +252,7 @@ class LocalitySplits:
                 pieces += subgraph.num_connected_components()
         return pieces
 
-    def naked_boundary(self, partition) -> int:
+    def naked_boundary(self, partition: Partition) -> int:
         """Computes the number of cut edges inside localities.
 
         Args:
@@ -274,7 +273,7 @@ class LocalitySplits:
                 cut_edges_within += 1
         return cut_edges_within
 
-    def shannon_entropy(self, partition) -> float:
+    def shannon_entropy(self, partition: Partition) -> float:
         """Computes the shannon entropy score of a district plan.
 
         Args:
@@ -316,7 +315,7 @@ class LocalitySplits:
             entropy += q * (inner_sum)
         return entropy
 
-    def power_entropy(self, partition) -> float:
+    def power_entropy(self, partition: Partition) -> float:
         """Computes the power entropy score of a district plan.
 
         Args:
@@ -358,7 +357,7 @@ class LocalitySplits:
             entropy += 1 / q * (inner_sum - 1)
         return entropy
 
-    def symmetric_entropy(self, partition) -> float:  # IN PROGRESS
+    def symmetric_entropy(self, partition: Partition) -> float:  # IN PROGRESS
         """Calculates the symmetric entropy score
 
         Warning:
@@ -371,26 +370,24 @@ class LocalitySplits:
             float: The symmetric square root entropy score.
         """
 
-        district_dict = dict(partition.parts)
-
-        for district in district_dict.keys():
-            vtds = district_dict[district]
-            locality_pop = {k: 0 for k in self.localities}
+        district_dict: dict[Hashable, dict[Hashable, int | float]] = {}
+        for district, vtds in partition.parts.items():
+            locality_pop: dict[Hashable, int | float] = {k: 0 for k in self.localities}
             for vtd in vtds:
                 locality_pop[self.localitydict[vtd]] += partition.graph.node_data(vtd)[self.pop_col]
             district_dict[district] = locality_pop
 
-        district_dict_inv = defaultdict(dict)
+        district_dict_inv: defaultdict[Hashable, dict[Hashable, int | float]] = defaultdict(dict)
         for k, v in district_dict.items():
             for k2, v2 in v.items():
                 district_dict_inv[k2][k] = v2
 
         # how do districts split localities?
-        score = 0
+        score = 0.0
         for district in district_dict.keys():
             localities_and_pops = district_dict[district]
             total = sum(localities_and_pops.values())
-            fractional_sum = 0
+            fractional_sum = 0.0
             for locality in localities_and_pops.keys():
                 fractional_sum += math.sqrt(localities_and_pops[locality] / total)
             score += total * fractional_sum
@@ -399,14 +396,14 @@ class LocalitySplits:
         for locality in district_dict_inv.keys():
             districts_and_pops = district_dict_inv[locality]
             total = sum(districts_and_pops.values())
-            fractional_sum = 0
+            fractional_sum = 0.0
             for district in districts_and_pops.keys():
                 fractional_sum += math.sqrt(districts_and_pops[district] / total)
             score += total * fractional_sum
 
         return score
 
-    def num_split_localities(self, partition) -> int:
+    def num_split_localities(self, partition: Partition) -> int:
         """Calculates the number of localities touching 2 or more districts.
 
         Args:

--- a/gerrychain/updaters/spanning_trees.py
+++ b/gerrychain/updaters/spanning_trees.py
@@ -5,6 +5,7 @@ Updaters that compute spanning tree statistics.
 from __future__ import annotations
 
 import math
+from collections.abc import Hashable
 from typing import TYPE_CHECKING
 
 import numpy
@@ -13,12 +14,12 @@ if TYPE_CHECKING:
     from ..partition.partition import Partition
 
 
-def _num_spanning_trees_in_district(partition: Partition, district: int) -> int:
+def _num_spanning_trees_in_district(partition: Partition, district: Hashable) -> int:
     """Computes the number of spanning trees in a subgraph of the partition defined by a district.
 
     Args:
         partition (Partition): Partition
-        district (int): A district label (part) in the partition.
+        district (Hashable): A district label (part) in the partition.
 
     Returns:
         int: The number of spanning trees in the subgraph of the partition corresponding to
@@ -26,13 +27,13 @@ def _num_spanning_trees_in_district(partition: Partition, district: int) -> int:
     """
     laplacian = partition.graph.laplacian_matrix()
     L = numpy.delete(numpy.delete(laplacian.todense(), 0, 0), 1, 1)
-    return math.exp(numpy.linalg.slogdet(L)[1])
+    return round(math.exp(numpy.linalg.slogdet(L)[1]))
 
 
-def num_spanning_trees(partition: Partition) -> dict[int, int]:
+def num_spanning_trees(partition: Partition) -> dict[Hashable, int]:
     """Return number of spanning trees in each part (district) of a partition.
 
     Returns:
-        Dict[int, int]: The number of spanning trees in each part (district) of a partition.
+        dict[Hashable, int]: The number of spanning trees in each part of a partition.
     """
     return {part: _num_spanning_trees_in_district(partition, part) for part in partition.parts}

--- a/gerrychain/updaters/tally.py
+++ b/gerrychain/updaters/tally.py
@@ -3,14 +3,15 @@ from __future__ import annotations
 import collections
 import math
 import warnings
-from typing import TYPE_CHECKING
+from collections.abc import Callable, Hashable, Mapping
+from typing import TYPE_CHECKING, cast
 
 import pandas
 
 from .flows import flows_from_changes, on_flow
 
 if TYPE_CHECKING:
-    from ..graph.graph import Graph
+    from ..graph.graph import FrozenGraph, Graph
     from ..partition.partition import Partition
 
 
@@ -20,7 +21,7 @@ class DataTally:
     node attributes
 
     Attributes:
-        data (Union[Dict, pandas.Series, str]): A Dict or Series indexed by the graph's nodes,
+        data (dict | pandas.Series | str): A Dict or Series indexed by the graph's nodes,
             or the string key for a node attribute containing the Tally's data.
         alias (str): The name of the tally in the Partition's `updaters` dictionary
     """
@@ -37,11 +38,15 @@ class DataTally:
 
     __slots__ = ["data", "alias", "_call"]
 
-    def __init__(self, data: dict | pandas.Series | str, alias: str) -> None:
+    def __init__(
+        self,
+        data: Mapping[Hashable, float] | pandas.Series | str,
+        alias: str,
+    ) -> None:
         """Initialize a DataTally instance.
 
         Args:
-            data (Union[Dict, pandas.Series, str]): A Dict or Series indexed by the graph's nodes,
+            data (dict | pandas.Series | str): A Dict or Series indexed by the graph's nodes,
                 or the string key for a node attribute containing the Tally's data.
             alias (str): The name of the tally in the Partition's `updaters` dictionary
 
@@ -49,8 +54,7 @@ class DataTally:
         self.data = data
         self.alias = alias
 
-        def initialize_tally(partition: Partition) -> dict[int, float]:
-
+        def initialize_tally(partition: Partition) -> dict[Hashable, float]:
             # If the "data" passed in was a string, then interpret that string
             # as the name of a node attribute in the graph, and construct
             # a dict of the form: {node_id: node_attribution_value}
@@ -66,9 +70,9 @@ class DataTally:
                 attribute = self.data
                 self.data = {node_id: graph.node_data(node_id)[attribute] for node_id in node_ids}
 
-            tally = collections.defaultdict(int)
+            tally: dict[Hashable, float] = collections.defaultdict(int)
             for node_id, part in partition.assignment.items():
-                add = self.data[node_id]
+                add = self._value(node_id)
 
                 # Note: math.isnan() will raise an exception if the value passed in is not
                 # numeric, so there is no need to do another check to ensure that the value
@@ -88,18 +92,23 @@ class DataTally:
         def update_tally(
             partition: Partition,
             previous: float,
-            new_nodes: set[int],
-            old_nodes: set[int],
+            new_nodes: set[Hashable],
+            old_nodes: set[Hashable],
         ) -> float:
-            inflow = sum(self.data[node] for node in new_nodes)
-            outflow = sum(self.data[node] for node in old_nodes)
+            inflow = sum(self._value(node) for node in new_nodes)
+            outflow = sum(self._value(node) for node in old_nodes)
             return previous + inflow - outflow
 
         self._call = update_tally
 
+    def _value(self, node: Hashable) -> float:
+        if isinstance(self.data, str):
+            raise RuntimeError("Tally data has not been initialized")
+        return cast(float, self.data[node])
+
     def __call__(
-        self, partition: Partition, previous: dict[int, float] | None = None
-    ) -> dict[int, float]:
+        self, partition: Partition, previous: dict[Hashable, float] | None = None
+    ) -> dict[Hashable, float]:
         return self._call(partition, previous)
 
 
@@ -108,12 +117,13 @@ class Tally:
     An updater for keeping a tally of one or more node attributes.
 
     Attributes:
-        fields (Union[str, List[str]]): The list of node attributes that you want to tally. Or just
+        fields (str | list[str]): The list of node attributes that you want to tally. Or just
         a
             single attribute name as a string.
-        alias (Optional[str]): The aliased name of this Tally (meaning, the key corresponding to
+        alias (str | None): The aliased name of this Tally (meaning, the key corresponding to
             this Tally in the Partition's updaters dictionary)
-        dtype (Any): The type (int, float, etc.) that you want the tally to have
+        dtype (Callable[[], float]): A zero-argument callable that creates the tally's initial
+            value.
     """
 
     __slots__ = ["fields", "alias", "dtype"]
@@ -122,18 +132,18 @@ class Tally:
         self,
         fields: str | list[str],
         alias: str | None = None,
-        dtype: type = int,
+        dtype: Callable[[], float] = int,
     ) -> None:
         """Initialize a Tally instance.
 
         Args:
-            fields (Union[str, List[str]]): The list of node attributes that you want to tally. Or
+            fields (str | list[str]): The list of node attributes that you want to tally. Or
                 a just a single attribute name as a string.
-            alias (Optional[str], optional): The aliased name of this Tally (meaning, the key
+            alias (str | None, optional): The aliased name of this Tally (meaning, the key
                 corresponding to this Tally in the Partition's updaters dictionary). Default is
                 None.
-            dtype (Any, optional): The type (int, float, etc.) that you want the tally to have.
-                Default is int.
+            dtype (Callable[[], float], optional): A zero-argument callable that creates the
+                tally's initial value. Defaults to ``int``.
 
         """
         if not isinstance(fields, list):
@@ -144,12 +154,12 @@ class Tally:
         self.alias = alias
         self.dtype = dtype
 
-    def __call__(self, partition: Partition) -> dict:
+    def __call__(self, partition: Partition) -> dict[Hashable, float]:
         if partition.parent is None:
             return self._initialize_tally(partition)
         return self._update_tally(partition)
 
-    def _initialize_tally(self, partition: Partition) -> dict:
+    def _initialize_tally(self, partition: Partition) -> dict[Hashable, float]:
         """Compute initial part-level tallies for the configured field values.
 
         Args:
@@ -157,7 +167,7 @@ class Tally:
                 tally for.
 
         Returns:
-            Dict: A dictionary keyed by the parts of the partition, with values being the sum of
+            dict: A dictionary keyed by the parts of the partition, with values being the sum of
                 the "field" attribute of nodes in that part.
         """
         tally = collections.defaultdict(self.dtype)
@@ -173,7 +183,7 @@ class Tally:
                 tally[part] += add
         return dict(tally)
 
-    def _update_tally(self, partition: Partition) -> dict:
+    def _update_tally(self, partition: Partition) -> dict[Hashable, float]:
         """Compute the district-wide tally of data stored in the "field" attribute of nodes.
 
         Args:
@@ -181,10 +191,11 @@ class Tally:
                 for.
 
         Returns:
-            Dict: A dictionary keyed by the parts of the partition, with the updated tallies of the
+            dict: A dictionary keyed by the parts of the partition, with the updated tallies of the
                 "field" attribute of nodes in each part.
         """
         parent = partition.parent
+        assert parent is not None
 
         old_tally = parent[self.alias]
         new_tally = dict(old_tally)
@@ -198,39 +209,41 @@ class Tally:
 
         return new_tally
 
-    def _get_tally_from_node(self, partition: Partition, node: int) -> float:
+    def _get_tally_from_node(self, partition: Partition, node: Hashable) -> float:
         return sum(partition.graph.node_data(node)[field] for field in self.fields)
 
 
-def compute_out_flow(graph: Graph, fields: str | list[str], flow: dict[str, set[int]]) -> float:
+def compute_out_flow(
+    graph: Graph | FrozenGraph, fields: list[str], flow: dict[str, set[Hashable]]
+) -> float:
     """Return sum of the "field" attribute of nodes in the "out" set of the flow.
 
     Args:
         graph (Graph): The graph that the partition is defined on.
-        fields (Union[str, List[str]]): The list of node attributes that you want to tally. Or just
-            a single attribute name as a string.
-        flow (Dict): A dictionary containing the flow from the parent of this partition to this
+        fields (list[str]): The list of node attributes that you want to tally.
+        flow (dict): A dictionary containing the flow from the parent of this partition to this
             partition. This dictionary is of the form `{part: {'in': <set of nodes that flowed in>,
             'out': <set of nodes that flowed out>}}`.
 
     Returns:
-        int: The sum of the "field" attribute of nodes in the "out" set of the flow.
+        float: The sum of the "field" attribute of nodes in the "out" set of the flow.
     """
     return sum(graph.node_data(node)[field] for node in flow["out"] for field in fields)
 
 
-def compute_in_flow(graph: Graph, fields: str | list[str], flow: dict[str, set[int]]) -> float:
+def compute_in_flow(
+    graph: Graph | FrozenGraph, fields: list[str], flow: dict[str, set[Hashable]]
+) -> float:
     """Return sum of the "field" attribute of nodes in the "in" set of the flow.
 
     Args:
         graph (Graph): The graph that the partition is defined on.
-        fields (Union[str, List[str]]): The list of node attributes that you want to tally. Or just
-            a single attribute name as a string.
-        flow (Dict): A dictionary containing the flow from the parent of this partition to this
+        fields (list[str]): The list of node attributes that you want to tally.
+        flow (dict): A dictionary containing the flow from the parent of this partition to this
             partition. This dictionary is of the form `{part: {'in': <set of nodes that flowed in>,
             'out': <set of nodes that flowed out>}}`.
 
     Returns:
-        int: The sum of the "field" attribute of nodes in the "in" set of the flow.
+        float: The sum of the "field" attribute of nodes in the "in" set of the flow.
     """
     return sum(graph.node_data(node)[field] for node in flow["in"] for field in fields)

--- a/gerrychain/vendor/utm/conversion.py
+++ b/gerrychain/vendor/utm/conversion.py
@@ -1,15 +1,11 @@
+from typing import Any
+
+import numpy as mathlib
+import numpy.typing as npt
+
 from .error import OutOfRangeError
 
-# For most use cases in this module, numpy is indistinguishable
-# from math, except it also works on numpy arrays
-try:
-    import numpy as mathlib
-
-    use_numpy = True
-except ImportError:
-    import math as mathlib  # type: ignore
-
-    use_numpy = False
+Coordinate = float | npt.NDArray[Any]
 
 __all__ = ["to_latlon", "from_latlon"]
 
@@ -42,17 +38,13 @@ R = 6378137
 ZONE_LETTERS = "CDEFGHJKLMNPQRSTUVWXX"
 
 
-def in_bounds(x, lower, upper, upper_strict=False):
-    if upper_strict and use_numpy:
-        return lower <= mathlib.min(x) and mathlib.max(x) < upper
-    elif upper_strict and not use_numpy:
-        return lower <= x < upper
-    elif use_numpy:
-        return lower <= mathlib.min(x) and mathlib.max(x) <= upper
-    return lower <= x <= upper
+def in_bounds(x: Coordinate, lower: float, upper: float, upper_strict: bool = False) -> bool:
+    if upper_strict:
+        return bool(lower <= mathlib.min(x)) and bool(mathlib.max(x) < upper)
+    return bool(lower <= mathlib.min(x)) and bool(mathlib.max(x) <= upper)
 
 
-def check_valid_zone(zone_number, zone_letter):
+def check_valid_zone(zone_number: int, zone_letter: str | None) -> None:
     if not 1 <= zone_number <= 60:
         raise OutOfRangeError("zone number out of range (must be between 1 and 60)")
 
@@ -63,41 +55,39 @@ def check_valid_zone(zone_number, zone_letter):
             raise OutOfRangeError("zone letter out of range (must be between C and X)")
 
 
-def mixed_signs(x):
-    return use_numpy and mathlib.min(x) < 0 and mathlib.max(x) >= 0
+def mixed_signs(x: Coordinate) -> bool:
+    return bool(mathlib.min(x) < 0) and bool(mathlib.max(x) >= 0)
 
 
-def negative(x):
-    if use_numpy:
-        return mathlib.max(x) < 0
-    return x < 0
+def negative(x: Coordinate) -> bool:
+    return bool(mathlib.max(x) < 0)
 
 
-def to_latlon(easting, northing, zone_number, zone_letter=None, northern=None, strict=True):
-    """This function convert an UTM coordinate into Latitude and Longitude
+def to_latlon(
+    easting: Coordinate,
+    northing: Coordinate,
+    zone_number: int,
+    zone_letter: str | None = None,
+    northern: bool | None = None,
+    strict: bool = True,
+) -> tuple[Coordinate, Coordinate]:
+    """Convert a UTM coordinate to latitude and longitude.
 
-     Parameters
-     ----------
-     easting: int
-         Easting value of UTM coordinate
+    Args:
+        easting (Coordinate): Easting value of the UTM coordinate.
+        northing (Coordinate): Northing value of the UTM coordinate.
+        zone_number (int): UTM zone number from 1 through 60.
+        zone_letter (str | None, optional): UTM zone letter. Defaults to ``None``.
+        northern (bool | None, optional): Whether the coordinate is in the northern hemisphere.
+            Defaults to ``None``.
+        strict (bool, optional): Whether to validate coordinate bounds. Defaults to ``True``.
 
-     northing: int
-         Northing value of UTM coordinate
+    Returns:
+        tuple[Coordinate, Coordinate]: Latitude and longitude.
 
-     zone number: int
-         Zone Number is represented with global map numbers of an UTM Zone
-         Numbers Map. More information see utmzones [1]_
-
-     zone_letter: str
-         Zone Letter can be represented as string values. Where UTM Zone
-         Designators can be accessed in [1]_
-
-     northern: bool
-         You can set True or False to set this parameter. Default is None
-
-
-    .. _[1]: http://www.jaworski.ca/utmzones.htm
-
+    Raises:
+        ValueError: If neither or both hemisphere indicators are provided.
+        OutOfRangeError: If a coordinate or zone is outside its valid range.
     """
     if not zone_letter and northern is None:
         raise ValueError("either zone_letter or northern needs to be set")
@@ -177,23 +167,26 @@ def to_latlon(easting, northing, zone_number, zone_letter=None, northern=None, s
     )
 
 
-def from_latlon(latitude, longitude, force_zone_number=None, force_zone_letter=None):
-    """This function convert Latitude and Longitude to UTM coordinate
+def from_latlon(
+    latitude: Coordinate,
+    longitude: Coordinate,
+    force_zone_number: int | None = None,
+    force_zone_letter: str | None = None,
+) -> tuple[Coordinate, Coordinate, int, str | None]:
+    """Convert latitude and longitude to a UTM coordinate.
 
-     Parameters
-     ----------
-     latitude: float
-         Latitude between 80 deg S and 84 deg N, e.g. (-80.0 to 84.0)
+    Args:
+        latitude (Coordinate): Latitude between 80 degrees south and 84 degrees north.
+        longitude (Coordinate): Longitude between 180 degrees west and 180 degrees east.
+        force_zone_number (int | None, optional): UTM zone number to use. Defaults to ``None``.
+        force_zone_letter (str | None, optional): UTM zone letter to use. Defaults to ``None``.
 
-     longitude: float
-         Longitude between 180 deg W and 180 deg E, e.g. (-180.0 to 180.0).
+    Returns:
+        tuple[Coordinate, Coordinate, int, str | None]: Easting, northing, zone number, and zone
+            letter.
 
-     force_zone number: int
-         Zone Number is represented with global map numbers of an UTM Zone
-         Numbers Map. You may force conversion including one UTM Zone Number.
-         More information see utmzones [1]_
-
-    .. _[1]: http://www.jaworski.ca/utmzones.htm
+    Raises:
+        OutOfRangeError: If a coordinate or forced zone is outside its valid range.
     """
     if not in_bounds(latitude, -80.0, 84.0):
         raise OutOfRangeError("latitude out of range (must be between 80 deg S and 84 deg N)")
@@ -271,11 +264,11 @@ def from_latlon(latitude, longitude, force_zone_number=None, force_zone_letter=N
     return easting, northing, zone_number, zone_letter
 
 
-def latitude_to_zone_letter(latitude):
+def latitude_to_zone_letter(latitude: Coordinate) -> str | None:
     # If the input is a numpy array, just use the first element
     # User responsibility to make sure that all points are in one zone
-    if use_numpy and isinstance(latitude, mathlib.ndarray):
-        latitude = latitude.flat[0]
+    if isinstance(latitude, mathlib.ndarray):
+        latitude = float(latitude.flat[0])
 
     if -80 <= latitude <= 84:
         return ZONE_LETTERS[int(latitude + 80) >> 3]
@@ -283,14 +276,13 @@ def latitude_to_zone_letter(latitude):
         return None
 
 
-def latlon_to_zone_number(latitude, longitude):
+def latlon_to_zone_number(latitude: Coordinate, longitude: Coordinate) -> int:
     # If the input is a numpy array, just use the first element
     # User responsibility to make sure that all points are in one zone
-    if use_numpy:
-        if isinstance(latitude, mathlib.ndarray):
-            latitude = latitude.flat[0]
-        if isinstance(longitude, mathlib.ndarray):
-            longitude = longitude.flat[0]
+    if isinstance(latitude, mathlib.ndarray):
+        latitude = float(latitude.flat[0])
+    if isinstance(longitude, mathlib.ndarray):
+        longitude = float(longitude.flat[0])
 
     if 56 <= latitude < 64 and 3 <= longitude < 12:
         return 32
@@ -308,5 +300,5 @@ def latlon_to_zone_number(latitude, longitude):
     return int((longitude + 180) / 6) + 1
 
 
-def zone_number_to_central_longitude(zone_number):
+def zone_number_to_central_longitude(zone_number: int) -> int:
     return (zone_number - 1) * 6 - 180 + 3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ packages = { find = { include = ["gerrychain*"], exclude = ["tests*"] } }
 [tool.setuptools.package-data]
 # Ship example graph data (e.g. Gerrymandria) inside the wheel so that
 # gerrychain.examples can load it via importlib.resources.
+"gerrychain" = ["py.typed"]
 "gerrychain.examples" = ["*.json"]
 
 [project]
@@ -34,28 +35,29 @@ dependencies = [
     "tqdm>=4.67.1",
 ]
 
-[tool.black]
-line-length = 100
-
-[tool.isort]
-profile = "black"
-line_length = 100
-multi_line_output = 3
-include_trailing_comma = true
-
 [tool.ruff]
 line-length = 100
-extend-exclude = [
-  "tests",
-  "**/__init__.py",
-  "gerrychain/vendor"
-]
 
 [tool.ruff.lint]
-select = ["E", "W", "F"]
+select = [
+  "E",
+  "W",
+  "F",
+  "UP006",
+  "UP007",
+  "UP045",
+  "ANN001",
+  "ANN002",
+  "ANN003",
+  "ANN201",
+  "ANN202",
+  "ANN204",
+  "ANN205",
+  "ANN206",
+]
 ignore = [
-    "E501",  # line length handled by black
-    "E203",  # whitespace before ':', handled by black
+    "E501",  # line length handled by Ruff's formatter
+    "E203",  # whitespace before ':', handled by Ruff's formatter
     "E731",  # do not assign lambda expression
 ]
 task-tags = ["TODO", "FIXME", "XXX", "HACK", "NOTE"]
@@ -63,12 +65,29 @@ task-tags = ["TODO", "FIXME", "XXX", "HACK", "NOTE"]
 [tool.ruff.lint.pycodestyle]
 ignore-overlong-task-comments = true
 
+[tool.ruff.lint.per-file-ignores]
+"**/__init__.py" = ["F401", "F403", "F405"]
+"tests/**" = ["ANN"]
+
+[tool.ty.environment]
+python-version = "3.11"
+
+[tool.ty.rules]
+missing-type-argument = "error"
+
+[tool.pyright]
+include = ["gerrychain", "tests/typing_assertions.py"]
+pythonVersion = "3.11"
+venvPath = "."
+venv = ".venv"
+typeCheckingMode = "standard"
+reportMissingParameterType = "error"
+reportMissingTypeArgument = "error"
+reportUnnecessaryTypeIgnoreComment = "error"
+
 [dependency-groups]
 dev = [
   # Linters, formatters, type checkers
-  "black>=25.1.0",
-  "isort>=6.0.1",
-  "autopep8>=2.3.2",
   "myst-parser>=4.0.1",
   # Iteractive kernel
   "ipykernel>=6.30.1",
@@ -79,6 +98,8 @@ dev = [
   # Other
   "pre-commit>=4.3.0",
   "ruff>=0.14.9",
+  "ty>=0.0.18",
+  "pyright>=1.1.402",
 ]
 docs = [
   "myst-parser>=4.0.1",

--- a/tests/_perf_tests/perf_test.py
+++ b/tests/_perf_tests/perf_test.py
@@ -9,7 +9,6 @@ from gerrychain.proposals import build_recom_proposal_fn
 
 
 def main():
-
     graph = gerrymandria()
 
     my_updaters = {
@@ -43,7 +42,7 @@ def main():
     assignment_list = []
 
     for i, item in enumerate(recom_chain):
-        print(f"Finished step {i+1}/{len(recom_chain)}", end="\r")
+        print(f"Finished step {i + 1}/{len(recom_chain)}", end="\r")
         assignment_list.append(item.assignment)
 
 

--- a/tests/_perf_tests/perf_test2.py
+++ b/tests/_perf_tests/perf_test2.py
@@ -14,7 +14,6 @@ from gerrychain.proposals import build_recom_proposal_fn
 
 
 def main():
-
     graph = Graph.from_json("./PA_VTDs.json")
 
     elections = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -182,7 +182,6 @@ def four_by_five_grid_nx():
 
 @pytest.fixture
 def graph_with_random_data_factory(three_by_three_grid):
-
     def factory(columns):
         graph = three_by_three_grid
         attach_random_data(graph, columns)

--- a/tests/constraints/test_contiguity.py
+++ b/tests/constraints/test_contiguity.py
@@ -3,7 +3,6 @@ from gerrychain.constraints.contiguity import contiguous_components
 
 
 def test_contiguous_components(graph):
-
     partition = Partition(graph, {0: 1, 1: 1, 2: 1, 3: 2, 4: 2, 5: 2, 6: 1, 7: 1, 8: 1})
 
     components = contiguous_components(partition)

--- a/tests/constraints/test_validity.py
+++ b/tests/constraints/test_validity.py
@@ -76,7 +76,7 @@ def test_discontiguous_with_single_flip_contiguous_no_flips_is_false(
 
 
 @pytest.mark.xfail(
-    reason="single_flip_contiguous does not work" "when the previous partition is discontiguous"
+    reason="single_flip_contiguous does not workwhen the previous partition is discontiguous"
 )
 def test_discontiguous_with_single_flip_contiguous_flips_is_false(
     discontiguous_partition_with_flips,

--- a/tests/frm_tests/test_frm_regression.py
+++ b/tests/frm_tests/test_frm_regression.py
@@ -28,9 +28,7 @@ initial_partition = Partition(graph, assignment="district", updaters=my_updaters
 # that we defined above and not with the population column in the json file.
 ideal_population = sum(initial_partition["population"].values()) / len(initial_partition)
 
-proposal = build_recom_proposal_fn(
-    pop_col="TOTPOP", pop_target=ideal_population, epsilon=0.01
-)
+proposal = build_recom_proposal_fn(pop_col="TOTPOP", pop_target=ideal_population, epsilon=0.01)
 
 recom_chain = MarkovChain(
     proposal=proposal,
@@ -44,7 +42,7 @@ recom_chain = MarkovChain(
 assignment_list = []
 
 for i, item in enumerate(recom_chain):
-    print(f"Finished step {i+1}/{len(recom_chain)}")
+    print(f"Finished step {i + 1}/{len(recom_chain)}")
     assignment_list.append(item.assignment)
 
 print("Enumerated the chain: number of entries in list is: ", len(assignment_list))

--- a/tests/optimization/test_single_metric.py
+++ b/tests/optimization/test_single_metric.py
@@ -48,6 +48,8 @@ def test_single_metric_sb_attains_min_quickly(four_by_five_grid_for_opt):
         maximize=False,
         rng=2024,
     )
+    assert optimizer.best_part is None
+    assert optimizer.best_score is None
 
     total_steps = 200
     burst_length = 5
@@ -507,7 +509,6 @@ def test_single_metric_sb_finds_hard_max(four_by_five_grid_for_opt):
 
 
 def test_single_metric_sa_finds_hard_max(four_by_five_grid_for_opt):
-
     def opt_fn(partition):
         mx = 10
         count = sum(1 for x in partition["opt_value_sum"].values() if x == mx)
@@ -560,7 +561,6 @@ def test_single_metric_sa_finds_hard_max(four_by_five_grid_for_opt):
 
 
 def test_single_metric_tilted_runs_finds_hard_max(four_by_five_grid_for_opt):
-
     def opt_fn(partition):
         mx = 10
         count = sum(1 for x in partition["opt_value_sum"].values() if x == mx)

--- a/tests/test_frm_graph.py
+++ b/tests/test_frm_graph.py
@@ -19,21 +19,21 @@ def top_level_graph_is_properly_configured(graph):
     # This routine tests that top-level graphs (not a subgraph)
     # are properly configured
     assert not graph._is_a_subgraph, "Top-level graph _is_a_subgraph is True"
-    assert hasattr(
-        graph, "_node_id_to_parent_node_id_map"
-    ), "Graph._node_id_to_parent_node_id_map is not set"
-    assert hasattr(
-        graph, "_node_id_to_original_nx_node_id_map"
-    ), "Graph._node_id_to_original_nx_node_id_map is not set"
+    assert hasattr(graph, "_node_id_to_parent_node_id_map"), (
+        "Graph._node_id_to_parent_node_id_map is not set"
+    )
+    assert hasattr(graph, "_node_id_to_original_nx_node_id_map"), (
+        "Graph._node_id_to_original_nx_node_id_map is not set"
+    )
 
 
 def test_from_networkx(four_by_five_grid_nx):
     graph = Graph.from_networkx(four_by_five_grid_nx)
     assert len(graph.node_indices) == 20, f"Expected 20 nodes but got {len(graph.node_indices)}"
     assert len(graph.edge_indices) == 26, f"Expected 26 edges but got {len(graph.edge_indices)}"
-    assert (
-        graph.node_data(1)["population"] == 10
-    ), f"Expected population of 10 but got {graph.node_data(1)['population']}"
+    assert graph.node_data(1)["population"] == 10, (
+        f"Expected population of 10 but got {graph.node_data(1)['population']}"
+    )
     top_level_graph_is_properly_configured(graph)
 
 
@@ -41,9 +41,9 @@ def test_from_rustworkx(four_by_five_grid_nx):
     rx_graph = rx.networkx_converter(four_by_five_grid_nx, keep_attributes=True)
     graph = Graph.from_rustworkx(rx_graph)
     assert len(graph.node_indices) == 20, f"Expected 20 nodes but got {len(graph.node_indices)}"
-    assert (
-        graph.node_data(1)["population"] == 10
-    ), f"Expected population of 10 but got {graph.node_data(1)['population']}"
+    assert graph.node_data(1)["population"] == 10, (
+        f"Expected population of 10 but got {graph.node_data(1)['population']}"
+    )
     top_level_graph_is_properly_configured(graph)
 
 
@@ -74,38 +74,38 @@ def test_convert_from_nx_to_rx(four_by_five_graph_nx):
 
     # Same number of nodes
     assert len(graph.node_indices) == 20, f"Expected 20 nodes but got {len(graph.node_indices)}"
-    assert (
-        len(converted_graph.node_indices) == 20
-    ), f"Expected 20 nodes but got {len(graph.node_indices)}"
+    assert len(converted_graph.node_indices) == 20, (
+        f"Expected 20 nodes but got {len(graph.node_indices)}"
+    )
 
     # Same number of edges
     assert len(graph.edge_indices) == 26, f"Expected 26 edges but got {len(graph.edge_indices)}"
-    assert (
-        len(converted_graph.edge_indices) == 26
-    ), f"Expected 26 edges but got {len(graph.edge_indices)}"
+    assert len(converted_graph.edge_indices) == 26, (
+        f"Expected 26 edges but got {len(graph.edge_indices)}"
+    )
 
     # Node data is the same
     # frm: TODO: Refactoring:  Do this the clever Python way and test ALL at the same time
     for node_id in graph.node_indices:
-        assert (
-            graph.node_data(node_id)["population"] == 10
-        ), f"Expected population of 10 but got {graph.node_data(node_id)['population']}"
-        assert (
-            graph.node_data(node_id)["nx_node_id"] == node_id
-        ), f"Expected nx_node_id of {node_id} but got {graph.node_data(node_id)['nx_node_id']}"
-        assert (
-            graph.node_data(node_id)["MVAP"] == 2
-        ), f"Expected MVAP of 2 but got {graph.node_data(node_id)['MVAP']}"
+        assert graph.node_data(node_id)["population"] == 10, (
+            f"Expected population of 10 but got {graph.node_data(node_id)['population']}"
+        )
+        assert graph.node_data(node_id)["nx_node_id"] == node_id, (
+            f"Expected nx_node_id of {node_id} but got {graph.node_data(node_id)['nx_node_id']}"
+        )
+        assert graph.node_data(node_id)["MVAP"] == 2, (
+            f"Expected MVAP of 2 but got {graph.node_data(node_id)['MVAP']}"
+        )
     for node_id in converted_graph.node_indices:
-        assert (
-            graph.node_data(node_id)["population"] == 10
-        ), f"Expected population of 10 but got {graph.node_data(node_id)['population']}"
+        assert graph.node_data(node_id)["population"] == 10, (
+            f"Expected population of 10 but got {graph.node_data(node_id)['population']}"
+        )
         # frm: TODO: Code: Need to use node_id map to get appropriate node_ids for RX graph
         # assert graph.node_data(node_id)["nx_node_id"] == node_id, \
         #   f"Expected nx_node_id of {node_id} but got {graph.node_data(node_id)['nx_node_id']}"
-        assert (
-            graph.node_data(node_id)["MVAP"] == 2
-        ), f"Expected MVAP of 2 but got {graph.node_data(node_id)['MVAP']}"
+        assert graph.node_data(node_id)["MVAP"] == 2, (
+            f"Expected MVAP of 2 but got {graph.node_data(node_id)['MVAP']}"
+        )
 
     # Confirm that the node_id map to the "original" NX node_ids is correct
     for node_id in converted_graph.nodes:
@@ -117,7 +117,6 @@ def test_convert_from_nx_to_rx(four_by_five_graph_nx):
 
 
 def test_get_edge_from_edge_id(four_by_five_graph_nx, four_by_five_graph_rx):
-
     # Test that get_edge_from_edge_id works for both NX and RX based Graph objects
 
     # NX edges and edge_ids are the same, so this first test is trivial
@@ -137,7 +136,6 @@ def test_get_edge_from_edge_id(four_by_five_graph_nx, four_by_five_graph_rx):
 
 
 def test_get_edge_id_from_edge(four_by_five_graph_nx, four_by_five_graph_rx):
-
     # Test that get_edge_id_from_edge works for both NX and RX based Graph objects
 
     # NX edges and edge_ids are the same, so this first test is trivial
@@ -216,9 +214,9 @@ def test_subgraph(four_by_five_graph_rx):
         subgraph_stored_node_id = subgraph_rx.node_data(subgraph_node_id)["nx_node_id"]
         subgraph_stored_node_id = subgraph_rx.node_data(subgraph_node_id)["nx_node_id"]
         parent_stored_node_id = parent_graph_rx.node_data(parent_node_id)["nx_node_id"]
-        assert (
-            parent_stored_node_id == subgraph_stored_node_id
-        ), "_node_id_to_parent_node_id_map is incorrect"
+        assert parent_stored_node_id == subgraph_stored_node_id, (
+            "_node_id_to_parent_node_id_map is incorrect"
+        )
 
     # verify that _node_id_to_original_nx_node_id_map is correct
     for (
@@ -226,9 +224,9 @@ def test_subgraph(four_by_five_graph_rx):
         original_node_id,
     ) in subgraph_rx._node_id_to_original_nx_node_id_map.items():
         subgraph_stored_node_id = subgraph_rx.node_data(subgraph_node_id)["nx_node_id"]
-        assert (
-            subgraph_stored_node_id == original_node_id
-        ), "_node_id_to_original_nx_node_id_map is incorrect"
+        assert subgraph_stored_node_id == original_node_id, (
+            "_node_id_to_original_nx_node_id_map is incorrect"
+        )
 
 
 def test_num_connected_components(four_by_five_graph_nx, four_by_five_graph_rx):
@@ -239,7 +237,6 @@ def test_num_connected_components(four_by_five_graph_nx, four_by_five_graph_rx):
 
 
 def test_subgraphs_for_connected_components(four_by_five_graph_nx, four_by_five_graph_rx):
-
     subgraphs_nx = four_by_five_graph_nx.subgraphs_for_connected_components()
     subgraphs_rx = four_by_five_graph_rx.subgraphs_for_connected_components()
 
@@ -283,7 +280,6 @@ def test_add_data():
 
 
 def graph_has_cycle(set_of_edges):
-
     #
     # Given a set of edges that define a graph, determine
     # if the graph has cycles.
@@ -325,7 +321,6 @@ def graph_has_cycle(set_of_edges):
         return adj_matrix
 
     def create_adjacency_matrix_from_set_of_edges(set_of_edges):
-
         # determine num_nodes
         #
         set_of_nodes = set()

--- a/tests/test_laplacian.py
+++ b/tests/test_laplacian.py
@@ -88,7 +88,6 @@ def rx_graph():
 
 
 def test_nx_rx_laplacian_matrix_equality(nx_graph, rx_graph):
-
     # Create Graph objects from the NX and RX graphs
     gc_nx_graph = Graph.from_networkx(nx_graph)
     gc_rx_graph = Graph.from_rustworkx(rx_graph)

--- a/tests/test_make_graph.py
+++ b/tests/test_make_graph.py
@@ -71,7 +71,6 @@ def target_file():
 
 
 def test_add_data_to_graph_can_handle_column_names_that_start_with_numbers():
-
     # frm: Test has been modified to work with new Graph object that has an NetworkX.Graph
     #           object embedded inside it.  I am not sure if this test actually tests
     #           anything useful anymore...

--- a/tests/test_metagraph.py
+++ b/tests/test_metagraph.py
@@ -15,7 +15,6 @@ def partition(graph):
 
 
 def test_all_cut_edge_flips(partition):
-
     # frm: TODO: Testing:  Maybe change all_cut_edge_flips to return a dict
     #
     # At present, it returns an iterator, which makes the code below

--- a/tests/test_region_aware.py
+++ b/tests/test_region_aware.py
@@ -318,7 +318,6 @@ def test_spanning_tree_fn_kwargs_forwarded_to_spanning_tree_fn():
 
 
 def test_region_surcharge_inside_spanning_tree_fn_kwargs_raises():
-
     nx_graph = nx.convert_node_labels_to_integers(nx.grid_2d_graph(6, 2))
     for node_id in nx_graph.nodes:
         nx_graph.nodes[node_id]["pop"] = 1

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -537,7 +537,6 @@ def test_bipartition_tree_threads_rng_to_custom_balanced_cut_fn(graph_with_pop_n
 
 
 def create_graphs_from_nx_edges(num_nodes, list_of_edges_nx, nx_to_rx_node_id_map):
-
     # NX is easy - just use the list of NX edges
     graph_nx = Graph.from_networkx(networkx.Graph(list_of_edges_nx))
 
@@ -698,7 +697,6 @@ def test_reversible_recom_works_as_a_proposal(partition_with_pop):
 
 
 def test_find_balanced_cuts_contraction():
-
     # frm: TODO: Testing:  Add test for RX-based Graph object
 
     tree = Graph.from_networkx(
@@ -720,7 +718,6 @@ def test_find_balanced_cuts_contraction():
 
 
 def test_no_balanced_cuts_contraction_when_one_side_okay():
-
     list_of_nodes_nx = [(0, 1), (1, 2), (2, 3), (3, 4)]
 
     # For this test we are not dealing with an RX-based Graph object
@@ -753,7 +750,6 @@ def test_no_balanced_cuts_contraction_when_one_side_okay():
 
 
 def test_find_balanced_cuts_memo():
-
     list_of_nodes_nx = [(0, 1), (1, 2), (1, 4), (3, 4), (4, 5), (3, 6), (6, 7), (6, 8)]
 
     # For this test we are not dealing with an RX-based Graph object
@@ -789,7 +785,6 @@ def test_find_balanced_cuts_memo():
 
 
 def test_no_balanced_cuts_memo_when_one_side_okay():
-
     list_of_nodes_nx = [(0, 1), (1, 2), (2, 3), (3, 4)]
 
     # For this test we are not dealing with an RX-based Graph object

--- a/tests/typing_assertions.py
+++ b/tests/typing_assertions.py
@@ -1,0 +1,41 @@
+"""Consumer-side assertions for public typing contracts."""
+
+from collections.abc import Hashable, Mapping
+from typing import Any, assert_type
+
+import networkx
+import rustworkx
+
+from gerrychain import Graph, Partition
+from gerrychain.constraints import Bounds, deviation_from_ideal, within_percent_of_ideal_population
+from gerrychain.optimization import SingleMetricOptimizer
+from gerrychain.updaters import Tally
+from gerrychain.updaters.election import get_percents
+
+
+def assert_public_types(
+    graph: Graph,
+    partition: Partition,
+    optimizer: SingleMetricOptimizer,
+    counts: Mapping[Hashable, float],
+    nx_graph: networkx.Graph[str, dict[str, int], dict[str, float]],
+    rx_graph: rustworkx.PyGraph[dict[str, int], dict[str, float]],
+) -> None:
+    """Pin public types from a package consumer's perspective."""
+    assert_type(graph.node_data(0), dict[str, Any])
+    assert_type(Graph.from_networkx(nx_graph), Graph)
+    assert_type(Graph.from_rustworkx(rx_graph), Graph)
+    assert_type(Partition(nx_graph, {"node": "district"}), Partition)
+
+    assert_type(partition.parts, dict[Hashable, frozenset[Hashable]])
+    assert_type(partition.flip({0: "district"}), Partition)
+
+    assert_type(optimizer.best_part, Partition | None)
+    assert_type(optimizer.best_score, float | None)
+
+    population_bound = within_percent_of_ideal_population(partition)
+    assert_type(population_bound, Bounds[[Partition]])
+    assert_type(deviation_from_ideal(partition), dict[Hashable, float])
+
+    assert_type(Tally("population")(partition), dict[Hashable, float])
+    assert_type(get_percents(counts, counts), dict[Hashable, float])

--- a/tests/updaters/test_perimeters.py
+++ b/tests/updaters/test_perimeters.py
@@ -8,7 +8,6 @@ from gerrychain.proposals import propose_random_flip
 
 
 def setup():
-
     # Note that the node_ids for the NX graph for a grid are tuples with the (x,y) position of the node
 
     grid = Grid((4, 4), with_diagonals=False)
@@ -35,7 +34,6 @@ def test_interior_perimeter_handles_flips_with_a_simple_grid():
 
 
 def test_cut_edges_by_part_handles_flips_with_a_simple_grid():
-
     # frm: TODO: Testing:  Add a graphic here
     #
     # That will allow the person reading this code to make sense

--- a/tests/updaters/test_split_scores.py
+++ b/tests/updaters/test_split_scores.py
@@ -101,7 +101,6 @@ def split_partition(graph_with_counties):
 
 
 class TestSplittingScores:
-
     def test_not_split(self, partition):
         _ = partition.updaters["splits"](partition)
         result = partition.updaters["splits"].scores

--- a/tests/updaters/test_splits.py
+++ b/tests/updaters/test_splits.py
@@ -51,7 +51,6 @@ class TestComputeCountySplits:
         assert set(second_result.keys()) == {"a", "b", "c"}
 
     def test_no_splits(self, graph_with_counties):
-
         # frm: TODO: Testing:  Why does this not just use "split_partition"?  Isn't it the same?
         partition = Partition(graph_with_counties, assignment="county")
 

--- a/tests/updaters/test_updaters.py
+++ b/tests/updaters/test_updaters.py
@@ -124,7 +124,6 @@ def test_vote_proportion_updater_returns_percentage_or_nan(partition_with_electi
 
 
 def test_vote_proportion_returns_nan_if_total_votes_is_zero(three_by_three_grid):
-
     election = Election("Mock Election", ["D", "R"], alias="election")
     graph = three_by_three_grid
 
@@ -202,7 +201,6 @@ def test_election_result_has_a_cute_str_method():
 def _convert_dict_of_set_of_rx_node_ids_to_set_of_nx_node_ids(
     dict_of_set_of_rx_nodes, nx_to_rx_node_id_map
 ):
-
     # frm: TODO: Testing:  This way to convert node_ids is clumsy and inconvenient.  Think of something better...
 
     # When we create a partition from an NX based Graph we convert it to be an
@@ -300,7 +298,6 @@ def test_exterior_boundaries_as_a_set(three_by_three_grid):
 
 
 def test_exterior_boundaries(three_by_three_grid):
-
     graph = three_by_three_grid
 
     for i in [0, 1, 2, 3, 5, 6, 7, 8]:
@@ -374,7 +371,6 @@ def reject_half_of_all_flips(partition):
 
 
 def test_elections_match_the_naive_computation(partition_with_election):
-
     chain = MarkovChain(
         propose_random_flip,
         Validator([no_vanishing_districts, reject_half_of_all_flips]),

--- a/uv.lock
+++ b/uv.lock
@@ -34,61 +34,12 @@ wheels = [
 ]
 
 [[package]]
-name = "autopep8"
-version = "2.3.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pycodestyle" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/50/d8/30873d2b7b57dee9263e53d142da044c4600a46f2d28374b3e38b023df16/autopep8-2.3.2.tar.gz", hash = "sha256:89440a4f969197b69a995e4ce0661b031f455a9f776d2c5ba3dbd83466931758", size = 92210, upload-time = "2025-01-14T14:46:18.454Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9e/43/53afb8ba17218f19b77c7834128566c5bbb100a0ad9ba2e8e89d089d7079/autopep8-2.3.2-py2.py3-none-any.whl", hash = "sha256:ce8ad498672c845a0c3de2629c15b635ec2b05ef8177a6e7c91c74f3e9b51128", size = 45807, upload-time = "2025-01-14T14:46:15.466Z" },
-]
-
-[[package]]
 name = "babel"
 version = "2.17.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7d/6b/d52e42361e1aa00709585ecc30b3f9684b3ab62530771402248b1b1d6240/babel-2.17.0.tar.gz", hash = "sha256:0c54cffb19f690cdcc52a3b50bcbf71e07a808d1c80d549f2459b9d2cf0afb9d", size = 9951852, upload-time = "2025-02-01T15:17:41.026Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/b8/3fe70c75fe32afc4bb507f75563d39bc5642255d1d94f1f23604725780bf/babel-2.17.0-py3-none-any.whl", hash = "sha256:4d0b53093fdfb4b21c92b5213dba5a1b23885afa8383709427046b21c366e5f2", size = 10182537, upload-time = "2025-02-01T15:17:37.39Z" },
-]
-
-[[package]]
-name = "black"
-version = "25.12.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "click" },
-    { name = "mypy-extensions" },
-    { name = "packaging" },
-    { name = "pathspec" },
-    { name = "platformdirs" },
-    { name = "pytokens" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c4/d9/07b458a3f1c525ac392b5edc6b191ff140b596f9d77092429417a54e249d/black-25.12.0.tar.gz", hash = "sha256:8d3dd9cea14bff7ddc0eb243c811cdb1a011ebb4800a5f0335a01a68654796a7", size = 659264, upload-time = "2025-12-08T01:40:52.501Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/60/ad/7ac0d0e1e0612788dbc48e62aef8a8e8feffac7eb3d787db4e43b8462fa8/black-25.12.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:d0cfa263e85caea2cff57d8f917f9f51adae8e20b610e2b23de35b5b11ce691a", size = 1877003, upload-time = "2025-12-08T01:43:29.967Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/dd/a237e9f565f3617a88b49284b59cbca2a4f56ebe68676c1aad0ce36a54a7/black-25.12.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1a2f578ae20c19c50a382286ba78bfbeafdf788579b053d8e4980afb079ab9be", size = 1712639, upload-time = "2025-12-08T01:52:46.756Z" },
-    { url = "https://files.pythonhosted.org/packages/12/80/e187079df1ea4c12a0c63282ddd8b81d5107db6d642f7d7b75a6bcd6fc21/black-25.12.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d3e1b65634b0e471d07ff86ec338819e2ef860689859ef4501ab7ac290431f9b", size = 1758143, upload-time = "2025-12-08T01:45:29.137Z" },
-    { url = "https://files.pythonhosted.org/packages/93/b5/3096ccee4f29dc2c3aac57274326c4d2d929a77e629f695f544e159bfae4/black-25.12.0-cp311-cp311-win_amd64.whl", hash = "sha256:a3fa71e3b8dd9f7c6ac4d818345237dfb4175ed3bf37cd5a581dbc4c034f1ec5", size = 1420698, upload-time = "2025-12-08T01:45:53.379Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/39/f81c0ffbc25ffbe61c7d0385bf277e62ffc3e52f5ee668d7369d9854fadf/black-25.12.0-cp311-cp311-win_arm64.whl", hash = "sha256:51e267458f7e650afed8445dc7edb3187143003d52a1b710c7321aef22aa9655", size = 1229317, upload-time = "2025-12-08T01:46:35.606Z" },
-    { url = "https://files.pythonhosted.org/packages/d1/bd/26083f805115db17fda9877b3c7321d08c647df39d0df4c4ca8f8450593e/black-25.12.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:31f96b7c98c1ddaeb07dc0f56c652e25bdedaac76d5b68a059d998b57c55594a", size = 1924178, upload-time = "2025-12-08T01:49:51.048Z" },
-    { url = "https://files.pythonhosted.org/packages/89/6b/ea00d6651561e2bdd9231c4177f4f2ae19cc13a0b0574f47602a7519b6ca/black-25.12.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:05dd459a19e218078a1f98178c13f861fe6a9a5f88fc969ca4d9b49eb1809783", size = 1742643, upload-time = "2025-12-08T01:49:59.09Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/f3/360fa4182e36e9875fabcf3a9717db9d27a8d11870f21cff97725c54f35b/black-25.12.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c1f68c5eff61f226934be6b5b80296cf6939e5d2f0c2f7d543ea08b204bfaf59", size = 1800158, upload-time = "2025-12-08T01:44:27.301Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/08/2c64830cb6616278067e040acca21d4f79727b23077633953081c9445d61/black-25.12.0-cp312-cp312-win_amd64.whl", hash = "sha256:274f940c147ddab4442d316b27f9e332ca586d39c85ecf59ebdea82cc9ee8892", size = 1426197, upload-time = "2025-12-08T01:45:51.198Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/60/a93f55fd9b9816b7432cf6842f0e3000fdd5b7869492a04b9011a133ee37/black-25.12.0-cp312-cp312-win_arm64.whl", hash = "sha256:169506ba91ef21e2e0591563deda7f00030cb466e747c4b09cb0a9dae5db2f43", size = 1237266, upload-time = "2025-12-08T01:45:10.556Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/52/c551e36bc95495d2aa1a37d50566267aa47608c81a53f91daa809e03293f/black-25.12.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:a05ddeb656534c3e27a05a29196c962877c83fa5503db89e68857d1161ad08a5", size = 1923809, upload-time = "2025-12-08T01:46:55.126Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/f7/aac9b014140ee56d247e707af8db0aae2e9efc28d4a8aba92d0abd7ae9d1/black-25.12.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:9ec77439ef3e34896995503865a85732c94396edcc739f302c5673a2315e1e7f", size = 1742384, upload-time = "2025-12-08T01:49:37.022Z" },
-    { url = "https://files.pythonhosted.org/packages/74/98/38aaa018b2ab06a863974c12b14a6266badc192b20603a81b738c47e902e/black-25.12.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0e509c858adf63aa61d908061b52e580c40eae0dfa72415fa47ac01b12e29baf", size = 1798761, upload-time = "2025-12-08T01:46:05.386Z" },
-    { url = "https://files.pythonhosted.org/packages/16/3a/a8ac542125f61574a3f015b521ca83b47321ed19bb63fe6d7560f348bfe1/black-25.12.0-cp313-cp313-win_amd64.whl", hash = "sha256:252678f07f5bac4ff0d0e9b261fbb029fa530cfa206d0a636a34ab445ef8ca9d", size = 1429180, upload-time = "2025-12-08T01:45:34.903Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/2d/bdc466a3db9145e946762d52cd55b1385509d9f9004fec1c97bdc8debbfb/black-25.12.0-cp313-cp313-win_arm64.whl", hash = "sha256:bc5b1c09fe3c931ddd20ee548511c64ebf964ada7e6f0763d443947fd1c603ce", size = 1239350, upload-time = "2025-12-08T01:46:09.458Z" },
-    { url = "https://files.pythonhosted.org/packages/35/46/1d8f2542210c502e2ae1060b2e09e47af6a5e5963cb78e22ec1a11170b28/black-25.12.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:0a0953b134f9335c2434864a643c842c44fba562155c738a2a37a4d61f00cad5", size = 1917015, upload-time = "2025-12-08T01:53:27.987Z" },
-    { url = "https://files.pythonhosted.org/packages/41/37/68accadf977672beb8e2c64e080f568c74159c1aaa6414b4cd2aef2d7906/black-25.12.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:2355bbb6c3b76062870942d8cc450d4f8ac71f9c93c40122762c8784df49543f", size = 1741830, upload-time = "2025-12-08T01:54:36.861Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/76/03608a9d8f0faad47a3af3a3c8c53af3367f6c0dd2d23a84710456c7ac56/black-25.12.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9678bd991cc793e81d19aeeae57966ee02909877cb65838ccffef24c3ebac08f", size = 1791450, upload-time = "2025-12-08T01:44:52.581Z" },
-    { url = "https://files.pythonhosted.org/packages/06/99/b2a4bd7dfaea7964974f947e1c76d6886d65fe5d24f687df2d85406b2609/black-25.12.0-cp314-cp314-win_amd64.whl", hash = "sha256:97596189949a8aad13ad12fcbb4ae89330039b96ad6742e6f6b45e75ad5cfd83", size = 1452042, upload-time = "2025-12-08T01:46:13.188Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/7c/d9825de75ae5dd7795d007681b752275ea85a1c5d83269b4b9c754c2aaab/black-25.12.0-cp314-cp314-win_arm64.whl", hash = "sha256:778285d9ea197f34704e3791ea9404cd6d07595745907dd2ce3da7a13627b29b", size = 1267446, upload-time = "2025-12-08T01:46:14.497Z" },
-    { url = "https://files.pythonhosted.org/packages/68/11/21331aed19145a952ad28fca2756a1433ee9308079bd03bd898e903a2e53/black-25.12.0-py3-none-any.whl", hash = "sha256:48ceb36c16dbc84062740049eef990bb2ce07598272e673c17d1a7720c71c828", size = 206191, upload-time = "2025-12-08T01:40:50.963Z" },
 ]
 
 [[package]]
@@ -250,18 +201,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/4b/51/8ade005e5ca5b0d80fb4aff72a3775b325bdc3d27408c8113811a7cbe640/charset_normalizer-3.4.4-cp314-cp314-win_amd64.whl", hash = "sha256:8a6562c3700cce886c5be75ade4a5db4214fda19fede41d9792d100288d8f94c", size = 107104, upload-time = "2025-10-14T04:41:51.051Z" },
     { url = "https://files.pythonhosted.org/packages/da/5f/6b8f83a55bb8278772c5ae54a577f3099025f9ade59d0136ac24a0df4bde/charset_normalizer-3.4.4-cp314-cp314-win_arm64.whl", hash = "sha256:de00632ca48df9daf77a2c65a484531649261ec9f25489917f09e455cb09ddb2", size = 100743, upload-time = "2025-10-14T04:41:52.122Z" },
     { url = "https://files.pythonhosted.org/packages/0a/4c/925909008ed5a988ccbb72dcc897407e5d6d3bd72410d69e051fc0c14647/charset_normalizer-3.4.4-py3-none-any.whl", hash = "sha256:7a32c560861a02ff789ad905a2fe94e3f840803362c84fecf1851cb4cf3dc37f", size = 53402, upload-time = "2025-10-14T04:42:31.76Z" },
-]
-
-[[package]]
-name = "click"
-version = "8.3.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
 ]
 
 [[package]]
@@ -627,16 +566,15 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "autopep8" },
-    { name = "black" },
     { name = "ipykernel" },
     { name = "ipywidgets" },
-    { name = "isort" },
     { name = "myst-parser" },
     { name = "pre-commit" },
+    { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "ruff" },
+    { name = "ty" },
 ]
 docs = [
     { name = "myst-parser" },
@@ -663,16 +601,15 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "autopep8", specifier = ">=2.3.2" },
-    { name = "black", specifier = ">=25.1.0" },
     { name = "ipykernel", specifier = ">=6.30.1" },
     { name = "ipywidgets", specifier = ">=8.1.7" },
-    { name = "isort", specifier = ">=6.0.1" },
     { name = "myst-parser", specifier = ">=4.0.1" },
     { name = "pre-commit", specifier = ">=4.3.0" },
+    { name = "pyright", specifier = ">=1.1.402" },
     { name = "pytest", specifier = ">=8.4.2" },
     { name = "pytest-cov", specifier = ">=6.3.0" },
     { name = "ruff", specifier = ">=0.14.9" },
+    { name = "ty", specifier = ">=0.0.18" },
 ]
 docs = [
     { name = "myst-parser", specifier = ">=4.0.1" },
@@ -791,15 +728,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/4c/ae/c5ce1edc1afe042eadb445e95b0671b03cee61895264357956e61c0d2ac0/ipywidgets-8.1.8.tar.gz", hash = "sha256:61f969306b95f85fba6b6986b7fe45d73124d1d9e3023a8068710d47a22ea668", size = 116739, upload-time = "2025-11-01T21:18:12.393Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/6d/0d9848617b9f753b87f214f1c682592f7ca42de085f564352f10f0843026/ipywidgets-8.1.8-py3-none-any.whl", hash = "sha256:ecaca67aed704a338f88f67b1181b58f821ab5dc89c1f0f5ef99db43c1c2921e", size = 139808, upload-time = "2025-11-01T21:18:10.956Z" },
-]
-
-[[package]]
-name = "isort"
-version = "7.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/63/53/4f3c058e3bace40282876f9b553343376ee687f3c35a525dc79dbd450f88/isort-7.0.0.tar.gz", hash = "sha256:5513527951aadb3ac4292a41a16cbc50dd1642432f5e8c20057d414bdafb4187", size = 805049, upload-time = "2025-10-11T13:30:59.107Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7f/ed/e3705d6d02b4f7aea715a353c8ce193efd0b5db13e204df895d38734c244/isort-7.0.0-py3-none-any.whl", hash = "sha256:1bcabac8bc3c36c7fb7b98a76c8abb18e0f841a3ba81decac7691008592499c1", size = 94672, upload-time = "2025-10-11T13:30:57.665Z" },
 ]
 
 [[package]]
@@ -1138,15 +1066,6 @@ wheels = [
 ]
 
 [[package]]
-name = "mypy-extensions"
-version = "1.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a2/6e/371856a3fb9d31ca8dac321cda606860fa4548858c0cc45d9d1d4ca2628b/mypy_extensions-1.1.0.tar.gz", hash = "sha256:52e68efc3284861e772bbcd66823fde5ae21fd2fdb51c62a211403730b916558", size = 6343, upload-time = "2025-04-22T14:54:24.164Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/79/7b/2c79738432f5c924bef5071f933bcc9efd0473bac3b4aa584a6f7c1c8df8/mypy_extensions-1.1.0-py3-none-any.whl", hash = "sha256:1be4cccdb0f2482337c4743e60421de3a356cd97508abadd57d47403e94f5505", size = 4963, upload-time = "2025-04-22T14:54:22.983Z" },
-]
-
-[[package]]
 name = "myst-parser"
 version = "4.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1344,15 +1263,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pathspec"
-version = "0.12.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ca/bc/f35b8446f4531a7cb215605d100cd88b7ac6f44ab3fc94870c120ab3adbf/pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712", size = 51043, upload-time = "2023-12-10T22:30:45Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/cc/20/ff623b09d963f88bfde16306a54e12ee5ea43e9b597108672ff3a408aad6/pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08", size = 31191, upload-time = "2023-12-10T22:30:43.14Z" },
-]
-
-[[package]]
 name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1542,15 +1452,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pycodestyle"
-version = "2.14.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/11/e0/abfd2a0d2efe47670df87f3e3a0e2edda42f055053c85361f19c0e2c1ca8/pycodestyle-2.14.0.tar.gz", hash = "sha256:c4b5b517d278089ff9d0abdec919cd97262a3367449ea1c8b49b91529167b783", size = 39472, upload-time = "2025-06-20T18:49:48.75Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d7/27/a58ddaf8c588a3ef080db9d0b7e0b97215cee3a45df74f3a94dbbf5c893a/pycodestyle-2.14.0-py2.py3-none-any.whl", hash = "sha256:dd6bf7cb4ee77f8e016f9c8e74a35ddd9f67e1d5fd4184d86c3b98e07099f42d", size = 31594, upload-time = "2025-06-20T18:49:47.491Z" },
-]
-
-[[package]]
 name = "pycparser"
 version = "2.23"
 source = { registry = "https://pypi.org/simple" }
@@ -1692,6 +1593,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pyright"
+version = "1.1.411"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodeenv" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7e/ab/265f7dc69d28113ebba19092e57b075f41543b2ed048429c5f56e2b88eac/pyright-1.1.411.tar.gz", hash = "sha256:d885a0551f2e763b089a02702174e7f4ba77548cddabc972ab86d1f7f1b0f998", size = 4112861, upload-time = "2026-06-25T02:14:06.37Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/49/385be530a6a5b78d1cbcd5c2e38debc8959a2fc6bdb716f4e581002979fc/pyright-1.1.411-py3-none-any.whl", hash = "sha256:dc7c72a8e2700c55baa127554040e067041ea53ccfd50bf96308cc4291c7d5d9", size = 6181526, upload-time = "2026-06-25T02:14:04.691Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1731,15 +1645,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
-]
-
-[[package]]
-name = "pytokens"
-version = "0.3.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4e/8d/a762be14dae1c3bf280202ba3172020b2b0b4c537f94427435f19c413b72/pytokens-0.3.0.tar.gz", hash = "sha256:2f932b14ed08de5fcf0b391ace2642f858f1394c0857202959000b68ed7a458a", size = 17644, upload-time = "2025-11-05T13:36:35.34Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/84/25/d9db8be44e205a124f6c98bc0324b2bb149b7431c53877fc6d1038dddaf5/pytokens-0.3.0-py3-none-any.whl", hash = "sha256:95b2b5eaf832e469d141a378872480ede3f251a5a5041b8ec6e581d3ac71bbf3", size = 12195, upload-time = "2025-11-05T13:36:33.183Z" },
 ]
 
 [[package]]
@@ -2319,6 +2224,31 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/eb/79/72064e6a701c2183016abbbfedaba506d81e30e232a68c9f0d6f6fcd1574/traitlets-5.14.3.tar.gz", hash = "sha256:9ed0579d3502c94b4b3732ac120375cda96f923114522847de4b3bb98b96b6b7", size = 161621, upload-time = "2024-04-19T11:11:49.746Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl", hash = "sha256:b74e89e397b1ed28cc831db7aea759ba6640cb3de13090ca145426688ff1ac4f", size = 85359, upload-time = "2024-04-19T11:11:46.763Z" },
+]
+
+[[package]]
+name = "ty"
+version = "0.0.58"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/09/4c/26c90732658903aeb1d289208f7b7b492fa21029e0c4d6c51bdd6f8f5e51/ty-0.0.58.tar.gz", hash = "sha256:8f22484174e65c630660a454bf81b80cae7a3a7e70479f19c170d6cd87949258", size = 6133665, upload-time = "2026-07-10T03:09:30.542Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/e1/5d1aa2a75829459834689f080e4be7a9d8828ce14b939ebed69161a35811/ty-0.0.58-py3-none-linux_armv6l.whl", hash = "sha256:47412850b6fbef61c42f244f6a51aa2f2c9e91f08cfbafd2d1e3730d2419d317", size = 11706915, upload-time = "2026-07-10T03:08:51.028Z" },
+    { url = "https://files.pythonhosted.org/packages/96/e1/929eda9cc72a9afe39a03c76f946a503508d37343cc8ff2e64226afda105/ty-0.0.58-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:79deb7bb4e5b3a1eee6ab9abc724d6ce3559d4977982707f310a139ee11fc703", size = 11532079, upload-time = "2026-07-10T03:08:53.771Z" },
+    { url = "https://files.pythonhosted.org/packages/07/43/ebc58b3fc7d86a7abba2829f1674f7d4ae3a08f9794c1f31b707950c871f/ty-0.0.58-py3-none-macosx_11_0_arm64.whl", hash = "sha256:5a28af3187e661708a386d44a4fc32896a5f589fb07b734a11ab2f516e7572b7", size = 11092983, upload-time = "2026-07-10T03:08:56.025Z" },
+    { url = "https://files.pythonhosted.org/packages/92/6e/9547dbb8e51e47749cfb721a02b4fc862f9a932fa0f66a34a4d6dc429bb1/ty-0.0.58-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:21a6977e34bc362fb378add46e59d5d56331c1c36727e6904767217ca8479718", size = 11490492, upload-time = "2026-07-10T03:08:58.49Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/76/9f83b51b5e7795d6c8d76b4bb1bb7cebf4c10d609e846c02ab138e404556/ty-0.0.58-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3ac23e6bf6105ceca46632debf1b10b98125aaf60202aeae02f6abfeea242b3d", size = 11503696, upload-time = "2026-07-10T03:09:00.741Z" },
+    { url = "https://files.pythonhosted.org/packages/47/9d/9fd48a0696c680f74e50f31cd54e524eeb58c97ea9bb1c3b8e04230ba215/ty-0.0.58-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bb6df6a8c6a21894807a49851370ec7fc64aa910296c78ada31db0ef19359112", size = 12158653, upload-time = "2026-07-10T03:09:02.998Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/ea/b5de845d2d8edae04d901c7585af7f04a057e18b26311f7fa4ca62b2da30/ty-0.0.58-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9df5847eebc026cde088b44420a03f7c6c169a7db747176bdf0a656eb1144713", size = 12723019, upload-time = "2026-07-10T03:09:05.291Z" },
+    { url = "https://files.pythonhosted.org/packages/17/1c/54083b23eeff1e101f50b6df6a2c7f1e14b31abe0577c91bcae9e2c9395d/ty-0.0.58-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:53a331a7f1f85872c810676a0f16096ef98c1b95c8c9a573fe7fde64d0a93e7c", size = 12275715, upload-time = "2026-07-10T03:09:07.564Z" },
+    { url = "https://files.pythonhosted.org/packages/22/88/16925434b06faa49d36aa7e7508a6821ec6feacb429ca2fd80a3d52716b4/ty-0.0.58-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fb0b05cd479fdcedc2e6781d376ee1a33569f37ae7f58357004635f615c4374c", size = 12033075, upload-time = "2026-07-10T03:09:10.222Z" },
+    { url = "https://files.pythonhosted.org/packages/58/2b/b55708dd483982ae03d14da3667e3f0346cd384e11cca3dd3674a8b598c1/ty-0.0.58-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:9a0012786077e5becbb6add9fe51eda1d4d36d249afd3ae6cd141d554af15ae3", size = 12367729, upload-time = "2026-07-10T03:09:12.338Z" },
+    { url = "https://files.pythonhosted.org/packages/91/a3/99ad66652956408f7e9ac3db6b4a416199d773b6c073cf95b0eea126d340/ty-0.0.58-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:4ede96d7f6d149156da254e784b062b817736b68d4c6d660555a3d02d96966fb", size = 11439798, upload-time = "2026-07-10T03:09:14.518Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/23/344ceed4fe02ed498711e1f4a47b6e311fb1e9c4fecc19d31894be7a3472/ty-0.0.58-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:47608e58f73901b989402e6f283249cda4c2314282ec368aa74ab61761c62bd5", size = 11512695, upload-time = "2026-07-10T03:09:16.852Z" },
+    { url = "https://files.pythonhosted.org/packages/55/cf/3801831812c468f3fd0b3043a80f557a9aa90e6c27375763d7c3121e03f2/ty-0.0.58-py3-none-musllinux_1_2_i686.whl", hash = "sha256:9757de17cc17e4c6bc26e18d4e26dea52ffee53d41a10d9087c6465e6ab12e2b", size = 11812253, upload-time = "2026-07-10T03:09:19.151Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/80/bce4f245787b77d1ec9feec7d9161eade5e01a77dbc132e016b24df83b0d/ty-0.0.58-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:f3776d54c1d935fcb8f814bd58efba402c86c555f93e1144c59d087e7aa8b906", size = 12123918, upload-time = "2026-07-10T03:09:21.636Z" },
+    { url = "https://files.pythonhosted.org/packages/46/00/bab3d6268e7e88c792bf7cdde81bd11b31aa587eaba75196502b729747c8/ty-0.0.58-py3-none-win32.whl", hash = "sha256:8f50ec0ac3b42baa4c75895dc367071dc86b00ab440d29fdc72c633286a94815", size = 11230897, upload-time = "2026-07-10T03:09:23.871Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/68/d9504c895864aaa84a840dce6ac7f8e681f6938be1882c8d4f60832dbe57/ty-0.0.58-py3-none-win_amd64.whl", hash = "sha256:de8847b3a65475ae4773bddd3126bfcf29f017e88967c4dcc9c75d743a4d3e5c", size = 12299376, upload-time = "2026-07-10T03:09:26.292Z" },
+    { url = "https://files.pythonhosted.org/packages/26/04/c9847cb680b5fe8e1f7d7b483edd5cedcc29394496e7b8ed40d96be796ba/ty-0.0.58-py3-none-win_arm64.whl", hash = "sha256:7334bb38789878f60677f2eb9c1de4bfdf4583e2443790989c77da9b10fe0989", size = 11710495, upload-time = "2026-07-10T03:09:28.478Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Strengthen Python typing and update typecheck tooling

## Summary

No review required on this PR: it just strengthens the type annotations and docstrings across the shipped `gerrychain` package updates some of the development tooling.

This PR completes the type annotations across the package and modernizes existing docstrings to use Python 3.11 syntax. It also replaces the previous mix of formatting and import-sorting tools with Ruff and adds two-stage type checking with Astral's `ty` followed by Pyright.

## Changes

- Add parameter and return annotations to every function in `gerrychain`.
- Replace legacy typing forms such as `Optional[T]`, `Union`, and capitalized collection aliases with `T | None` and built-in generics.
- Update Google-style docstring types to match the annotated APIs.
- Ship a PEP 561 `py.typed` marker so type checkers recognize the installed package as typed.
- Use concrete types, protocols, generics, and runtime narrowing instead of broad `Any` types.
- Keep `Any` only at genuinely dynamic boundaries: heterogeneous graph attributes and updater results, delegated NetworkX attributes, and third-party plotting keyword arguments.
- Preserve wrapped callable signatures with `ParamSpec` and use typed protocols for callback contracts that cannot be expressed accurately with a broad `Callable`.
- Model graph node, edge, district, county, and locality identifiers as `Hashable` where the APIs do not require integers.
- Keep graph-conversion TypeVars where they allow invariant NetworkX and RustworkX graph types to retain concrete payload types at the input boundary.
- Correct flow updater parameters to accept `set[Hashable]` and remove stale `None` handling from balanced-tree callbacks whose contract returns a node set or raises.
- Add consumer-side type assertions for the public contracts shared by `ty` and Pyright.
- Configure Ruff as the formatter and linter.
- Add `ty` and Pyright to the uv development dependencies and lockfile.
- Add a `make type-check` target that runs `ty` first and Pyright second, and include it in `make lint`.
- Simplify the uv setup targets by removing redundant editable installs and sync operations.

## Validation

- `make type-check`
  - `ty`: passed
  - Pyright: 0 errors, 0 warnings
- `uv run ruff check gerrychain tests`: passed
- `make test-all`: 322 passed, 2 xfailed, 0 failed
- Speed benchmark showed no regressions from all of the casting
