### PR TITLE
Update ReCom class to behave like a simpler namespace / interface for users

### DIFF
--- a/gerrychain/graph/graph.py
+++ b/gerrychain/graph/graph.py
@@ -2036,9 +2036,12 @@ class Graph:
         is, all of the nodes that are directly connected to the given node by an edge.
 
         The result supports iteration (repeatedly), ``len()``, and indexing, but it is not
-        guaranteed to be a ``list``: for an RX graph it is the ``rustworkx.NodeIndices``
-        sequence returned by the backend, which avoids copying the neighbors into a fresh
-        list on every call. Callers that need list methods should wrap it in ``list()``.
+        guaranteed to be a ``list``. Callers that need list methods should wrap it in ``list()``.
+
+        The neighbors are returned in a deterministic order. RX collects neighbors into a randomly
+        seeded HashSet, so the raw ``rustworkx.NodeIndices`` order varies call to call; any seeded
+        algorithm that maps RNG draws over neighbor order (a random walk, a BFS feeding a random
+        choice) would otherwise be unreproducible.
 
         Args:
             node_id (Hashable): A node ID.
@@ -2047,7 +2050,7 @@ class Graph:
             Sequence[Hashable]: The neighboring node IDs.
         """
         if self._rx_graph is not None:
-            return self._rx_graph.neighbors(cast(int, node_id))
+            return sorted(self._rx_graph.neighbors(cast(int, node_id)))
         elif self._nx_graph is not None:
             # NX returns a single-pass iterator, so it must be materialized here;
             # callers (and the FrozenGraph.neighbors lru_cache) expect a re-iterable result.

--- a/gerrychain/proposals/__init__.py
+++ b/gerrychain/proposals/__init__.py
@@ -1,6 +1,7 @@
 from .proposals import *
 from .spectral_proposals import build_spectral_recom_proposal_fn, spectral_recom
 from .tree_proposals import (
+    ReCom,
     build_recom_proposal_fn,
     build_reversible_recom_proposal_fn,
     recom,
@@ -9,6 +10,7 @@ from .tree_proposals import (
 
 __all__ = [
     "ProposalFn",
+    "ReCom",
     "recom",
     "reversible_recom",
     "spectral_recom",

--- a/gerrychain/proposals/tree_proposals.py
+++ b/gerrychain/proposals/tree_proposals.py
@@ -1,7 +1,7 @@
 import random
-from collections.abc import Callable, Hashable, Sequence, Set as AbstractSet
+from collections.abc import Callable, Hashable, Iterable, Iterator, Sequence, Set as AbstractSet
 from functools import partial
-from typing import cast
+from typing import Literal, cast
 
 from gerrychain._rng import make_rng
 from gerrychain.partition import Partition
@@ -129,6 +129,66 @@ def epsilon_tree_bipartition(
     return translated_flips
 
 
+PairSelection = Literal["district_pairs", "cut_edges"]
+
+
+def _candidate_district_pairs(
+    partition: Partition,
+    pair_selection: PairSelection,
+    rng: random.Random,
+) -> Iterable[tuple[Hashable, Hashable]]:
+    """Return the adjacent district pairs to try merging, in try order.
+
+    With ``"district_pairs"`` each adjacent pair appears once, so the first pair is drawn uniformly
+    from the adjacent district pairs. With ``"cut_edges"`` a pair's chance of coming first is
+    proportional to the number of cut edges the two districts share, matching a uniform draw over
+    the cut edges. Later entries are fallbacks, tried only if bipartitioning the earlier pairs
+    fails; the ``"cut_edges"`` draws are lazy, so a successful first pair costs a single draw.
+    """
+    if pair_selection not in ("district_pairs", "cut_edges"):
+        raise ValueError(
+            f"Unknown pair_selection {pair_selection!r}; expected 'district_pairs' or 'cut_edges'."
+        )
+
+    part_order = {part: index for index, part in enumerate(partition.parts)}
+
+    def normalized_pair(edge: tuple[Hashable, Hashable]) -> tuple[Hashable, Hashable]:
+        pair = [partition.assignment.mapping[edge[0]], partition.assignment.mapping[edge[1]]]
+        # Need to sort the pair so that the order is consistent
+        pair.sort(key=part_order.__getitem__)
+        return (pair[0], pair[1])
+
+    def pair_sort_key(pair: tuple[Hashable, Hashable]) -> tuple[int, int]:
+        return (part_order[pair[0]], part_order[pair[1]])
+
+    if pair_selection == "district_pairs":
+        # Sorted so the order does not depend on string-hash iteration order (PYTHONHASHSEED).
+        pairs = sorted(
+            {normalized_pair(edge) for edge in partition["cut_edges"]}, key=pair_sort_key
+        )
+        rng.shuffle(pairs)
+        return pairs
+
+    # "cut_edges": weight each adjacent pair by the number of cut edges it shares. Counting keeps
+    # the per-edge work to one dict update, with sorting and drawing over the (much smaller) set
+    # of adjacent pairs.
+    counts: dict[tuple[Hashable, Hashable], int] = {}
+    for edge in partition["cut_edges"]:
+        pair = normalized_pair(edge)
+        counts[pair] = counts.get(pair, 0) + 1
+    # Sorted so the order does not depend on string-hash iteration order (PYTHONHASHSEED).
+    pairs = sorted(counts, key=pair_sort_key)
+    weights = [counts[pair] for pair in pairs]
+
+    def draw_without_replacement() -> Iterator[tuple[Hashable, Hashable]]:
+        while pairs:
+            index = rng.choices(range(len(pairs)), weights=weights)[0]
+            weights.pop(index)
+            yield pairs.pop(index)
+
+    return draw_without_replacement()
+
+
 def recom(
     partition: Partition,
     pop_col: str,
@@ -137,6 +197,7 @@ def recom(
     node_repeats: int = 0,
     region_surcharge: dict[str, float] | None = None,
     bipartition_tree_fn: Callable[..., AbstractSet[Hashable]] = bipartition_tree,
+    pair_selection: PairSelection = "district_pairs",
     *,
     rng: random.Random | int | None = None,
 ) -> Partition:
@@ -179,6 +240,11 @@ def recom(
             spanning-tree step (e.g. ``max_attempts``, or ``spanning_tree_fn_kwargs`` for
             spanning-tree options), pass a pre-bound function, e.g.
             ``partial(bipartition_tree, spanning_tree_fn_kwargs={...})``.
+        pair_selection ("district_pairs" | "cut_edges", optional): How to choose the pair of
+            adjacent districts to merge. ``"district_pairs"`` (default) draws uniformly among
+            the adjacent district pairs; ``"cut_edges"`` draws uniformly among the cut edges,
+            so a pair's chance is proportional to the number of cut edges the two districts
+            share.
         rng (random.Random | int | None, optional): Source of randomness. Pass a shared
             ``Random`` for repeated standalone calls; an integer restarts the stream each call.
 
@@ -188,34 +254,7 @@ def recom(
 
     rng = make_rng(rng)
 
-    # Compute the set of pairs of "parts" that touch - meaning that there is
-    # a cut_edge between the two "parts"
-    #
-    part_order = {part: index for index, part in enumerate(partition.parts)}
-    set_of_district_pairs_that_touch = set()
-    for edge in partition["cut_edges"]:
-        pair_that_touches = [
-            partition.assignment.mapping[edge[0]],
-            partition.assignment.mapping[edge[1]],
-        ]
-        # Need to sort the tuple so that the order is consistent
-        pair_that_touches.sort(key=part_order.__getitem__)
-        pair_that_touches = tuple(pair_that_touches)
-
-        set_of_district_pairs_that_touch.add(pair_that_touches)
-
-    # Convert to a list to make it easy to randomly select and remove element.
-    # Sorted so the order does not depend on string-hash iteration order (PYTHONHASHSEED).
-    list_of_district_pairs_that_touch = sorted(
-        set_of_district_pairs_that_touch,
-        key=lambda pair: (part_order[pair[0]], part_order[pair[1]]),
-    )
-
-    # To randomly select a pair of districts efficiently, randomly shuffle the
-    # list and then pop from the end of the list to get the next randomly
-    # selected pair to try.
-    #
-    rng.shuffle(list_of_district_pairs_that_touch)
+    candidate_pairs = _candidate_district_pairs(partition, pair_selection, rng)
 
     # Bind region_surcharge onto the bipartition_tree_fn. Other bipartition / spanning-tree options
     # (e.g. spanning_tree_fn_kwargs) are configured by passing a pre-bound bipartition_tree_fn, such
@@ -227,9 +266,7 @@ def recom(
     # Find a pair of touching "parts" that can be successfully bipartitioned into
     # two new "parts"
     #
-    while len(list_of_district_pairs_that_touch) > 0:
-        parts_to_merge = list_of_district_pairs_that_touch.pop()
-
+    for parts_to_merge in candidate_pairs:
         try:
             subgraph_nodes = partition.parts[parts_to_merge[0]] | partition.parts[parts_to_merge[1]]
 
@@ -265,6 +302,7 @@ def build_recom_proposal_fn(
     node_repeats: int = 0,
     region_surcharge: dict[str, float] | None = None,
     bipartition_tree_fn: Callable[..., AbstractSet[Hashable]] = bipartition_tree,
+    pair_selection: PairSelection = "district_pairs",
 ) -> ProposalFn:
     proposal_fn = partial(
         recom,
@@ -274,6 +312,7 @@ def build_recom_proposal_fn(
         node_repeats=node_repeats,
         region_surcharge=region_surcharge,
         bipartition_tree_fn=bipartition_tree_fn,
+        pair_selection=pair_selection,
     )
     return cast(ProposalFn, proposal_fn)
 
@@ -461,250 +500,240 @@ def build_reversible_recom_proposal_fn(
     return cast(ProposalFn, proposal_fn)
 
 
-# frm TODO: Refactoring:  Finish making class ReCom useful...
-#
-# Peter responded in a January 2026 code review that he thinks the purpose
-# of the ReCom class is to make it easier for folks who find partial functions
-# odd/confusing.  The idea is that this class can be used instead of creating
-# a partial function.
-#
-# I have to admit that I personally find using a class instead of a
-# partial function MORE confusing, but whatever.
-#
-# Here is what Peter said in the PR (with some comments by me afterwards):
-#
-# I am not so sure that we want to get rid of this. I think that this was
-# built by someone trying to solve the problem where, when a user wants
-# to run a chain with ReCom, they have to do the following bit of
-# syntax twister:
-#
-#     from functools import partial
-#
-#     proposal = partial(
-#         recom,
-#         pop_col="TOTPOP",
-#         pop_target=ideal_population,
-#         epsilon=0.01,
-#         node_repeats=2
-#     )
-#
-# This partial application is familiar to anyone that does
-# functional programming, and is effectively just
-#
-#     def proposal(state: Partition) -> Partition:
-#         return recom(
-#             state,
-#             pop_col="TOTPOP",
-#             pop_target=ideal_population,
-#             epsilon=0.01,
-#             node_repeats=2,
-#         )
-#
-# in disguise. But our users are not programmers, and I get a
-# lot of questions about the "partial" function that appears
-# in the documentation. The ReCom class does this partial application
-# under the hood using its __call__ attribute, and eliminates the need
-# for the import of partial from functools, so the user only has to do
-#
-#     Recom(
-#         pop_col="TOTPOP",
-#         ideal_pop=ideal_population,
-#         epsilon=0.01,
-#     )
-#
-# rather than the partial rigmarole.
-#
-# I discovered this class existed in the codebase after doing a big
-# refresh on the main documentation a while ago. I have been waiting
-# to update things until a major release because the values that need
-# to be passed to the __init__ of Recom depend on the underlying
-# bipartition function, and the class would probably be better
-# transformed into something closer to a "namespace" to improve
-# discoverability
-#
-# class ReCom:
-#     def __init__(self, *args, **kwargs):
-#         raise TypeError("ReCom is not instantiable; use ReCom.mst(...), etc.")
-#
-#     @classmethod
-#     def mst(...):
-#         # minimum spanning tree version
-#
-#     @classmethod
-#     def B(...):
-#         # This is the "district pairs minimum spanning tree".  An absolutely terrible name
-#         # for a function, to be sure, but it will make replication of what is in the
-#         # Reversible ReCom paper (https://data-democracy.org/rrc) we published a while
-#         # back easier for other people. This function would just be a wrapper around mst
-#         # defined above.
-#
-# and so on. I am happy to put all of this functionality in later if you don't
-# want to mess with it..
-#
-# ===========================================
-# Fred's comments to Peter's remarks above:
-#
-# Firstly a nit: Peter should have said ReCom(...) instead of Recom()...
-#
-# As Peter points out, there is the issue of passing the proper set of parameters
-# to the ReCom __init__() function.  Given the recent update to tree.py - creating
-# a new module bipartition_tree.py with a unified bipartition_tree approach
-# using _internal_bipartition_tree(), the set of parameters for the ReCom
-# constructor would just be the set of parameters to _internal_bipartition_tree(),
-# which unfortunately is a long list.
-#
-# Peter's other approach, to create a bunch of specific routines (via a namespace
-# approach) would allow the user to deal with fewer parameters - only providing
-# the ones needed).  I presume that the implementation for each of these
-# class methods would just be a partial function.
-#
-# So this is kind of just syntactic sugar, but hey sugar tastes good!
-#
-# One nice thing about this approach is that it is a way to make it obvious
-# to people what the standard ways of doing things are, and it provides
-# the opportunity to introduce a user to partial functions, by adding
-# comments in the ReCom class that tell the user that he/she can create
-# his/her own ReCom function by just creating their own partial function.
-# Stated differently, this provides a very nice, logical, discoverable
-# place in the codebase for a user to grok how the recom approach works
-# and how to extend it if he/she would like to.
-#
-# My only question to Peter is how this namespace should look.  I think
-# the following is what would be the first step, and then Peter could
-# add more later:
-#
-#     from functools import partial
-#
-#     class ReCom:
-#
-#         def __init__(self, *args, **kwargs):
-#             raise TypeError("ReCom is not instantiable; use ReCom.mst(...), etc.")
-#
-#         @classmethod
-#         def std_recom_proposal(
-#             partition: Partition,
-#             pop_col: str,
-#             pop_target: int | float,
-#             epsilon: float,
-#             node_repeats: int = 1,
-#             region_surcharge: dict[str, float] | None = None,
-#             bipartition_tree_fn: Callable = bipartition_tree,
-#         ) -> Partition:
-#             new_proposal = partial(
-#                 recom,
-#                 pop_col = pop_col,
-#                 pop_target = pop_target,
-#                 epsilon = epsilon,
-#                 node_repeats = node_repeats,
-#                 region_surcharge =  region_surcharge,
-#                 bipartition_tree_fn = bipartition_tree_fn,
-#             )
-#             return new_proposal
-#
-#         @classmethod
-#         def mst(...):
-#             # minimum spanning tree version
-
-
-#         @classmethod
-#         def B(...):
-#             # This is the "district pairs minimum spanning tree".  An absolutely terrible name
-#             # for a function, to be sure, but it will make replication of what is in the
-#             # Reversible ReCom paper (https://data-democracy.org/rrc) we published a while
-#             # back easier for other people. This function would just be a wrapper around mst
-#             # defined above..
-#
-# and then a user could just do:
-#
-#     my_proposal = ReCom.std_recom_proposal(
-#         pop_col="TOTPOP",
-#         pop_target=ideal_population,
-#         epsilon=0.01,
-#         node_repeats=2
-#     )
-#
-# Peter: Is this what you had in mind?
-#
-# New question for Peter:  Should we use the ProposalFn definition here?
-#
-# This is really just making the point that if you are OK with my
-# ProposalFn definition, then it should be used in the ReCom class,
-# something like this:
-#
-#         @classmethod
-#         def generate_std_recom_proposal(
-#             partition: Partition,
-#             pop_col: str,
-#             pop_target: int | float,
-#             epsilon: float,
-#             node_repeats: int = 1,
-#             region_surcharge: dict[str, float] | None = None,
-#             bipartition_tree_fn: Callable = bipartition_tree,
-#         ) -> ProposalFn:
-#             new_proposal = partial(
-#                 recom,
-#                 pop_col = pop_col,
-#                 pop_target = pop_target,
-#                 epsilon = epsilon,
-#                 node_repeats = node_repeats,
-#                 region_surcharge =  region_surcharge,
-#                 bipartition_tree_fn = bipartition_tree_fn,
-#             )
-#             return new_proposal
-
-
-# and then a user could just do:
-#
-#     my_proposal = ReCom.generate_std_recom_proposal(
-#         pop_col="TOTPOP",
-#         pop_target=ideal_population,
-#         epsilon=0.01,
-#         node_repeats=2
-#     )
-#
-#
-# ===========================================
-#
 class ReCom:
-    """
-    ReCom (short for ReCombination) is a class that represents a ReCom proposal
-    for redistricting. It is used to create new partitions by recombining existing
-    districts while maintaining population balance.
+    """Ready-made builders for the standard ReCom proposal variants.
 
+    Each method returns a proposal function ready to hand to :class:`~gerrychain.MarkovChain`, so
+    instead of the ``functools.partial`` incantation::
+
+        from functools import partial
+        proposal = partial(recom, pop_col="TOTPOP", pop_target=ideal_pop, epsilon=0.01)
+
+    you can write::
+
+        proposal = ReCom.district_pairs_mst(pop_col="TOTPOP", pop_target=ideal_pop, epsilon=0.01)
+
+    This class is a namespace, not a type: it cannot be instantiated.
+
+    The variants differ along two axes:
+
+    * **Pair selection**: ``cut_edges_*`` picks a cut edge uniformly at random and merges the two
+      districts on either side of it, so a pair's chance is proportional to the number of cut edges
+      the districts share. ``district_pairs_*`` picks uniformly among the adjacent district pairs
+      themselves.
+    * **Spanning tree**: ``*_mst`` draws a minimum spanning tree on random edge weights using
+      Kruskal's algorithm. ``*_ust`` draws a uniform spanning tree using Wilson's algorithm.
+
+    :meth:`reversible` is the Reversible ReCom proposal, which samples exactly from the
+    spanning-tree distribution; see :func:`reversible_recom`.
+
+    The aliases ``A``, ``B``, ``C``, ``D``, and ``R`` name the same builders after the variants in
+    "Spanning Tree Methods for Sampling Graph Partitions" (Cannon et al., 2022,
+    https://arxiv.org/abs/2210.01401), to ease replication of results from that paper.
+
+    These builders expose only the most common options. For anything else (a custom bipartition or
+    spanning-tree function, ``node_repeats``, ...), use :func:`build_recom_proposal_fn` or
+    :func:`build_reversible_recom_proposal_fn`, which these methods wrap, or bind
+    ``functools.partial(recom, ...)`` yourself.
     """
 
