### PR TITLE
Fix Gingleator empty list maximum

### DIFF
--- a/gerrychain/optimization/gingleator.py
+++ b/gerrychain/optimization/gingleator.py
@@ -138,7 +138,12 @@ class Gingleator(SingleMetricOptimizer):
         """
         dist_percs = part[minority_perc_col].values()
         num_opport_dists = sum(list(map(lambda v: v >= threshold, dist_percs)))
-        next_dist = max(i for i in dist_percs if i < threshold)
+
+        if num_opport_dists < len(dist_percs):
+            next_dist = max(i for i in dist_percs if i < threshold)
+        else:
+            next_dist = 0
+
         return num_opport_dists + next_dist
 
     @classmethod
@@ -163,7 +168,11 @@ class Gingleator(SingleMetricOptimizer):
         """
         dist_percs = part[minority_perc_col].values()
         num_opport_dists = sum(list(map(lambda v: v >= threshold, dist_percs)))
-        next_dist = max(i for i in dist_percs if i < threshold)
+
+        if num_opport_dists < len(dist_percs):
+            next_dist = max(i for i in dist_percs if i < threshold)
+        else:
+            next_dist = 0
 
         if next_dist < threshold - 0.1:
             return num_opport_dists

--- a/tests/optimization/test_gingleator.py
+++ b/tests/optimization/test_gingleator.py
@@ -197,7 +197,7 @@ def test_reward_partial_dist(four_by_five_grid_for_opt):
     assert Gingleator.reward_partial_dist(initial_partition, "m_perc", 0.6) == 0.52
 
     try:
-        Gingleator.reward_partial_dist(initial_partition, "m_perc", 0.0)
+        assert Gingleator.reward_partial_dist(initial_partition, "m_perc", 0.0) == 4 + 0
     except ValueError as val_err:
         pytest.fail(f"ValueError raised when all districts are majority-minority: {str(val_err)}")
 
@@ -212,7 +212,7 @@ def test_reward_next_highest_close(four_by_five_grid_for_opt):
     )
 
     try:
-        Gingleator.reward_next_highest_close(initial_partition, "m_perc", 0.0)
+        assert Gingleator.reward_next_highest_close(initial_partition, "m_perc", 0.0) == 4 + (0 - 0.0 + 0.1) * 10
     except ValueError as val_err:
         pytest.fail(f"ValueError raised when all districts are majority-minority: {str(val_err)}")
 

--- a/tests/optimization/test_gingleator.py
+++ b/tests/optimization/test_gingleator.py
@@ -196,6 +196,11 @@ def test_reward_partial_dist(four_by_five_grid_for_opt):
     assert Gingleator.reward_partial_dist(initial_partition, "m_perc", 0.5) == 2 + 0.2
     assert Gingleator.reward_partial_dist(initial_partition, "m_perc", 0.6) == 0.52
 
+    try:
+        Gingleator.reward_partial_dist(initial_partition, "m_perc", 0.0)
+    except ValueError as val_err:
+        pytest.fail(f"ValueError raised when all districts are majority-minority: {str(val_err)}")
+
 
 def test_reward_next_highest_close(four_by_five_grid_for_opt):
     initial_partition = gingleator_test_partition(four_by_five_grid_for_opt)
@@ -205,6 +210,11 @@ def test_reward_next_highest_close(four_by_five_grid_for_opt):
     assert (
         round(Gingleator.reward_next_highest_close(initial_partition, "m_perc", 0.29), 5) == 2 + 0.1
     )
+
+    try:
+        Gingleator.reward_next_highest_close(initial_partition, "m_perc", 0.0)
+    except ValueError as val_err:
+        pytest.fail(f"ValueError raised when all districts are majority-minority: {str(val_err)}")
 
 
 def test_penalize_maximum_over(four_by_five_grid_for_opt):


### PR DESCRIPTION
## Summary

This PR avoids `ValueError: max() iterable argument is empty` for globally optimal Gingle districts.

Closes #424.

## Why

As detailed in #424, the `reward_partial_dist()` and `reward_next_highest_close()` methods of `Gingleator` throw an error when all districts are majority-minority; they attempt to get the maximum of a list of below-threshold percentages, which is empty when all districts are above the Gingle threshold.

## Changes

- Set `next_dist = 0` if no districts are below the Gingle district threshold

## Testing

Added regression tests to avoid this in future.

- [x] Tests pass locally
- [x] Added/updated tests
- [x] Manually tested relevant behavior
- [ ] Not applicable

## Reviewer Notes

- No test (`pytest` and `flake8`) failed that did not also fail on main 4a66510.
- Regression tests have `threshold = 0.0` to test when all districts are majority-minority.