-    def __init__(
-        self,
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        raise TypeError(
+            "ReCom is not instantiable; use the builder methods, e.g. "
+            "ReCom.district_pairs_mst(...) or ReCom.reversible(...)."
+        )
+
+    @staticmethod
+    def cut_edges_mst(
         pop_col: str,
-        ideal_pop: int | float,
+        pop_target: int | float,
         epsilon: float,
-        bipartition_tree_fn: Callable[..., AbstractSet[Hashable]] = bipartition_tree,
-    ) -> None:
-        """Initialize a ReCom instance.
+        region_surcharge: dict[str, float] | None = None,
+        allow_pair_reselection: bool = False,
+    ) -> ProposalFn:
+        """ReCom variant A: cut-edges pair selection, minimum spanning tree.
+
+        A cut edge is selected at random and the two districts on either side of it are merged. The
+        merged region is split back into two districts by drawing a minimum spanning tree on random
+        edge weights (Kruskal's algorithm) and finding a population-balanced cut.
 
         Args:
-            pop_col (str): The name of the column in the partition that contains the population
-                data.
-            ideal_pop (int | float): The ideal population for each district.
-            epsilon (float): The epsilon value for population deviation as a percentage of the
-                target population.
-            bipartition_tree_fn (function, optional): The method used for bipartitioning the tree.
-                Defaults to `bipartition_tree`.
-        """
-        self.pop_col = pop_col
-        self.ideal_pop = ideal_pop
-        self.epsilon = epsilon
-        self.bipartition_tree_fn = bipartition_tree_fn
+            pop_col (str): The name of the population column.
+            pop_target (int | float): The target population for each district.
+            epsilon (float): Allowed population deviation as a percentage of the target
+                population.
+            region_surcharge (dict | None, optional): Surcharge dictionary for region-aware
+                chains; see :func:`~gerrychain.tree.random_spanning_tree`. Default is None.
+            allow_pair_reselection (bool, optional): Whether to fall back to a cut edge between
+                a different district pair if bipartitioning the merged pair fails. Default is
+                False.
 
-    def __call__(self, partition: Partition, *, rng: random.Random) -> Partition:
-        return recom(
-            partition,
-            self.pop_col,
-            self.ideal_pop,
-            self.epsilon,
-            bipartition_tree_fn=self.bipartition_tree_fn,
-            rng=rng,
+        Returns:
+            ProposalFn: A proposal function for use with :class:`~gerrychain.MarkovChain`.
+        """
+        return build_recom_proposal_fn(
+            pop_col=pop_col,
+            pop_target=pop_target,
+            epsilon=epsilon,
+            region_surcharge=region_surcharge,
+            bipartition_tree_fn=partial(
+                bipartition_tree,
+                allow_pair_reselection=allow_pair_reselection,
+            ),
+            pair_selection="cut_edges",
         )
+
+    @staticmethod
+    def district_pairs_mst(
+        pop_col: str,
+        pop_target: int | float,
+        epsilon: float,
+        region_surcharge: dict[str, float] | None = None,
+        allow_pair_reselection: bool = False,
+    ) -> ProposalFn:
+        """ReCom variant B: district-pairs pair selection, minimum spanning tree.
+
+        A pair of adjacent districts is selected uniformly at random and merged. The merged region
+        is split back into two districts by drawing a minimum spanning tree on random edge weights
+        (Kruskal's algorithm) and finding a population-balanced cut.
+
+        Args:
+            pop_col (str): The name of the population column.
+            pop_target (int | float): The target population for each district.
+            epsilon (float): Allowed population deviation as a percentage of the target population.
+            region_surcharge (dict | None, optional): Surcharge dictionary for region-aware chains;
+                see :func:`~gerrychain.tree.random_spanning_tree`. Default is None.
+            allow_pair_reselection (bool, optional): Whether to allow reselection of the same
+                district pair if bipartitioning fails. Default is False.
+
+        Returns:
+            ProposalFn: A proposal function for use with :class:`~gerrychain.MarkovChain`.
+        """
+        return build_recom_proposal_fn(
+            pop_col=pop_col,
+            pop_target=pop_target,
+            epsilon=epsilon,
+            region_surcharge=region_surcharge,
+            bipartition_tree_fn=partial(
+                bipartition_tree,
+                allow_pair_reselection=allow_pair_reselection,
+            ),
+            pair_selection="district_pairs",
+        )
+
+    @staticmethod
+    def cut_edges_ust(
+        pop_col: str,
+        pop_target: int | float,
+        epsilon: float,
+        allow_pair_reselection: bool = False,
+    ) -> ProposalFn:
+        """ReCom variant C: cut-edges pair selection, uniform spanning tree.
+
+        Like :meth:`cut_edges_mst`, except the merged region is split using a spanning tree drawn
+        uniformly at random (Wilson's algorithm). Region surcharges are not supported: a uniform
+        spanning tree ignores edge weights.
+
+        Args:
+            pop_col (str): The name of the population column.
+            pop_target (int | float): The target population for each district.
+            epsilon (float): Allowed population deviation as a percentage of the target
+                population.
+            allow_pair_reselection (bool, optional): Whether to fall back to a cut edge between
+                a different district pair if bipartitioning the merged pair fails. Default is
+                False.
+
+        Returns:
+            ProposalFn: A proposal function for use with :class:`~gerrychain.MarkovChain`.
+        """
+        return build_recom_proposal_fn(
+            pop_col=pop_col,
+            pop_target=pop_target,
+            epsilon=epsilon,
+            pair_selection="cut_edges",
+            bipartition_tree_fn=partial(
+                bipartition_tree,
+                spanning_tree_fn=uniform_spanning_tree,
+                allow_pair_reselection=allow_pair_reselection,
+            ),
+        )
+
+    @staticmethod
+    def district_pairs_ust(
+        pop_col: str,
+        pop_target: int | float,
+        epsilon: float,
+        allow_pair_reselection: bool = False,
+    ) -> ProposalFn:
+        """ReCom variant D: district-pairs pair selection, uniform spanning tree.
+
+        Like :meth:`district_pairs_mst`, except the merged region is split using a spanning
+        tree drawn uniformly at random (Wilson's algorithm). Region surcharges are not
+        supported: a uniform spanning tree ignores edge weights.
+
+        Args:
+            pop_col (str): The name of the population column.
+            pop_target (int | float): The target population for each district.
+            epsilon (float): Allowed population deviation as a percentage of the target population.
+            allow_pair_reselection (bool, optional): Whether to allow reselection of the same
+                district pair if bipartitioning fails. Default is False.
+
+        Returns:
+            ProposalFn: A proposal function for use with :class:`~gerrychain.MarkovChain`.
+        """
+        return build_recom_proposal_fn(
+            pop_col=pop_col,
+            pop_target=pop_target,
+            epsilon=epsilon,
+            pair_selection="district_pairs",
+            bipartition_tree_fn=partial(
+                bipartition_tree,
+                spanning_tree_fn=uniform_spanning_tree,
+                allow_pair_reselection=allow_pair_reselection,
+            ),
+        )
+
+    @staticmethod
+    def reversible(
+        pop_col: str,
+        pop_target: int | float,
+        epsilon: float,
+        max_balanced_edge_cuts: int,
+        repeat_until_valid: bool = False,
+    ) -> ProposalFn:
+        """ReCom variant R: the reversible ReCom proposal.
+
+        Samples exactly from the spanning-tree distribution rather than an approximation of it; see
+        :func:`reversible_recom` and the paper "Spanning Tree Methods for Sampling Graph Partitions"
+        (https://arxiv.org/abs/2210.01401) for details.
+
+        Args:
+            pop_col (str): The name of the population column.
+            pop_target (int | float): The target population for each district.
+            epsilon (float): Allowed population deviation as a percentage of the target
+                population.
+            max_balanced_edge_cuts (int): The number of balanced edge cuts to draw from the
+                spanning tree before selecting one, used to make the proposal reversible.
+            repeat_until_valid (bool, optional): Whether to repeat until a valid partition is
+                found. Default is False.
+
+        Returns:
+            ProposalFn: A proposal function for use with :class:`~gerrychain.MarkovChain`.
+        """
+        return build_reversible_recom_proposal_fn(
+            pop_col=pop_col,
+            pop_target=pop_target,
+            epsilon=epsilon,
+            max_balanced_edge_cuts=max_balanced_edge_cuts,
+            repeat_until_valid=repeat_until_valid,
+        )
+
+    # Variant names from "Spanning Tree Methods for Sampling Graph Partitions".
+    A = cut_edges_mst
+    B = district_pairs_mst
+    C = cut_edges_ust
+    D = district_pairs_ust
+    R = reversible
 
 
 class ReversibilityError(Exception):

--- a/gerrychain/tree/spanning_tree.py
+++ b/gerrychain/tree/spanning_tree.py
@@ -70,6 +70,9 @@ Dependencies:
 
 import random
 from collections.abc import Hashable, Iterator
+from typing import cast
+
+import rustworkx
 
 from .._rng import make_rng
 from ..graph import FrozenGraph, Graph
@@ -84,8 +87,14 @@ the context of the parent.  Stated differently, a spanning tree is not used to
 compute something about a subgraph but rather to compute something about whatever
 graph is currently being dealt with.
 
-In short, I am assuming that we can ignore the fact that RX subgraphs have different
-node_ids for this function and all will be well...
+
+prr: Update that was caught when making ReCom namespace class 
+
+It turns out that the tree must, however, use the SAME node_ids as the graph it spans: the 
+balanced-cut search returns node subsets in the tree's id space and the caller applies them to the
+input graph. Building the tree through NX and converting (convert_from_nx_to_rx) renumbers the 
+nodes in insertion order and silently relabels the tree, which is why uniform_spanning_tree 
+constructs the RX tree directly with preserved node_ids.
 """
 
 
@@ -335,22 +344,28 @@ def uniform_spanning_tree(
             tree_nodes.add(u)
             u = parent_node_id[u]
 
+    if graph.is_rx_graph():
+        # Build the tree as an RX graph directly, preserving the input graph's node_ids
+        # (RX ids are 0..n-1, and add_nodes_from assigns ids in list order). Round-tripping
+        # through NX and convert_from_nx_to_rx() renumbers the nodes in NX insertion order,
+        # silently relabeling the tree relative to the graph it spans; balanced cuts computed
+        # on such a tree then split the wrong nodes.
+        rx_tree: rustworkx.PyGraph = rustworkx.PyGraph()
+        rx_tree.add_nodes_from(
+            [graph.node_data(node_id) for node_id in sorted(cast("list[int]", nodes))]
+        )
+        for node_id, parent_id in parent_node_id.items():
+            if parent_id is not None:
+                rx_tree.add_edge(cast(int, node_id), cast(int, parent_id), {})
+        return Graph.from_rustworkx(rx_tree)
+
     graph_of_spanning_tree = Graph.from_null_networkx()
     nx_graph = graph_of_spanning_tree.get_nx_graph()
-    output_nodes = nodes if graph.is_nx_graph() else tree_nodes
-    if graph.is_nx_graph():
-        nx_graph.add_nodes_from(nodes)
+    nx_graph.add_nodes_from(nodes)
 
-    for node_id in output_nodes:
+    for node_id in nodes:
         if parent_node_id[node_id] is not None:
             # Add the nodes and the edge to the spanning_tree
             nx_graph.add_edge(node_id, parent_node_id[node_id])
-
-    # Return a graph that is the same "kind" of graph as the graph passed in.
-    # The current graph_of_spanning_tree is an NX-based graph, so convert it to
-    # be RX-based if the graph passed in was RX-based.
-    #
-    if graph.is_rx_graph():
-        graph_of_spanning_tree = graph_of_spanning_tree.convert_from_nx_to_rx()
 
     return graph_of_spanning_tree

--- a/tests/test_frm_graph.py
+++ b/tests/test_frm_graph.py
@@ -229,6 +229,28 @@ def test_subgraph(four_by_five_graph_rx):
         )
 
 
+def test_rx_neighbors_are_sorted_and_stable_across_subgraph_rebuilds(four_by_five_graph_rx):
+    """Regression test for a bug I encountered when updating ReCom class for 1.0.0 release.
+
+    RX collects neighbors into a randomly seeded HashSet, so the raw rustworkx order varies call to
+    call. Seeded algorithms map RNG draws over neighbor order (e.g. Wilson's random walk in
+    uniform_spanning_tree runs on the RX-backed merged-pair subgraphs recom creates), so an
+    unstable order makes seeded chains unreproducible even within one process.
+    """
+    parent = four_by_five_graph_rx
+    for node_id in parent.node_indices:
+        assert list(parent.neighbors(node_id)) == sorted(parent.neighbors(node_id))
+
+    subgraph_node_ids = [2, 4, 5, 8, 11, 13]
+    first = None
+    for _ in range(20):
+        subgraph = parent.subgraph(subgraph_node_ids)
+        orders = [tuple(subgraph.neighbors(n)) for n in sorted(subgraph.node_indices)]
+        if first is None:
+            first = orders
+        assert orders == first, "neighbor order changed between identical subgraph rebuilds"
+
+
 def test_num_connected_components(four_by_five_graph_nx, four_by_five_graph_rx):
     num_components_nx = four_by_five_graph_nx.num_connected_components()
     num_components_rx = four_by_five_graph_rx.num_connected_components()

--- a/tests/test_proposals.py
+++ b/tests/test_proposals.py
@@ -1,8 +1,10 @@
 import random
+from functools import partial
 
 import pytest
 
 from gerrychain import Partition, proposals, updaters
+from gerrychain.tree import bipartition_tree, uniform_spanning_tree
 
 
 @pytest.fixture
@@ -124,6 +126,66 @@ def test_recom_variants_run_with_pair_reselection(build_proposal, populated_part
     proposed = proposal(populated_partition, rng=random.Random(0))
     assert isinstance(proposed, Partition)
     assert all(pop == 3 for pop in proposed["population"].values())
+
+
+@pytest.mark.parametrize(
+    "build_proposal, recom_kwargs",
+    [
+        (proposals.ReCom.cut_edges_mst, {"pair_selection": "cut_edges"}),
+        (proposals.ReCom.district_pairs_mst, {"pair_selection": "district_pairs"}),
+        (
+            proposals.ReCom.cut_edges_ust,
+            {
+                "pair_selection": "cut_edges",
+                "bipartition_tree_fn": partial(
+                    bipartition_tree, spanning_tree_fn=uniform_spanning_tree
+                ),
+            },
+        ),
+        (
+            proposals.ReCom.district_pairs_ust,
+            {
+                "pair_selection": "district_pairs",
+                "bipartition_tree_fn": partial(
+                    bipartition_tree, spanning_tree_fn=uniform_spanning_tree
+                ),
+            },
+        ),
+    ],
+)
+def test_recom_variants_match_direct_recom_calls(build_proposal, recom_kwargs, populated_partition):
+    """Pin each builder's wiring: same seed, same trajectory as recom with the bound options.
+
+    A builder that binds the wrong pair_selection or forgets the uniform spanning tree consumes
+    the RNG stream differently, so the assignments diverge.
+    """
+    proposal = build_proposal(pop_col="population", pop_target=3, epsilon=0)
+    proposed = proposal(populated_partition, rng=random.Random(0))
+    expected = proposals.recom(
+        populated_partition,
+        pop_col="population",
+        pop_target=3,
+        epsilon=0,
+        rng=random.Random(0),
+        **recom_kwargs,
+    )
+    assert proposed.assignment.mapping == expected.assignment.mapping
+
+
+def test_reversible_variant_matches_direct_reversible_recom_call(populated_partition):
+    proposal = proposals.ReCom.reversible(
+        pop_col="population", pop_target=3, epsilon=0, max_balanced_edge_cuts=100
+    )
+    proposed = proposal(populated_partition, rng=random.Random(0))
+    expected = proposals.reversible_recom(
+        populated_partition,
+        pop_col="population",
+        pop_target=3,
+        epsilon=0,
+        max_balanced_edge_cuts=100,
+        rng=random.Random(0),
+    )
+    assert proposed.assignment.mapping == expected.assignment.mapping
 
 
 def test_recom_reversible_variant_runs(populated_partition):

--- a/tests/test_proposals.py
+++ b/tests/test_proposals.py
@@ -63,3 +63,113 @@ def test_proposals_support_mixed_type_part_labels(graph):
         epsilon=0,
         rng=0,
     )
+
+
+@pytest.fixture
+def populated_partition(graph):
+    for node in graph:
+        graph.node_data(node)["population"] = 1
+    return Partition(
+        graph,
+        {0: 1, 1: 1, 2: 1, 3: 2, 4: 2, 5: 2, 6: 3, 7: 3, 8: 3},
+        {
+            "cut_edges": updaters.cut_edges,
+            "population": updaters.Tally("population"),
+        },
+    )
+
+
+def test_recom_namespace_is_not_instantiable():
+    with pytest.raises(TypeError, match="not instantiable"):
+        proposals.ReCom(pop_col="population", pop_target=3, epsilon=0)
+
+
+def test_recom_letter_aliases_match_named_variants():
+    assert proposals.ReCom.A is proposals.ReCom.cut_edges_mst
+    assert proposals.ReCom.B is proposals.ReCom.district_pairs_mst
+    assert proposals.ReCom.C is proposals.ReCom.cut_edges_ust
+    assert proposals.ReCom.D is proposals.ReCom.district_pairs_ust
+    assert proposals.ReCom.R is proposals.ReCom.reversible
+
+
+@pytest.mark.parametrize(
+    "build_proposal",
+    [
+        proposals.ReCom.cut_edges_mst,
+        proposals.ReCom.district_pairs_mst,
+        proposals.ReCom.cut_edges_ust,
+        proposals.ReCom.district_pairs_ust,
+    ],
+)
+def test_recom_variants_return_balanced_partitions(build_proposal, populated_partition):
+    proposal = build_proposal(pop_col="population", pop_target=3, epsilon=0)
+    proposed = proposal(populated_partition, rng=random.Random(0))
+    assert isinstance(proposed, Partition)
+    assert all(pop == 3 for pop in proposed["population"].values())
+
+
+@pytest.mark.parametrize(
+    "build_proposal",
+    [
+        proposals.ReCom.cut_edges_mst,
+        proposals.ReCom.district_pairs_mst,
+        proposals.ReCom.cut_edges_ust,
+        proposals.ReCom.district_pairs_ust,
+    ],
+)
+def test_recom_variants_run_with_pair_reselection(build_proposal, populated_partition):
+    proposal = build_proposal(
+        pop_col="population", pop_target=3, epsilon=0, allow_pair_reselection=True
+    )
+    proposed = proposal(populated_partition, rng=random.Random(0))
+    assert isinstance(proposed, Partition)
+    assert all(pop == 3 for pop in proposed["population"].values())
+
+
+def test_recom_reversible_variant_runs(populated_partition):
+    proposal = proposals.ReCom.reversible(
+        pop_col="population", pop_target=3, epsilon=0, max_balanced_edge_cuts=100
+    )
+    proposed = proposal(populated_partition, rng=random.Random(0))
+    assert isinstance(proposed, Partition)
+
+
+def test_recom_rejects_unknown_pair_selection(populated_partition):
+    with pytest.raises(ValueError, match="pair_selection"):
+        proposals.recom(
+            populated_partition,
+            pop_col="population",
+            pop_target=3,
+            epsilon=0,
+            pair_selection="nope",
+            rng=0,
+        )
+
+
+def test_cut_edges_pair_selection_weights_by_shared_boundary(graph):
+    """District pairs sharing more cut edges should be tried first more often.
+
+    On the 3x3 grid with districts a={0}, b={1,2}, c={3..8}, the pair (b,c) shares two cut
+    edges (1-4 and 2-5) while (a,b) and (a,c) share one each (0-1 and 0-3). Under "cut_edges"
+    selection (b,c) should come first about half the time; under "district_pairs" about a
+    third of the time.
+    """
+    from gerrychain.proposals.tree_proposals import _candidate_district_pairs
+
+    partition = Partition(
+        graph,
+        {0: "a", 1: "b", 2: "b", 3: "c", 4: "c", 5: "c", 6: "c", 7: "c", 8: "c"},
+        {"cut_edges": updaters.cut_edges},
+    )
+
+    def count_bc_first(pair_selection):
+        count = 0
+        for seed in range(600):
+            pairs = list(_candidate_district_pairs(partition, pair_selection, random.Random(seed)))
+            assert sorted(pairs) == [("a", "b"), ("a", "c"), ("b", "c")]
+            count += pairs[0] == ("b", "c")
+        return count
+
+    # Expected 300 of 600 for cut_edges, 200 of 600 for district_pairs.
+    assert count_bc_first("cut_edges") > 260
+    assert count_bc_first("district_pairs") < 240

--- a/tests/test_reproducibility.py
+++ b/tests/test_reproducibility.py
@@ -303,5 +303,5 @@ def test_pa_freeze():
     # tests around. Captured with rng=2018; independent of PYTHONHASHSEED.
     assert (
         hashlib.sha256(result.encode()).hexdigest()
-        == "9837b0f4dae11ec90310e5f230f5b28a47180265e17fd6b3e761048c26588104"
+        == "9308a9251f89c58630b68fb4aefadb5923a8c566d129ad4c20af63d53075e8ae"
     )

--- a/tests/test_reproducibility.py
+++ b/tests/test_reproducibility.py
@@ -255,6 +255,31 @@ def test_repeatable(three_by_three_grid):
     assert flips == expected_flips
 
 
+def test_ust_recom_is_repeatable_in_process(three_by_three_grid):
+    import random
+
+    from gerrychain import Partition, proposals, updaters
+
+    for node in three_by_three_grid:
+        three_by_three_grid.node_data(node)["population"] = 1
+
+    def run():
+        partition = Partition(
+            three_by_three_grid,
+            {0: 1, 1: 1, 2: 1, 3: 2, 4: 2, 5: 2, 6: 3, 7: 3, 8: 3},
+            {"cut_edges": updaters.cut_edges, "population": updaters.Tally("population")},
+        )
+        proposal = proposals.ReCom.district_pairs_ust(pop_col="population", pop_target=3, epsilon=0)
+        rng = random.Random(2024)
+        trajectory = []
+        for _ in range(5):
+            partition = proposal(partition, rng=rng)
+            trajectory.append(sorted(partition.assignment.mapping.items()))
+        return trajectory
+
+    assert run() == run()
+
+
 @pytest.mark.slow
 def test_pa_freeze():
     import hashlib


### PR DESCRIPTION
## Summary

This PR does not update any documentation since I would like feedback on the API design first.

This PR replaces the old callable `ReCom` class with a namespace of ready-made proposal builders for the standard ReCom variants.

It also adds explicit control over district-pair selection and fixes two RustworkX issues uncovered by builder-equivalence testing:

- RustworkX neighbor iteration was not deterministic.
- Uniform spanning trees could silently use node IDs that did not match the graph they spanned.

Together, these changes should make the common ReCom variants easier to discover and configure while preserving deterministic seeded trajectories.

## ReCom proposal namespace

`ReCom` is now a non-instantiable namespace with builders for the four combinations of pair selection and spanning-tree algorithm described in _Spanning Tree Methods for Sampling Graph Partitions_:

- `ReCom.cut_edges_mst`, alias `A`: cut-edge pair selection with a minimum spanning tree.
- `ReCom.district_pairs_mst`, alias `B`: district-pair selection with a minimum spanning tree.
- `ReCom.cut_edges_ust`, alias `C`: cut-edge pair selection with a uniform spanning tree.
- `ReCom.district_pairs_ust`, alias `D`: district-pair selection with a uniform spanning tree.
- `ReCom.reversible`, alias `R`: reversible ReCom.

Each builder returns a `ProposalFn` ready to pass to `MarkovChain`:

```python
from gerrychain.proposals import ReCom

proposal = ReCom.district_pairs_mst(
    pop_col="TOT_POP",
    pop_target=ideal_population,
    epsilon=0.01,
)
```

The named builders are intentionally more limited to reduce cognitive burden, but expose the most common options:

- `region_surcharge` for the minimum-spanning-tree variants;
- `allow_pair_reselection` for the four standard variants; and
- `max_balanced_edge_cuts` and `repeat_until_valid` for reversible ReCom.

Advanced users can continue to use `recom`, `build_recom_proposal_fn`, `reversible_recom`, or `build_reversible_recom_proposal_fn` directly.

## District-pair selection

`recom` and `build_recom_proposal_fn` now accept a `pair_selection` argument:

- `"district_pairs"` selects uniformly among adjacent district pairs and remains the default.
- `"cut_edges"` selects proportionally to the number of cut edges shared by each pair. This is equivalent to selecting a cut edge uniformly for the first attempt.

Candidate pairs are normalized and sorted before random selection so their order does not depend on Python hash iteration. Mixed-type district labels remain supported.

If bipartitioning fails and pair reselection is enabled, remaining candidate pairs are tried without replacement. Cut-edge-weighted candidates are drawn lazily, so a successful first attempt requires only one weighted draw.

Invalid `pair_selection` values now raise a clear `ValueError`.

## RustworkX correctness and reproducibility fixes

### Deterministic neighbor order

RustworkX collects neighbors in a randomly seeded hash set, so its raw neighbor order can vary between otherwise identical calls.

`Graph.neighbors` now sorts RustworkX neighbors before returning them. This prevents seeded algorithms such as Wilson random walks and randomized breadth-first traversals from mapping the same random draws onto different neighbors.

### Preserved node IDs in uniform spanning trees

The RustworkX path in `uniform_spanning_tree` previously built a NetworkX tree and converted it back to RustworkX. That conversion could renumber nodes according to NetworkX insertion order.

Balanced-cut searches return subsets in the spanning tree's node-ID space. Applying a renumbered subset to the original graph could therefore split the wrong nodes.

Uniform spanning trees for RustworkX graphs are now constructed directly as RustworkX graphs, preserving the input graph's node IDs.

## Testing

- [x] Tests pass locally
- [x] Added/updated tests
- [x] Manually tested relevant behavior

Added coverage for:

- all named ReCom builders and their letter aliases;
- the non-instantiable namespace contract;
- balanced output from every standard variant;
- pair-reselection behavior;
- equivalence between each builder and its corresponding direct function call;
- reversible-builder equivalence;
- cut-edge weighting versus district-pair weighting;
- invalid pair-selection values;
- stable RustworkX neighbor order across repeated subgraph construction;
- repeatable uniform-spanning-tree ReCom trajectories; and
- the updated Pennsylvania reproducibility freeze.

Verified with

```
make test-all
```

Which shows

```
403 passed, 5 skipped, 2 xfailed,
```