### PR TITLE
Make the test suite pass the type checkers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ PYTHON_VERSION = 3.11
 VENV_DIR ?= .venv
 PKG ?= gerrychain
 TEST_PATHS ?= tests
-TYPECHECK_PATHS ?= $(PKG) tests/typing_assertions.py
+TYPECHECK_PATHS ?= $(PKG) $(TEST_PATHS)
 DOCS_PY_PATHS ?= docs/conf.py docs/_clear_notebook_outputs.py \
 	docs/_refresh_notebooks.py docs/generate_recom_assets.py
 DOCS_CACHE_FLAGS = $(if $(filter 1,$(FRESH)),--force)

--- a/gerrychain/_rng.py
+++ b/gerrychain/_rng.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 import numbers
 import random
 
+import numpy
 
-def make_rng(rng: random.Random | int | None = None) -> random.Random:
+
+def make_rng(rng: random.Random | int | numpy.integer | None = None) -> random.Random:
     """Return ``rng`` or create a ``Random`` from a seed or system entropy."""
     if isinstance(rng, random.Random):
         return rng

--- a/gerrychain/graph/graph.py
+++ b/gerrychain/graph/graph.py
@@ -200,7 +200,9 @@ class Graph:
         return Graph.from_networkx(nx_graph)
 
     @classmethod
-    def from_rustworkx(cls, rx_graph: rustworkx.PyGraph[_NodeDataT, Any]) -> Graph:
+    def from_rustworkx(
+        cls, rx_graph: rustworkx.PyGraph[_NodeDataT, Any] | rustworkx.PyDiGraph[_NodeDataT, Any]
+    ) -> Graph:
         """Create a Graph from a RustworkX.PyGraph object.
 
         There are three primary use cases for this routine: 1) converting an NX-based Graph to be
@@ -226,7 +228,8 @@ class Graph:
         create an RX-based GerryChain graph object.
 
         Args:
-            rx_graph (rustworkx.PyGraph): a RustworkX PyGraph object
+            rx_graph (rustworkx.PyGraph | rustworkx.PyDiGraph): a RustworkX graph object. A
+                directed ``PyDiGraph`` is rejected with :class:`GraphValidationError`.
 
         Returns:
             'Graph': a GerryChain Graph object with an embedded RustworkX.PyGraph object

--- a/gerrychain/partition/partition.py
+++ b/gerrychain/partition/partition.py
@@ -77,6 +77,7 @@ Note that the mapping / ``[]`` interface of a Partition is over its *updaters*
 from __future__ import annotations
 
 import json
+import os
 import random
 from collections.abc import Callable, Hashable, KeysView, Mapping
 from typing import TYPE_CHECKING, Any, TypeVar, cast
@@ -603,7 +604,7 @@ class Partition:
     def from_districtr_file(
         cls,
         graph: Graph,
-        districtr_file: str,
+        districtr_file: str | os.PathLike[str],
         updaters: Mapping[str, Callable[[Partition], Any]] | None = None,
     ) -> Partition:
         """Return partition created from the Districtr file.
@@ -621,7 +622,8 @@ class Partition:
 
         Args:
             graph (Graph): The graph to create the Partition from
-            districtr_file (str): the path to the ``.json`` file exported from Districtr
+            districtr_file (str | os.PathLike): the path to the ``.json`` file exported
+                from Districtr
             updaters (Mapping[str, Callable] | None, optional): Dictionary of updaters.
 
         Returns:

--- a/gerrychain/tree/bipartition_tree.py
+++ b/gerrychain/tree/bipartition_tree.py
@@ -29,7 +29,7 @@ import itertools
 import random
 import warnings
 from collections import deque
-from collections.abc import Callable, Hashable, Sequence, Set as AbstractSet
+from collections.abc import Callable, Hashable, Mapping, Sequence, Set as AbstractSet
 from functools import partial
 from inspect import signature
 from typing import NamedTuple, Protocol, cast
@@ -881,7 +881,7 @@ def _internal_bipartition_tree(
     spanning_tree: GraphLike | None = None,
     spanning_tree_fn: SpanningTreeFn = random_spanning_tree,
     region_surcharge: dict[str, float] | None = None,
-    spanning_tree_fn_kwargs: dict[str, object] | None = None,
+    spanning_tree_fn_kwargs: Mapping[str, object] | None = None,
     find_balanced_edge_cuts_fn: Callable[..., list[_Cut]] = find_balanced_edge_cuts_memoization,
     one_sided_cut: bool = False,
     rootnode_choice_fn: Callable[[Sequence[Hashable]], Hashable] | None = None,
@@ -1084,7 +1084,7 @@ def bipartition_tree(
     spanning_tree: GraphLike | None = None,
     spanning_tree_fn: SpanningTreeFn = random_spanning_tree,
     region_surcharge: dict[str, float] | None = None,
-    spanning_tree_fn_kwargs: dict[str, object] | None = None,
+    spanning_tree_fn_kwargs: Mapping[str, object] | None = None,
     find_balanced_edge_cuts_fn: Callable[..., list[_Cut]] = find_balanced_edge_cuts_memoization,
     one_sided_cut: bool = False,
     rootnode_choice_fn: Callable[[Sequence[Hashable]], Hashable] | None = None,

--- a/gerrychain/tree/spanning_tree.py
+++ b/gerrychain/tree/spanning_tree.py
@@ -88,12 +88,12 @@ compute something about a subgraph but rather to compute something about whateve
 graph is currently being dealt with.
 
 
-prr: Update that was caught when making ReCom namespace class 
+prr: Update that was caught when making ReCom namespace class
 
-It turns out that the tree must, however, use the SAME node_ids as the graph it spans: the 
+It turns out that the tree must, however, use the SAME node_ids as the graph it spans: the
 balanced-cut search returns node subsets in the tree's id space and the caller applies them to the
-input graph. Building the tree through NX and converting (convert_from_nx_to_rx) renumbers the 
-nodes in insertion order and silently relabels the tree, which is why uniform_spanning_tree 
+input graph. Building the tree through NX and converting (convert_from_nx_to_rx) renumbers the
+nodes in insertion order and silently relabels the tree, which is why uniform_spanning_tree
 constructs the RX tree directly with preserved node_ids.
 """
 

--- a/gerrychain/updaters/election.py
+++ b/gerrychain/updaters/election.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import math
-from collections.abc import Hashable, Iterable, Mapping
-from typing import TYPE_CHECKING
+from collections.abc import Hashable, Iterable, Mapping, Sequence
+from typing import TYPE_CHECKING, cast
 
 import gerrychain.metrics.partisan as pm
 from gerrychain.updaters.tally import DataTally
@@ -72,7 +72,7 @@ class Election:
     def __init__(
         self,
         name: str,
-        party_names_to_node_attribute_names: dict[str, str] | list[str],
+        party_names_to_node_attribute_names: Mapping[str, str | Sequence[float]] | list[str],
         alias: str | None = None,
     ) -> None:
         """Initialize a Election instance.
@@ -107,17 +107,18 @@ class Election:
         # "node_attribute_names" are the names of the node attributes storing vote counts
         # "party_names_to_node_attribute_names" is a mapping from one to the other
         #
-        if isinstance(party_names_to_node_attribute_names, dict):
+        if isinstance(party_names_to_node_attribute_names, list):
+            # name of the party and the attribute name containing value is the same
+            names = cast("list[str]", party_names_to_node_attribute_names)
+            self.parties: list[str] = names
+            self.node_attribute_names: list[str | Sequence[float]] = list(names)
+            self.party_names_to_node_attribute_names: Mapping[str, str | Sequence[float]] = dict(
+                zip(names, names)
+            )
+        elif isinstance(party_names_to_node_attribute_names, Mapping):
             self.parties = list(party_names_to_node_attribute_names.keys())
             self.node_attribute_names = list(party_names_to_node_attribute_names.values())
             self.party_names_to_node_attribute_names = party_names_to_node_attribute_names
-        elif isinstance(party_names_to_node_attribute_names, list):
-            # name of the party and the attribute name containing value is the same
-            self.parties = party_names_to_node_attribute_names
-            self.node_attribute_names = party_names_to_node_attribute_names
-            self.party_names_to_node_attribute_names = dict(
-                zip(self.parties, self.node_attribute_names)
-            )
         else:
             raise TypeError(
                 "Election expects party_names_to_node_attribute_names to be a dict or list"

--- a/gerrychain/updaters/tally.py
+++ b/gerrychain/updaters/tally.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import collections
 import math
 import warnings
-from collections.abc import Callable, Hashable, Mapping
+from collections.abc import Callable, Hashable, Mapping, Sequence
 from typing import TYPE_CHECKING, cast
 
 import pandas
@@ -40,14 +40,15 @@ class DataTally:
 
     def __init__(
         self,
-        data: Mapping[Hashable, float] | pandas.Series | str,
+        data: Mapping[Hashable, float] | Sequence[float] | pandas.Series | str,
         alias: str,
     ) -> None:
         """Initialize a DataTally instance.
 
         Args:
-            data (dict | pandas.Series | str): A Dict or Series indexed by the graph's nodes,
-                or the string key for a node attribute containing the Tally's data.
+            data (dict | Sequence | pandas.Series | str): A Dict, Series, or sequence indexed by
+                the graph's nodes, or the string key for a node attribute containing the Tally's
+                data.
             alias (str): The name of the tally in the Partition's `updaters` dictionary
 
         """
@@ -104,7 +105,8 @@ class DataTally:
     def _value(self, node: Hashable) -> float:
         if isinstance(self.data, str):
             raise RuntimeError("Tally data has not been initialized")
-        return cast(float, self.data[node])
+        # A Sequence is valid data when the node ids are 0..n-1 ints; index uniformly as a Mapping.
+        return cast("Mapping[Hashable, float]", self.data)[node]
 
     def __call__(
         self, partition: Partition, previous: dict[Hashable, float] | None = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,11 +72,16 @@ ignore-overlong-task-comments = true
 [tool.ty.environment]
 python-version = "3.11"
 
+[tool.ty.src]
+# tests/_foo is stale scratch (imports that no longer resolve); not collected by pytest.
+exclude = ["tests/_foo"]
+
 [tool.ty.rules]
 missing-type-argument = "error"
 
 [tool.pyright]
-include = ["gerrychain", "tests/typing_assertions.py"]
+include = ["gerrychain", "tests"]
+exclude = ["tests/_foo"]
 pythonVersion = "3.11"
 venvPath = "."
 venv = ".venv"

--- a/tests/_perf_tests/perf_test2.py
+++ b/tests/_perf_tests/perf_test2.py
@@ -1,11 +1,13 @@
 import cProfile
 import sys
+from collections.abc import Callable
 
 from gerrychain import (
     Election,
     GeographicPartition,
     Graph,
     MarkovChain,
+    Partition,
     accept,
     constraints,
     updaters,
@@ -26,7 +28,9 @@ def main():
 
     # Population updater, for computing how close to equality the district
     # populations are. "TOTPOP" is the population column from our shapefile.
-    my_updaters = {"population": updaters.Tally("TOT_POP", alias="population")}
+    my_updaters: dict[str, Callable[[Partition], object]] = {
+        "population": updaters.Tally("TOT_POP", alias="population")
+    }
 
     # Election updaters, for computing election results using the vote totals
     # from our shapefile.
@@ -51,7 +55,7 @@ def main():
         node_repeats=0,
     )
 
-    def cut_edges_length(p):
+    def cut_edges_length(p: Partition) -> int:
         return len(p["cut_edges"])
 
     compactness_bound = constraints.UpperBound(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,6 @@
 import random
+from collections.abc import Callable, Iterable, Iterator
+from typing import Any
 
 import networkx as nx
 import pytest
@@ -10,7 +12,7 @@ random.seed(2018)
 
 
 @pytest.fixture(autouse=True)
-def _enable_runtime_checks():
+def _enable_runtime_checks() -> Iterator[None]:
     """Run the whole suite with GerryChain's thorough integrity checks enabled.
 
     These checks are off by default in production for performance; turning them on
@@ -24,7 +26,7 @@ def _enable_runtime_checks():
 
 
 @pytest.fixture
-def three_by_three_grid():
+def three_by_three_grid() -> Graph:
     """Returns a graph that looks like this:
     0 1 2
     3 4 5
@@ -51,7 +53,7 @@ def three_by_three_grid():
 
 
 @pytest.fixture
-def four_by_five_grid_for_opt():
+def four_by_five_grid_for_opt() -> Graph:
     #  1  2  2  2  2
     #  1  2  1  1  2
     #  1  2  2  1  2
@@ -128,7 +130,7 @@ def four_by_five_grid_for_opt():
 
 
 @pytest.fixture
-def four_by_five_grid_nx():
+def four_by_five_grid_nx() -> "nx.Graph[int, dict[str, Any], dict[str, Any]]":
     # A raw networkx 4x5 grid with a "nx_node_id" attribute (an effective stable
     # original id) and two connected components (rows 0-1 and rows 2-3). Lives in
     # conftest so it is shared across test modules.
@@ -181,8 +183,8 @@ def four_by_five_grid_nx():
 
 
 @pytest.fixture
-def graph_with_random_data_factory(three_by_three_grid):
-    def factory(columns):
+def graph_with_random_data_factory(three_by_three_grid: Graph) -> Callable[[Iterable[str]], Graph]:
+    def factory(columns: Iterable[str]) -> Graph:
         graph = three_by_three_grid
         attach_random_data(graph, columns)
         return graph
@@ -191,7 +193,7 @@ def graph_with_random_data_factory(three_by_three_grid):
     return factory
 
 
-def attach_random_data(graph, columns):
+def attach_random_data(graph: Graph, columns: Iterable[str]) -> None:
     for node in graph.nodes:
         for col in columns:
             graph.node_data(node)[col] = random.randint(1, 1000)
@@ -202,12 +204,12 @@ def attach_random_data(graph, columns):
 #               the reader an idea of how many nodes there are?  What is the
 #               value of just having a generic "graph" test fixture???
 #
-def graph(three_by_three_grid):
+def graph(three_by_three_grid: Graph) -> Graph:
     return three_by_three_grid
 
 
 @pytest.fixture
-def example_partition():
+def example_partition() -> Partition:
     graph = Graph.from_networkx(nx.complete_graph(3))
     assignment = {0: 1, 1: 1, 2: 2}
     partition = Partition(graph, assignment, {"cut_edges": cut_edges})
@@ -215,7 +217,7 @@ def example_partition():
 
 
 # From the docs: https://docs.pytest.org/en/latest/example/simple.html#control-skipping-of-tests-according-to-command-line-option
-def pytest_addoption(parser):
+def pytest_addoption(parser: pytest.Parser) -> None:
     parser.addoption("--runslow", action="store_true", default=False, help="run slow tests")
     parser.addoption(
         "--rundocs",
@@ -225,14 +227,14 @@ def pytest_addoption(parser):
     )
 
 
-def pytest_configure(config):
+def pytest_configure(config: pytest.Config) -> None:
     config.addinivalue_line("markers", "slow: mark test as slow to run")
     config.addinivalue_line(
         "markers", "docs: executes documentation code blocks; needs the docs-exec group"
     )
 
 
-def pytest_collection_modifyitems(config, items):
+def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
     skip_slow = pytest.mark.skip(reason="need --runslow option to run")
     skip_docs = pytest.mark.skip(reason="need --rundocs option to run")
     for item in items:

--- a/tests/constraints/test_bounds.py
+++ b/tests/constraints/test_bounds.py
@@ -1,43 +1,49 @@
+from typing import cast
+
 from gerrychain import constraints
 from gerrychain.constraints import within_percent_of_ideal_population
+from gerrychain.partition import Partition
 
 
 class TestWithinPercent:
     def test_within_percent_fails_when_deviation_too_large(self):
-        partition = {"population": {1: 100, 2: 100, 3: 100}}
+        partition = cast(Partition, {"population": {1: 100, 2: 100, 3: 100}})
 
         percent = 0.5
         constraint = within_percent_of_ideal_population(partition, percent)
 
         ideal = 100
         too_much_deviation = ideal * (percent + 0.2)
-        new_partition = {
-            "population": {
-                1: 100 - too_much_deviation / 2,
-                2: 100 - too_much_deviation / 2,
-                3: 100 + too_much_deviation,
-            }
-        }
+        new_partition = cast(
+            Partition,
+            {
+                "population": {
+                    1: 100 - too_much_deviation / 2,
+                    2: 100 - too_much_deviation / 2,
+                    3: 100 + too_much_deviation,
+                }
+            },
+        )
 
         assert not constraint(new_partition)
 
     def test_within_percent_fails_when_expected(self):
-        partition = {"population": {1: 100, 2: 100, 3: 100}}
+        partition = cast(Partition, {"population": {1: 100, 2: 100, 3: 100}})
 
         percent = 0.5
         constraint = within_percent_of_ideal_population(partition, percent)
 
-        new_partition = {"population": {1: 280, 2: 100, 3: 100}}
+        new_partition = cast(Partition, {"population": {1: 280, 2: 100, 3: 100}})
 
         assert not constraint(new_partition)
 
     def test_within_percent_fails_when_expected2(self):
-        partition = {"population": {1: 100, 2: 100, 3: 100}}
+        partition = cast(Partition, {"population": {1: 100, 2: 100, 3: 100}})
 
         percent = 0.5
         constraint = within_percent_of_ideal_population(partition, percent)
 
-        new_partition = {"population": {1: 200, 2: 10, 3: 100}}
+        new_partition = cast(Partition, {"population": {1: 200, 2: 10, 3: 100}})
 
         assert not constraint(new_partition)
 
@@ -59,7 +65,7 @@ class TestLowerBound:
         assert bound(100) is True
 
     def test_has_informative_repr(self):
-        def my_function(x):
+        def my_function(x: Partition) -> float:
             return 150
 
         bound = constraints.LowerBound(my_function, 100)
@@ -84,7 +90,7 @@ class TestUpperBound:
         assert bound(100) is True
 
     def test_has_informative_repr(self):
-        def my_function(x):
+        def my_function(x: Partition) -> float:
             return 150
 
         bound = constraints.UpperBound(my_function, 100)

--- a/tests/constraints/test_contiguity.py
+++ b/tests/constraints/test_contiguity.py
@@ -1,8 +1,8 @@
-from gerrychain import Partition
+from gerrychain import Graph, Partition
 from gerrychain.constraints.contiguity import contiguous_components
 
 
-def test_contiguous_components(graph):
+def test_contiguous_components(graph: Graph):
     partition = Partition(graph, {0: 1, 1: 1, 2: 1, 3: 2, 4: 2, 5: 2, 6: 1, 7: 1, 8: 1})
 
     components = contiguous_components(partition)
@@ -14,10 +14,10 @@ def test_contiguous_components(graph):
     # to compare against the original node_ids, since RX node_ids change every time
     # you create a subgraph.
 
-    assert set(frozenset(g.original_nx_node_ids_for_set(g.nodes)) for g in components[1]) == {
+    assert set(frozenset(g.original_nx_node_ids_for_set(set(g.nodes))) for g in components[1]) == {
         frozenset([0, 1, 2]),
         frozenset([6, 7, 8]),
     }
-    assert set(frozenset(g.original_nx_node_ids_for_set(g.nodes)) for g in components[2]) == {
+    assert set(frozenset(g.original_nx_node_ids_for_set(set(g.nodes))) for g in components[2]) == {
         frozenset([3, 4, 5]),
     }

--- a/tests/constraints/test_validity.py
+++ b/tests/constraints/test_validity.py
@@ -1,3 +1,4 @@
+from typing import cast
 from unittest.mock import MagicMock
 
 import networkx as nx
@@ -19,7 +20,7 @@ from gerrychain.partition.partition import get_assignment
 
 
 @pytest.fixture
-def contiguous_partition_with_flips():
+def contiguous_partition_with_flips() -> tuple[Partition, dict[int, int]]:
     graph = nx.Graph()
     graph.add_nodes_from(range(4))
     graph.add_edges_from([(0, 1), (1, 2), (2, 3), (3, 0)])
@@ -30,7 +31,7 @@ def contiguous_partition_with_flips():
 
 
 @pytest.fixture
-def discontiguous_partition_with_flips():
+def discontiguous_partition_with_flips() -> tuple[Partition, dict[int, int]]:
     graph = nx.Graph()
     graph.add_nodes_from(range(4))
     graph.add_edges_from([(0, 1), (1, 2), (2, 3)])
@@ -41,22 +42,28 @@ def discontiguous_partition_with_flips():
 
 
 @pytest.fixture
-def contiguous_partition(contiguous_partition_with_flips):
+def contiguous_partition(
+    contiguous_partition_with_flips: tuple[Partition, dict[int, int]],
+) -> Partition:
     return contiguous_partition_with_flips[0]
 
 
 @pytest.fixture
-def discontiguous_partition(discontiguous_partition_with_flips):
+def discontiguous_partition(
+    discontiguous_partition_with_flips: tuple[Partition, dict[int, int]],
+) -> Partition:
     return discontiguous_partition_with_flips[0]
 
 
-def test_contiguous_with_contiguity_no_flips_is_true(contiguous_partition):
+def test_contiguous_with_contiguity_no_flips_is_true(contiguous_partition: Partition):
     assert contiguous(contiguous_partition)
     assert single_flip_contiguous(contiguous_partition)
     assert contiguous(contiguous_partition)
 
 
-def test_contiguous_with_contiguity_flips_is_true(contiguous_partition_with_flips):
+def test_contiguous_with_contiguity_flips_is_true(
+    contiguous_partition_with_flips: tuple[Partition, dict[int, int]],
+):
     contiguous_partition, test_flips = contiguous_partition_with_flips
     # frm: TODO: Testing:  Figure out whether test_flips are in original node_ids or internal RX node_ids
     contiguous_partition2 = contiguous_partition.flip(test_flips)
@@ -65,12 +72,12 @@ def test_contiguous_with_contiguity_flips_is_true(contiguous_partition_with_flip
     assert contiguous(contiguous_partition2)
 
 
-def test_discontiguous_with_contiguous_no_flips_is_false(discontiguous_partition):
+def test_discontiguous_with_contiguous_no_flips_is_false(discontiguous_partition: Partition):
     assert not contiguous(discontiguous_partition)
 
 
 def test_discontiguous_with_single_flip_contiguous_no_flips_is_false(
-    discontiguous_partition,
+    discontiguous_partition: Partition,
 ):
     assert not single_flip_contiguous(discontiguous_partition)
 
@@ -79,7 +86,7 @@ def test_discontiguous_with_single_flip_contiguous_no_flips_is_false(
     reason="single_flip_contiguous does not workwhen the previous partition is discontiguous"
 )
 def test_discontiguous_with_single_flip_contiguous_flips_is_false(
-    discontiguous_partition_with_flips,
+    discontiguous_partition_with_flips: tuple[Partition, dict[int, int]],
 ):
     part, test_flips = discontiguous_partition_with_flips
     # frm: TODO: Testing:  Figure out whether test_flips are in original node_ids or internal RX node_ids
@@ -88,7 +95,7 @@ def test_discontiguous_with_single_flip_contiguous_flips_is_false(
 
 
 def test_discontiguous_with_contiguous_flips_is_false(
-    discontiguous_partition_with_flips,
+    discontiguous_partition_with_flips: tuple[Partition, dict[int, int]],
 ):
     part, test_flips = discontiguous_partition_with_flips
     # frm: TODO: Testing:  Figure out whether test_flips are in original node_ids or internal RX node_ids
@@ -98,7 +105,7 @@ def test_discontiguous_with_contiguous_flips_is_false(
 
 def test_districts_within_tolerance_returns_false_if_districts_are_not_within_tolerance():
     # 100 and 1 are not within 1% of each other, so we should expect False
-    mock_partition = {"population": {0: 100.0, 1: 1.0}}
+    mock_partition = cast(Partition, {"population": {0: 100.0, 1: 1.0}})
 
     result = districts_within_tolerance(
         mock_partition, attribute_name="population", percentage=0.01
@@ -109,7 +116,7 @@ def test_districts_within_tolerance_returns_false_if_districts_are_not_within_to
 
 def test_districts_within_tolerance_returns_true_if_districts_are_within_tolerance():
     # 100 and 100.1 are not within 1% of each other, so we should expect True
-    mock_partition = {"population": {0: 100.0, 1: 100.1}}
+    mock_partition = cast(Partition, {"population": {0: 100.0, 1: 100.1}})
 
     result = districts_within_tolerance(
         mock_partition, attribute_name="population", percentage=0.01
@@ -119,9 +126,9 @@ def test_districts_within_tolerance_returns_true_if_districts_are_within_toleran
 
 
 def test_self_configuring_lower_bound_always_allows_the_first_argument_it_gets():
-    mock_partition = {"value": 1}
+    mock_partition = cast(Partition, {"value": 1})
 
-    def mock_func(partition):
+    def mock_func(partition: Partition) -> float:
         return partition["value"]
 
     bound = SelfConfiguringLowerBound(mock_func)
@@ -170,5 +177,5 @@ def test_no_vanishing_districts_works():
 
 
 def test_deviation_from_ideal():
-    mock_partition = {"population": {0: 99.0, 1: 101.0}}
+    mock_partition = cast(Partition, {"population": {0: 99.0, 1: 101.0}})
     assert deviation_from_ideal(mock_partition, "population") == {0: -0.01, 1: 0.01}

--- a/tests/frm_tests/test_frm_make_graph.py
+++ b/tests/frm_tests/test_frm_make_graph.py
@@ -9,6 +9,7 @@
 
 import pathlib
 from tempfile import TemporaryDirectory
+from typing import Any, cast
 from unittest.mock import patch
 
 import geopandas as gp
@@ -34,7 +35,7 @@ def geodataframe():
 
 
 @pytest.fixture
-def gdf_with_data(geodataframe):
+def gdf_with_data(geodataframe: gp.GeoDataFrame):
     geodataframe["data"] = list(range(len(geodataframe)))
     geodataframe["data2"] = list(range(len(geodataframe)))
     return geodataframe
@@ -58,11 +59,12 @@ def geodataframe_with_boundary():
 
 
 @pytest.fixture
-def shapefile(gdf_with_data):
+def shapefile(gdf_with_data: gp.GeoDataFrame):
     with TemporaryDirectory() as d:
         filepath = pathlib.Path(d) / "temp.shp"
         filename = str(filepath.absolute())
-        gdf_with_data.to_file(filename)
+        # geopandas annotates to_file as PathLike-only, so pass the Path
+        gdf_with_data.to_file(filepath.absolute())
         yield filename
 
 
@@ -104,26 +106,26 @@ def test_join_can_handle_right_index():
     assert graph.node_data("03")["16SenDVote"] == 50
 
 
-def test_make_graph_from_dataframe_creates_graph(geodataframe):
+def test_make_graph_from_dataframe_creates_graph(geodataframe: gp.GeoDataFrame):
     graph = Graph.from_geodataframe(geodataframe)
     assert isinstance(graph, Graph)
 
 
-def test_make_graph_from_dataframe_preserves_df_index(geodataframe):
-    df = geodataframe.set_index("ID")
+def test_make_graph_from_dataframe_preserves_df_index(geodataframe: gp.GeoDataFrame):
+    df = cast(gp.GeoDataFrame, geodataframe.set_index("ID"))
     graph = Graph.from_geodataframe(df)
     assert set(graph.nodes) == {"a", "b", "c", "d"}
 
 
-def test_make_graph_from_dataframe_gives_correct_graph(geodataframe):
-    df = geodataframe.set_index("ID")
+def test_make_graph_from_dataframe_gives_correct_graph(geodataframe: gp.GeoDataFrame):
+    df = cast(gp.GeoDataFrame, geodataframe.set_index("ID"))
     graph = Graph.from_geodataframe(df)
 
     assert edge_set_equal(set(graph.edges), {("a", "b"), ("a", "c"), ("b", "d"), ("c", "d")})
 
 
-def test_make_graph_works_with_queen_adjacency(geodataframe):
-    df = geodataframe.set_index("ID")
+def test_make_graph_works_with_queen_adjacency(geodataframe: gp.GeoDataFrame):
+    df = cast(gp.GeoDataFrame, geodataframe.set_index("ID"))
     graph = Graph.from_geodataframe(df, adjacency="queen")
 
     assert edge_set_equal(
@@ -132,8 +134,8 @@ def test_make_graph_works_with_queen_adjacency(geodataframe):
     )
 
 
-def test_can_pass_queen_or_rook_strings_to_control_adjacency(geodataframe):
-    df = geodataframe.set_index("ID")
+def test_can_pass_queen_or_rook_strings_to_control_adjacency(geodataframe: gp.GeoDataFrame):
+    df = cast(gp.GeoDataFrame, geodataframe.set_index("ID"))
     graph = Graph.from_geodataframe(df, adjacency="queen")
 
     assert edge_set_equal(
@@ -142,8 +144,8 @@ def test_can_pass_queen_or_rook_strings_to_control_adjacency(geodataframe):
     )
 
 
-def test_can_insist_on_not_reprojecting(geodataframe):
-    df = geodataframe.set_index("ID")
+def test_can_insist_on_not_reprojecting(geodataframe: gp.GeoDataFrame):
+    df = cast(gp.GeoDataFrame, geodataframe.set_index("ID"))
     graph = Graph.from_geodataframe(df, reproject=False)
 
     for node in ("a", "b", "c", "d"):
@@ -153,8 +155,8 @@ def test_can_insist_on_not_reprojecting(geodataframe):
         assert graph.edge_data(edge)["shared_perim"] == 1
 
 
-def test_does_not_reproject_by_default(geodataframe):
-    df = geodataframe.set_index("ID")
+def test_does_not_reproject_by_default(geodataframe: gp.GeoDataFrame):
+    df = cast(gp.GeoDataFrame, geodataframe.set_index("ID"))
     graph = Graph.from_geodataframe(df)
 
     for node in ("a", "b", "c", "d"):
@@ -164,10 +166,10 @@ def test_does_not_reproject_by_default(geodataframe):
         assert graph.edge_data(edge)["shared_perim"] == 1.0
 
 
-def test_reproject(geodataframe):
+def test_reproject(geodataframe: gp.GeoDataFrame):
     # I don't know what the areas and perimeters are in UTM for these made-up polygons,
     # but I'm pretty sure they're not 1.
-    df = geodataframe.set_index("ID")
+    df = cast(gp.GeoDataFrame, geodataframe.set_index("ID"))
     graph = Graph.from_geodataframe(df, reproject=True)
 
     for node in ("a", "b", "c", "d"):
@@ -177,8 +179,8 @@ def test_reproject(geodataframe):
         assert graph.edge_data(edge)["shared_perim"] != 1
 
 
-def test_identifies_boundary_nodes(geodataframe_with_boundary):
-    df = geodataframe_with_boundary.set_index("ID")
+def test_identifies_boundary_nodes(geodataframe_with_boundary: gp.GeoDataFrame):
+    df = cast(gp.GeoDataFrame, geodataframe_with_boundary.set_index("ID"))
     graph = Graph.from_geodataframe(df)
 
     for node in ("a", "b", "c", "e"):
@@ -186,8 +188,8 @@ def test_identifies_boundary_nodes(geodataframe_with_boundary):
     assert not graph.node_data("d")["boundary_node"]
 
 
-def test_computes_boundary_perims(geodataframe_with_boundary):
-    df = geodataframe_with_boundary.set_index("ID")
+def test_computes_boundary_perims(geodataframe_with_boundary: gp.GeoDataFrame):
+    df = cast(gp.GeoDataFrame, geodataframe_with_boundary.set_index("ID"))
     graph = Graph.from_geodataframe(df, reproject=False)
 
     expected = {"a": 5, "e": 5, "b": 1, "c": 1}
@@ -196,11 +198,11 @@ def test_computes_boundary_perims(geodataframe_with_boundary):
         assert graph.node_data(node)["boundary_perim"] == value
 
 
-def edge_set_equal(set1, set2):
+def edge_set_equal(set1: set[tuple[Any, Any]], set2: set[tuple[Any, Any]]):
     return {(y, x) for x, y in set1} | set1 == {(y, x) for x, y in set2} | set2
 
 
-def test_from_file_adds_all_data_by_default(shapefile):
+def test_from_file_adds_all_data_by_default(shapefile: str):
     graph = Graph.from_file(shapefile)
 
     # data dictionaries for all of the nodes
@@ -210,7 +212,7 @@ def test_from_file_adds_all_data_by_default(shapefile):
     assert all("data2" in node_data for node_data in all_node_data)
 
 
-def test_from_file_and_then_to_json_does_not_error(shapefile, target_file):
+def test_from_file_and_then_to_json_does_not_error(shapefile: str, target_file: str):
     graph = Graph.from_file(shapefile)
 
     # Even the geometry column is copied to the graph
@@ -223,7 +225,7 @@ def test_from_file_and_then_to_json_does_not_error(shapefile, target_file):
     graph.to_json(target_file)
 
 
-def test_from_file_and_then_to_json_with_geometries(shapefile, target_file):
+def test_from_file_and_then_to_json_with_geometries(shapefile: str, target_file: str):
     graph = Graph.from_file(shapefile)
 
     # data dictionaries for all of the nodes
@@ -245,27 +247,27 @@ def test_graph_warns_for_islands():
         graph.warn_for_islands()
 
 
-def test_graph_raises_if_crs_is_missing_when_reprojecting(geodataframe):
+def test_graph_raises_if_crs_is_missing_when_reprojecting(geodataframe: gp.GeoDataFrame):
     geodataframe.crs = None
 
     with pytest.raises(ValueError):
         Graph.from_geodataframe(geodataframe, reproject=True)
 
 
-def test_raises_geometry_error_if_invalid_geometry(shapefile):
+def test_raises_geometry_error_if_invalid_geometry(shapefile: str):
     with patch("gerrychain.graph.geo.explain_validity") as explain:
         explain.return_value = "Invalid geometry"
         with pytest.raises(GeometryError):
             Graph.from_file(shapefile, ignore_errors=False)
 
 
-def test_can_ignore_errors_while_making_graph(shapefile):
+def test_can_ignore_errors_while_making_graph(shapefile: str):
     with patch("gerrychain.graph.geo.explain_validity") as explain:
         explain.return_value = "Invalid geometry"
         assert Graph.from_file(shapefile, ignore_errors=True)
 
 
-def test_data_and_geometry(gdf_with_data):
+def test_data_and_geometry(gdf_with_data: gp.GeoDataFrame):
     df = gdf_with_data
     graph = Graph.from_geodataframe(df, cols_to_add=["data", "data2"])
     assert graph.geometry is df.geometry
@@ -275,12 +277,12 @@ def test_data_and_geometry(gdf_with_data):
     assert list(graph.data.columns) == ["data", "data2"]
 
 
-def test_make_graph_from_dataframe_has_crs(gdf_with_data):
+def test_make_graph_from_dataframe_has_crs(gdf_with_data: gp.GeoDataFrame):
     graph = Graph.from_geodataframe(gdf_with_data)
     assert CRS.from_json(graph.graph["crs"]).equals(gdf_with_data.crs)
 
 
-def test_make_graph_from_shapefile_has_crs(shapefile):
+def test_make_graph_from_shapefile_has_crs(shapefile: str):
     graph = Graph.from_file(shapefile)
     df = gp.read_file(shapefile)
     assert CRS.from_json(graph.graph["crs"]).equals(df.crs)

--- a/tests/frm_tests/test_frm_nx_rx_graph.py
+++ b/tests/frm_tests/test_frm_nx_rx_graph.py
@@ -11,7 +11,10 @@ Graph object works the same with NetworkX and RustworkX.
 
 # Set the random seed so that the results are reproducible!
 import random
+from collections.abc import Hashable
+from typing import Any
 
+import networkx as nx
 import pytest
 import rustworkx as rx
 
@@ -36,19 +39,19 @@ def gerrychain_nx_graph():
 
 
 @pytest.fixture(scope="module")
-def nx_graph(gerrychain_nx_graph):
+def nx_graph(gerrychain_nx_graph: Graph):
     # Fetch the NX graph object from inside the Graph object
     return gerrychain_nx_graph.get_nx_graph()
 
 
 @pytest.fixture(scope="module")
-def rx_graph(nx_graph):
+def rx_graph(nx_graph: "nx.Graph[Hashable, dict[str, Any], dict[str, Any]]"):
     # Create an RX graph object from NX, preserving node data
     return rx.networkx_converter(nx_graph, keep_attributes=True)
 
 
 @pytest.fixture(scope="module")
-def gerrychain_rx_graph(rx_graph):
+def gerrychain_rx_graph(rx_graph: "rx.PyGraph[dict[str, Any], dict[str, Any]]"):
     # Create a Graph object with an RX graph inside
     return Graph.from_rustworkx(rx_graph)
 
@@ -64,31 +67,34 @@ def test_sanity():
     assert True
 
 
-def test_nx_rx_sets_of_nodes_agree(nx_graph, rx_graph):
+def test_nx_rx_sets_of_nodes_agree(
+    nx_graph: "nx.Graph[Hashable, dict[str, Any], dict[str, Any]]",
+    rx_graph: "rx.PyGraph[dict[str, Any], dict[str, Any]]",
+):
     nx_set_of_nodes = set(nx_graph.nodes())
     rx_set_of_nodes = set(rx_graph.node_indices())
     assert nx_set_of_nodes == rx_set_of_nodes
 
 
-def test_nx_rx_node_data_agree(gerrychain_nx_graph, gerrychain_rx_graph):
+def test_nx_rx_node_data_agree(gerrychain_nx_graph: Graph, gerrychain_rx_graph: Graph):
     nx_data_dict = gerrychain_nx_graph.node_data(1)
     rx_data_dict = gerrychain_rx_graph.node_data(1)
     assert nx_data_dict == rx_data_dict
 
 
-def test_nx_rx_node_indices_agree(gerrychain_nx_graph, gerrychain_rx_graph):
+def test_nx_rx_node_indices_agree(gerrychain_nx_graph: Graph, gerrychain_rx_graph: Graph):
     nx_node_indices = gerrychain_nx_graph.node_indices
     rx_node_indices = gerrychain_rx_graph.node_indices
     assert nx_node_indices == rx_node_indices
 
 
-def test_nx_rx_edges_agree(gerrychain_nx_graph, gerrychain_rx_graph):
+def test_nx_rx_edges_agree(gerrychain_nx_graph: Graph, gerrychain_rx_graph: Graph):
     nx_edges = set(gerrychain_nx_graph.edges)
     rx_edges = set(gerrychain_rx_graph.edges)
     assert nx_edges == rx_edges
 
 
-def test_nx_rx_node_neighbors_agree(gerrychain_nx_graph, gerrychain_rx_graph):
+def test_nx_rx_node_neighbors_agree(gerrychain_nx_graph: Graph, gerrychain_rx_graph: Graph):
     for i in gerrychain_nx_graph:
         # Need to convert to set, because ordering of neighbor nodes differs in the lists
         nx_neighbors = set(gerrychain_nx_graph.neighbors(i))
@@ -96,7 +102,7 @@ def test_nx_rx_node_neighbors_agree(gerrychain_nx_graph, gerrychain_rx_graph):
         assert nx_neighbors == rx_neighbors
 
 
-def test_nx_rx_subgraphs_agree(gerrychain_nx_graph, gerrychain_rx_graph):
+def test_nx_rx_subgraphs_agree(gerrychain_nx_graph: Graph, gerrychain_rx_graph: Graph):
     subgraph_nodes = [
         0,
         1,
@@ -115,7 +121,7 @@ def test_nx_rx_subgraphs_agree(gerrychain_nx_graph, gerrychain_rx_graph):
     #                   nodes as the nx_subgraph, and it does not test edge data...
 
 
-def test_nx_rx_degrees_agree(gerrychain_nx_graph, gerrychain_rx_graph):
+def test_nx_rx_degrees_agree(gerrychain_nx_graph: Graph, gerrychain_rx_graph: Graph):
     # Verify that the degree of each node agrees between NX and RX versions
     nx_degrees = {
         node_id: gerrychain_nx_graph.degree(node_id) for node_id in gerrychain_nx_graph.node_indices

--- a/tests/frm_tests/test_frm_regression.py
+++ b/tests/frm_tests/test_frm_regression.py
@@ -49,4 +49,4 @@ print("Enumerated the chain: number of entries in list is: ", len(assignment_lis
 
 
 def test_success():
-    len(assignment_list) == 40
+    assert len(assignment_list) == 40

--- a/tests/meta/test_diversity.py
+++ b/tests/meta/test_diversity.py
@@ -6,6 +6,16 @@ from gerrychain.partition import Partition
 from gerrychain.updaters import cut_edges
 
 
+def last_stats(chain: list[Partition]) -> DiversityStats:
+    """Run the chain through collect_diversity_stats and return the final stats."""
+    stats = None
+    for part, stats in collect_diversity_stats(chain):
+        assert isinstance(stats, DiversityStats)
+        assert isinstance(part, Partition)
+    assert stats is not None
+    return stats
+
+
 def test_stats_one_step():
     graph = Graph.from_networkx(networkx.complete_graph(3))
     assignment = {0: 1, 1: 1, 2: 2}
@@ -13,9 +23,7 @@ def test_stats_one_step():
 
     chain = [partition]
 
-    for part, stats in collect_diversity_stats(chain):
-        assert isinstance(stats, DiversityStats)
-        assert isinstance(part, Partition)
+    stats = last_stats(chain)
 
     assert stats.unique_plans == 1
     assert stats.unique_districts == 2
@@ -30,9 +38,7 @@ def test_stats_two_steps():
         Partition(graph, {0: 1, 1: 2, 2: 1}, {"cut_edges": cut_edges}),
     ]
 
-    for part, stats in collect_diversity_stats(chain):
-        assert isinstance(stats, DiversityStats)
-        assert isinstance(part, Partition)
+    stats = last_stats(chain)
 
     assert stats.unique_plans == 2
     assert stats.unique_districts == 4
@@ -47,9 +53,7 @@ def test_stats_two_steps_many_duplicate_districts():
         Partition(graph, {0: 1, 1: 3, 2: 2}, {"cut_edges": cut_edges}),
     ]
 
-    for part, stats in collect_diversity_stats(chain):
-        assert isinstance(stats, DiversityStats)
-        assert isinstance(part, Partition)
+    stats = last_stats(chain)
 
     assert stats.unique_plans == 1
     assert stats.unique_districts == 3
@@ -64,9 +68,7 @@ def test_stats_two_steps_duplicate_plans():
         Partition(graph, {0: 1, 1: 2, 2: 3}, {"cut_edges": cut_edges}),
     ]
 
-    for part, stats in collect_diversity_stats(chain):
-        assert isinstance(stats, DiversityStats)
-        assert isinstance(part, Partition)
+    stats = last_stats(chain)
 
     assert stats.unique_plans == 1
     assert stats.unique_districts == 3

--- a/tests/metrics/test_partisan.py
+++ b/tests/metrics/test_partisan.py
@@ -13,7 +13,7 @@ from gerrychain.updaters.election import ElectionResults
 
 
 @pytest.fixture
-def mock_election():
+def mock_election() -> ElectionResults:
     election = MagicMock()
     election.parties = ["B", "A"]
 
@@ -27,12 +27,12 @@ def mock_election():
     )
 
 
-def test_efficiency_gap(mock_election):
+def test_efficiency_gap(mock_election: ElectionResults):
     result = efficiency_gap(mock_election)
     assert result == 0.3
 
 
-def test_wasted_votes(mock_election):
+def test_wasted_votes(mock_election: ElectionResults):
     result = [
         wasted_votes(
             mock_election.totals_for_party["A"][i],
@@ -43,7 +43,7 @@ def test_wasted_votes(mock_election):
     assert result == [(45, 5), (40, 10), (25, 25), (45, 5), (45, 5)]
 
 
-def test_signed_partisan_scores_point_the_same_way(mock_election):
+def test_signed_partisan_scores_point_the_same_way(mock_election: ElectionResults):
     eg = efficiency_gap(mock_election)
     mm = mean_median(mock_election)
     pb = partisan_bias(mock_election)
@@ -51,14 +51,14 @@ def test_signed_partisan_scores_point_the_same_way(mock_election):
     assert (eg > 0 and mm > 0 and pb > 0) or (eg < 0 and mm < 0 and pb < 0)
 
 
-def test_mean_median_has_right_value(mock_election):
+def test_mean_median_has_right_value(mock_election: ElectionResults):
     mm = mean_median(mock_election)
 
     assert abs(mm - 0.15) < 0.00001
 
 
 def test_signed_partisan_scores_are_positive_if_first_party_has_advantage(
-    mock_election,
+    mock_election: ElectionResults,
 ):
     eg = efficiency_gap(mock_election)
     mm = mean_median(mock_election)
@@ -67,13 +67,13 @@ def test_signed_partisan_scores_are_positive_if_first_party_has_advantage(
     assert eg > 0 and mm > 0 and pb > 0
 
 
-def test_partisan_bias_has_right_value(mock_election):
+def test_partisan_bias_has_right_value(mock_election: ElectionResults):
     pb = partisan_bias(mock_election)
 
     assert abs(pb - 0.1) < 0.00001
 
 
-def test_partisan_gini_has_right_value(mock_election):
+def test_partisan_gini_has_right_value(mock_election: ElectionResults):
     pg = partisan_gini(mock_election)
 
     assert abs(pg - 0.12) < 0.00001

--- a/tests/optimization/test_gingleator.py
+++ b/tests/optimization/test_gingleator.py
@@ -1,18 +1,18 @@
 import numpy as np
 import pytest
 
-from gerrychain import Partition
+from gerrychain import Graph, Partition
 from gerrychain.constraints import contiguous
 from gerrychain.optimization import Gingleator
 from gerrychain.proposals import build_recom_proposal_fn
 from gerrychain.updaters import Tally
 
 
-def simple_cut_edge_count(partition):
+def simple_cut_edge_count(partition: Partition) -> int:
     return len(partition["cut_edges"])
 
 
-def gingleator_test_partition(four_by_five_grid_for_opt):
+def gingleator_test_partition(four_by_five_grid_for_opt: Graph) -> Partition:
     return Partition(
         graph=four_by_five_grid_for_opt,
         assignment={
@@ -48,7 +48,7 @@ def gingleator_test_partition(four_by_five_grid_for_opt):
     )
 
 
-def test_ginglator_needs_min_perc_or_min_pop_col(four_by_five_grid_for_opt):
+def test_ginglator_needs_min_perc_or_min_pop_col(four_by_five_grid_for_opt: Graph):
     initial_partition = Partition.from_random_assignment(
         graph=four_by_five_grid_for_opt,
         n_parts=4,
@@ -86,7 +86,7 @@ def test_ginglator_needs_min_perc_or_min_pop_col(four_by_five_grid_for_opt):
     )
 
 
-def test_ginglator_warns_if_min_perc_and_min_pop_col_set(four_by_five_grid_for_opt):
+def test_ginglator_warns_if_min_perc_and_min_pop_col_set(four_by_five_grid_for_opt: Graph):
     initial_partition = Partition.from_random_assignment(
         graph=four_by_five_grid_for_opt,
         n_parts=4,
@@ -129,7 +129,7 @@ def test_ginglator_warns_if_min_perc_and_min_pop_col_set(four_by_five_grid_for_o
     )
 
 
-def test_gingleator_finds_best_partition(four_by_five_grid_for_opt):
+def test_gingleator_finds_best_partition(four_by_five_grid_for_opt: Graph):
     initial_partition = Partition.from_random_assignment(
         graph=four_by_five_grid_for_opt,
         n_parts=4,
@@ -178,21 +178,21 @@ def test_gingleator_finds_best_partition(four_by_five_grid_for_opt):
     assert max(max_scores_sb) == 2
 
 
-def test_count_num_opportunity_dists(four_by_five_grid_for_opt):
+def test_count_num_opportunity_dists(four_by_five_grid_for_opt: Graph):
     initial_partition = gingleator_test_partition(four_by_five_grid_for_opt)
 
     assert Gingleator.num_opportunity_dists(initial_partition, "m_perc", 0.5) == 2
     assert Gingleator.num_opportunity_dists(initial_partition, "m_perc", 0.6) == 0
 
 
-def test_reward_partial_dist(four_by_five_grid_for_opt):
+def test_reward_partial_dist(four_by_five_grid_for_opt: Graph):
     initial_partition = gingleator_test_partition(four_by_five_grid_for_opt)
 
     assert Gingleator.reward_partial_dist(initial_partition, "m_perc", 0.5) == 2 + 0.2
     assert Gingleator.reward_partial_dist(initial_partition, "m_perc", 0.6) == 0.52
 
 
-def test_reward_next_highest_close(four_by_five_grid_for_opt):
+def test_reward_next_highest_close(four_by_five_grid_for_opt: Graph):
     initial_partition = gingleator_test_partition(four_by_five_grid_for_opt)
 
     assert Gingleator.reward_next_highest_close(initial_partition, "m_perc", 0.5) == 2
@@ -202,7 +202,7 @@ def test_reward_next_highest_close(four_by_five_grid_for_opt):
     )
 
 
-def test_penalize_maximum_over(four_by_five_grid_for_opt):
+def test_penalize_maximum_over(four_by_five_grid_for_opt: Graph):
     initial_partition = gingleator_test_partition(four_by_five_grid_for_opt)
 
     assert Gingleator.penalize_maximum_over(initial_partition, "m_perc", 0.5) == 2.0 + 0.48 / 0.50
@@ -210,7 +210,7 @@ def test_penalize_maximum_over(four_by_five_grid_for_opt):
     assert Gingleator.penalize_maximum_over(initial_partition, "m_perc", 0.6) == 0
 
 
-def test_penalize_avg_over(four_by_five_grid_for_opt):
+def test_penalize_avg_over(four_by_five_grid_for_opt: Graph):
     initial_partition = gingleator_test_partition(four_by_five_grid_for_opt)
 
     assert Gingleator.penalize_avg_over(initial_partition, "m_perc", 0.5) == 2.0 + 0.48 / 0.50

--- a/tests/optimization/test_single_metric.py
+++ b/tests/optimization/test_single_metric.py
@@ -2,14 +2,14 @@ import random
 
 import numpy as np
 
-from gerrychain import Partition
+from gerrychain import Graph, Partition
 from gerrychain.constraints import contiguous
 from gerrychain.optimization import SingleMetricOptimizer
 from gerrychain.proposals import build_recom_proposal_fn
 from gerrychain.updaters import Tally
 
 
-def simple_cut_edge_count(partition):
+def simple_cut_edge_count(partition: Partition) -> int:
     return len(partition["cut_edges"])
 
 
@@ -18,7 +18,7 @@ def simple_cut_edge_count(partition):
 # ================
 
 
-def test_single_metric_sb_attains_min_quickly(four_by_five_grid_for_opt):
+def test_single_metric_sb_attains_min_quickly(four_by_five_grid_for_opt: Graph):
     initial_partition = Partition.from_random_assignment(
         graph=four_by_five_grid_for_opt,
         n_parts=4,
@@ -67,7 +67,7 @@ def test_single_metric_sb_attains_min_quickly(four_by_five_grid_for_opt):
     assert np.min(min_scores_sb) == 11
 
 
-def test_single_metric_tilted_sb_attains_min_quickly(four_by_five_grid_for_opt):
+def test_single_metric_tilted_sb_attains_min_quickly(four_by_five_grid_for_opt: Graph):
     initial_partition = Partition.from_random_assignment(
         graph=four_by_five_grid_for_opt,
         n_parts=4,
@@ -115,7 +115,7 @@ def test_single_metric_tilted_sb_attains_min_quickly(four_by_five_grid_for_opt):
     assert np.min(min_scores_sb) == 11
 
 
-def test_single_metric_variable_len_sb_attains_min_quickly(four_by_five_grid_for_opt):
+def test_single_metric_variable_len_sb_attains_min_quickly(four_by_five_grid_for_opt: Graph):
     initial_partition = Partition.from_random_assignment(
         graph=four_by_five_grid_for_opt,
         n_parts=4,
@@ -166,7 +166,7 @@ def test_single_metric_variable_len_sb_attains_min_quickly(four_by_five_grid_for
 # ========================
 
 
-def test_single_metric_sa_jumpcycle_attains_min_quickly(four_by_five_grid_for_opt):
+def test_single_metric_sa_jumpcycle_attains_min_quickly(four_by_five_grid_for_opt: Graph):
     initial_partition = Partition.from_random_assignment(
         graph=four_by_five_grid_for_opt,
         n_parts=4,
@@ -213,7 +213,7 @@ def test_single_metric_sa_jumpcycle_attains_min_quickly(four_by_five_grid_for_op
     assert np.min(min_scores_anneal) == 11
 
 
-def test_single_metric_sa_lincycle_attains_min_quickly(four_by_five_grid_for_opt):
+def test_single_metric_sa_lincycle_attains_min_quickly(four_by_five_grid_for_opt: Graph):
     initial_partition = Partition.from_random_assignment(
         graph=four_by_five_grid_for_opt,
         n_parts=4,
@@ -260,7 +260,7 @@ def test_single_metric_sa_lincycle_attains_min_quickly(four_by_five_grid_for_opt
 
 
 def test_single_metric_sa_linear_jumpcycle_attains_min_quickly(
-    four_by_five_grid_for_opt,
+    four_by_five_grid_for_opt: Graph,
 ):
     initial_partition = Partition.from_random_assignment(
         graph=four_by_five_grid_for_opt,
@@ -307,7 +307,7 @@ def test_single_metric_sa_linear_jumpcycle_attains_min_quickly(
     assert np.min(min_scores_anneal) == 11
 
 
-def test_single_metric_sa_logitcycle_attains_min_quickly(four_by_five_grid_for_opt):
+def test_single_metric_sa_logitcycle_attains_min_quickly(four_by_five_grid_for_opt: Graph):
     initial_partition = Partition.from_random_assignment(
         graph=four_by_five_grid_for_opt,
         n_parts=4,
@@ -354,7 +354,7 @@ def test_single_metric_sa_logitcycle_attains_min_quickly(four_by_five_grid_for_o
 
 
 def test_single_metric_sa_logit_jumpcycle_attains_min_quickly(
-    four_by_five_grid_for_opt,
+    four_by_five_grid_for_opt: Graph,
 ):
     initial_partition = Partition.from_random_assignment(
         graph=four_by_five_grid_for_opt,
@@ -407,7 +407,7 @@ def test_single_metric_sa_logit_jumpcycle_attains_min_quickly(
 
 
 def test_single_metric_tilted_runs_attains_min_quickly_with_p_eq_0p1(
-    four_by_five_grid_for_opt,
+    four_by_five_grid_for_opt: Graph,
 ):
     initial_partition = Partition.from_random_assignment(
         graph=four_by_five_grid_for_opt,
@@ -455,8 +455,8 @@ def test_single_metric_tilted_runs_attains_min_quickly_with_p_eq_0p1(
 # ==========================
 
 
-def test_single_metric_sb_finds_hard_max(four_by_five_grid_for_opt):
-    def opt_fn(partition):
+def test_single_metric_sb_finds_hard_max(four_by_five_grid_for_opt: Graph):
+    def opt_fn(partition: Partition) -> int:
         mx = 10
         count = sum(1 for x in partition["opt_value_sum"].values() if x == mx)
         return count
@@ -508,8 +508,8 @@ def test_single_metric_sb_finds_hard_max(four_by_five_grid_for_opt):
     assert np.max(max_scores_sb) == 2
 
 
-def test_single_metric_sa_finds_hard_max(four_by_five_grid_for_opt):
-    def opt_fn(partition):
+def test_single_metric_sa_finds_hard_max(four_by_five_grid_for_opt: Graph):
+    def opt_fn(partition: Partition) -> int:
         mx = 10
         count = sum(1 for x in partition["opt_value_sum"].values() if x == mx)
         return count
@@ -560,8 +560,8 @@ def test_single_metric_sa_finds_hard_max(four_by_five_grid_for_opt):
     assert np.max(max_scores_anneal) == 2
 
 
-def test_single_metric_tilted_runs_finds_hard_max(four_by_five_grid_for_opt):
-    def opt_fn(partition):
+def test_single_metric_tilted_runs_finds_hard_max(four_by_five_grid_for_opt: Graph):
+    def opt_fn(partition: Partition) -> int:
         mx = 10
         count = sum(1 for x in partition["opt_value_sum"].values() if x == mx)
         return count

--- a/tests/partition/test_assignment.py
+++ b/tests/partition/test_assignment.py
@@ -1,4 +1,5 @@
 from collections.abc import Mapping
+from typing import Any, cast
 
 import pandas
 import pytest
@@ -7,21 +8,21 @@ from gerrychain.partition.assignment import Assignment, get_assignment
 
 
 @pytest.fixture
-def assignment():
+def assignment() -> Assignment:
     return Assignment.from_dict({1: 1, 2: 2, 3: 2})
 
 
 class TestAssignment:
-    def test_assignment_can_be_updated(self, assignment):
+    def test_assignment_can_be_updated(self, assignment: Assignment):
         assignment.update_flows({1: {"out": set(), "in": {2}}, 2: {"out": {2}, "in": set()}})
         assert assignment[2] == 1
 
-    def test_assignment_copy_does_not_copy_the_node_sets(self, assignment):
+    def test_assignment_copy_does_not_copy_the_node_sets(self, assignment: Assignment):
         assignment2 = assignment.copy()
         for part in assignment.parts:
             assert assignment2[part] is assignment[part]
 
-    def test_to_series(self, assignment):
+    def test_to_series(self, assignment: Assignment):
         series = assignment.to_series()
 
         assert isinstance(series, pandas.Series)
@@ -31,7 +32,7 @@ class TestAssignment:
         assignment = Assignment.from_dict({0: 1, 1: 1, 2: 2})
         assert assignment.to_vector().tolist() == [1, 1, 2]
 
-    def test_to_vector_requires_contiguous_0_based_node_ids(self, assignment):
+    def test_to_vector_requires_contiguous_0_based_node_ids(self, assignment: Assignment):
         # The fixture's nodes are {1, 2, 3}, which are not 0-based.
         with pytest.raises(ValueError, match="contiguous"):
             assignment.to_vector()
@@ -52,25 +53,26 @@ class TestAssignment:
         vector[0] = "a_label_longer_than_one_character"
         assert vector[0] == "a_label_longer_than_one_character"
 
-    def test_to_dict(self, assignment):
+    def test_to_dict(self, assignment: Assignment):
         assignment_dict = assignment.to_dict()
 
         assert isinstance(assignment_dict, dict)
         assert list(assignment_dict.items()) == [(1, 1), (2, 2), (3, 2)]
 
-    def test_has_get_method_like_a_dict(self, assignment):
+    def test_has_get_method_like_a_dict(self, assignment: Assignment):
         assert assignment.get(1) == 1
-        assert assignment.get("not a node", default=5) == 5
+        # Mapping.get is positional-only in typeshed, but the runtime ABC takes a keyword.
+        assert cast(Any, assignment).get("not a node", default=5) == 5
 
-    def test_raises_keyerror_for_missing_nodes(self, assignment):
+    def test_raises_keyerror_for_missing_nodes(self, assignment: Assignment):
         with pytest.raises(KeyError):
             assignment["not a node"]
 
-    def test_can_update_parts(self, assignment):
+    def test_can_update_parts(self, assignment: Assignment):
         assignment.update_parts({2: {2}, 3: {3}})
         assert assignment.to_dict() == {1: 1, 2: 2, 3: 3}
 
-    def test_implements_Mapping_abc(self, assignment):
+    def test_implements_Mapping_abc(self, assignment: Assignment):
         # __iter__
         assert list(assignment) == [1, 2, 3]
 
@@ -107,7 +109,7 @@ class TestAssignment:
 
     def test_assignment_raises_if_a_key_has_two_assignments(self):
         with pytest.raises(ValueError):
-            Assignment({"one": {1, 2, 3}, "two": {1, 4, 5}})
+            Assignment({"one": frozenset({1, 2, 3}), "two": frozenset({1, 4, 5})})
 
     def test_assignment_can_be_instantiated_from_series(self):
         series = pandas.Series([1, 2, 1, 2], index=[1, 2, 3, 4])
@@ -115,7 +117,7 @@ class TestAssignment:
         assert assignment == {1: 1, 2: 2, 3: 1, 4: 2}
 
 
-def test_get_assignment_accepts_assignment(assignment):
+def test_get_assignment_accepts_assignment(assignment: Assignment):
     created = assignment
     get_assignment(assignment)
     assert assignment is created
@@ -123,7 +125,7 @@ def test_get_assignment_accepts_assignment(assignment):
 
 def test_get_assignment_raises_typeerror_for_unexpected_input():
     with pytest.raises(TypeError):
-        get_assignment(None)
+        get_assignment(cast(str, None))
 
 
 def test_get_assignment_with_series():
@@ -133,5 +135,5 @@ def test_get_assignment_with_series():
     assert assignment == {1: 1, 2: 2, 3: 1, 4: 2}
 
 
-def test_repr(assignment):
+def test_repr(assignment: Assignment):
     assert repr(assignment) == "<Assignment [3 keys, 2 parts]>"

--- a/tests/partition/test_partition.py
+++ b/tests/partition/test_partition.py
@@ -1,6 +1,8 @@
 import json
 import pathlib
 import random
+from collections.abc import Iterator
+from typing import cast
 from tempfile import TemporaryDirectory
 
 import networkx
@@ -13,7 +15,7 @@ from gerrychain.proposals import propose_random_flip
 from gerrychain.updaters import cut_edges
 
 
-def test_Partition_can_be_flipped(example_partition):
+def test_Partition_can_be_flipped(example_partition: Partition):
     # frm: TODO: Testing:  Verify that this flip is in internal RX-based graph node_ids and not "original" NX node_ids
     #
     # My guess is that this flip is intended to be in original node_ids but that the test works
@@ -36,7 +38,7 @@ def test_Partition_misnamed_vertices_raises_keyerror():
 def test_Partition_graph_raises_typeerror():
     assignment = {"0": 1, "1": 1, "2": 2}
     with pytest.raises(TypeError):
-        Partition("not a graph", assignment, {"cut_edges": cut_edges})
+        Partition(cast(Graph, "not a graph"), assignment, {"cut_edges": cut_edges})
 
 
 def test_Partition_unlabelled_vertices_raises_keyerror():
@@ -46,16 +48,16 @@ def test_Partition_unlabelled_vertices_raises_keyerror():
         Partition(graph, assignment, {"cut_edges": cut_edges})
 
 
-def test_assignment_vector(example_partition):
+def test_assignment_vector(example_partition: Partition):
     assert example_partition.assignment_vector.tolist() == [1, 1, 2]
 
 
-def test_assignment_vector_is_read_only(example_partition):
+def test_assignment_vector_is_read_only(example_partition: Partition):
     with pytest.raises(ValueError):
         example_partition.assignment_vector[0] = 5
 
 
-def test_assignment_vector_incremental_from_cached_parent(example_partition):
+def test_assignment_vector_incremental_from_cached_parent(example_partition: Partition):
     parent_vector = example_partition.assignment_vector
     child = example_partition.flip({1: 2})
     assert child.assignment_vector.tolist() == [1, 2, 2]
@@ -63,7 +65,7 @@ def test_assignment_vector_incremental_from_cached_parent(example_partition):
     assert parent_vector.tolist() == [1, 1, 2]
 
 
-def test_assignment_vector_without_cached_parent(example_partition):
+def test_assignment_vector_without_cached_parent(example_partition: Partition):
     child = example_partition.flip({1: 2})
     assert child.assignment_vector.tolist() == [1, 2, 2]
 
@@ -107,13 +109,13 @@ def test_assignment_vector_rejects_non_contiguous_graph():
         partition.assignment_vector
 
 
-def test_Partition_knows_cut_edges_K3(example_partition):
+def test_Partition_knows_cut_edges_K3(example_partition: Partition):
     partition = example_partition
     assert (1, 2) in partition["cut_edges"] or (2, 1) in partition["cut_edges"]
     assert (0, 2) in partition["cut_edges"] or (2, 0) in partition["cut_edges"]
 
 
-def test_propose_random_flip_proposes_a_partition(example_partition):
+def test_propose_random_flip_proposes_a_partition(example_partition: Partition):
     partition = example_partition
 
     # frm: TODO: Testing:  Verify that propose_random_flip() to make sure it is doing the right thing
@@ -123,7 +125,7 @@ def test_propose_random_flip_proposes_a_partition(example_partition):
 
 
 @pytest.fixture
-def example_geographic_partition():
+def example_geographic_partition() -> GeographicPartition:
     graph = Graph.from_networkx(networkx.complete_graph(3))
     assignment = {0: 1, 1: 1, 2: 2}
     for node in graph.nodes:
@@ -135,12 +137,14 @@ def example_geographic_partition():
     return GeographicPartition(graph, assignment, None, None, None)
 
 
-def test_geographic_partition_can_be_instantiated(example_geographic_partition):
+def test_geographic_partition_can_be_instantiated(
+    example_geographic_partition: GeographicPartition,
+):
     partition = example_geographic_partition
     assert isinstance(partition, GeographicPartition)
 
 
-def test_Partition_parts_is_a_dictionary_of_parts_to_nodes(example_partition):
+def test_Partition_parts_is_a_dictionary_of_parts_to_nodes(example_partition: Partition):
     partition = example_partition
     flip = {1: 2}
     new_partition = partition.flip(flip, flips_passed_in_use_original_nx_node_ids=True)
@@ -148,7 +152,7 @@ def test_Partition_parts_is_a_dictionary_of_parts_to_nodes(example_partition):
     assert all(isinstance(nodes, frozenset) for nodes in partition.parts.values())
 
 
-def test_Partition_has_subgraphs(example_partition):
+def test_Partition_has_subgraphs(example_partition: Partition):
     # Test that subgraphs work as intended.
     # The partition has two parts (districts) with IDs: 1, 2
     # Part #1 has nodes 0, 1, so the subgraph for part #1 should have these nodes
@@ -172,16 +176,16 @@ def test_Partition_has_subgraphs(example_partition):
     assert len(list(partition.subgraphs)) == 2
 
 
-def test_Partition_caches_subgraphs(example_partition):
+def test_Partition_caches_subgraphs(example_partition: Partition):
     subgraph = example_partition.subgraphs[1]
     assert subgraph is example_partition.subgraphs[1]
 
 
-def test_partition_implements_getattr_for_updater_access(example_partition):
+def test_partition_implements_getattr_for_updater_access(example_partition: Partition):
     assert example_partition["cut_edges"]
 
 
-def test_can_be_created_from_a_districtr_file(graph, districtr_plan_file):
+def test_can_be_created_from_a_districtr_file(graph: Graph, districtr_plan_file: pathlib.Path):
     for node in graph:
         graph.node_data(node)["area_num_1"] = node
 
@@ -211,13 +215,15 @@ def test_can_be_created_from_a_districtr_file(graph, districtr_plan_file):
     }
 
 
-def test_from_districtr_plan_raises_if_id_column_missing(graph, districtr_plan_file):
+def test_from_districtr_plan_raises_if_id_column_missing(
+    graph: Graph, districtr_plan_file: pathlib.Path
+):
     with pytest.raises(TypeError):
         Partition.from_districtr_file(graph, districtr_plan_file)
 
 
 @pytest.fixture
-def districtr_plan_file():
+def districtr_plan_file() -> Iterator[pathlib.Path]:
     districtr_plan = {
         "assignment": {
             "0": 1,
@@ -248,11 +254,11 @@ def districtr_plan_file():
         yield filename
 
 
-def test_repr(example_partition):
+def test_repr(example_partition: Partition):
     assert repr(example_partition) == "<Partition [2 parts]>"
 
 
-def test_partition_has_default_updaters(example_partition):
+def test_partition_has_default_updaters(example_partition: Partition):
     partition = example_partition
     should_have_updaters = {"cut_edges": cut_edges}
 
@@ -260,22 +266,22 @@ def test_partition_has_default_updaters(example_partition):
         assert should_have_updaters[updater](partition) == partition[updater]
 
 
-def test_partition_does_not_mutate_default_updaters(graph):
+def test_partition_does_not_mutate_default_updaters(graph: Graph):
     custom_updater = "custom_for_default_isolation_test"
     Partition(
         graph,
-        {node: node // 3 for node in graph},
+        {node: cast(int, node) // 3 for node in graph},
         {custom_updater: lambda partition: partition},
     )
 
     assert custom_updater not in Partition.default_updaters
 
 
-def test_partition_has_keys(example_partition):
+def test_partition_has_keys(example_partition: Partition):
     assert "cut_edges" in set(example_partition.keys())
 
 
-def test_geographic_partition_has_keys(example_geographic_partition):
+def test_geographic_partition_has_keys(example_geographic_partition: GeographicPartition):
     keys = set(example_geographic_partition.updaters.keys())
 
     assert "perimeter" in keys
@@ -287,7 +293,9 @@ def test_geographic_partition_has_keys(example_geographic_partition):
     assert "cut_edges_by_part" in keys
 
 
-def test_geographic_partition_has_default_updaters(example_geographic_partition):
+def test_geographic_partition_has_default_updaters(
+    example_geographic_partition: GeographicPartition,
+):
     assert example_geographic_partition["perimeter"]
     assert example_geographic_partition["exterior_boundaries"]
     assert example_geographic_partition["interior_boundaries"]

--- a/tests/partition/test_plotting.py
+++ b/tests/partition/test_plotting.py
@@ -1,3 +1,4 @@
+from typing import cast
 from unittest.mock import MagicMock
 
 import geopandas as gp
@@ -9,14 +10,14 @@ from gerrychain import Graph, Partition
 
 
 @pytest.fixture
-def partition():
+def partition() -> Partition:
     nx_graph = networkx.Graph([(0, 1), (1, 3), (2, 3), (0, 2)])
     graph = Graph.from_networkx(nx_graph)
     return Partition(graph, {0: 1, 1: 1, 2: 2, 3: 2})
 
 
 @pytest.fixture
-def geodataframe():
+def geodataframe() -> gp.GeoDataFrame:
     a = Polygon([(0, 0), (0, 1), (1, 1), (1, 0)])
     b = Polygon([(0, 1), (0, 2), (1, 2), (1, 1)])
     c = Polygon([(1, 0), (1, 1), (2, 1), (2, 0)])
@@ -27,44 +28,56 @@ def geodataframe():
 
 
 class TestPartitionPlotting:
-    def test_can_plot(self, geodataframe, partition):
+    def test_can_plot(
+        self, geodataframe: gp.GeoDataFrame, partition: Partition, monkeypatch: pytest.MonkeyPatch
+    ):
         mock_plot = MagicMock()
-        gp.GeoDataFrame.plot = mock_plot
+        monkeypatch.setattr(gp.GeoDataFrame, "plot", mock_plot)
         partition.plot(geodataframe)
         assert mock_plot.call_count == 1
 
-    def test_raises_typeerror_for_mismatched_indices(self, geodataframe, partition):
-        df = geodataframe.set_index("ID")
+    def test_raises_typeerror_for_mismatched_indices(
+        self, geodataframe: gp.GeoDataFrame, partition: Partition
+    ):
+        df = cast(gp.GeoDataFrame, geodataframe.set_index("ID"))
         with pytest.raises(TypeError):
             partition.plot(df)
 
-    def test_can_plot_using_geoseries(self, geodataframe, partition):
+    def test_can_plot_using_geoseries(
+        self, geodataframe: gp.GeoDataFrame, partition: Partition, monkeypatch: pytest.MonkeyPatch
+    ):
         mock_plot = MagicMock()
-        gp.GeoDataFrame.plot = mock_plot
+        monkeypatch.setattr(gp.GeoDataFrame, "plot", mock_plot)
         partition.plot(geodataframe.geometry)
         assert mock_plot.call_count == 1
 
-    def test_can_pass_kwargs_to_plot(self, geodataframe, partition):
+    def test_can_pass_kwargs_to_plot(
+        self, geodataframe: gp.GeoDataFrame, partition: Partition, monkeypatch: pytest.MonkeyPatch
+    ):
         mock_plot = MagicMock()
-        gp.GeoDataFrame.plot = mock_plot
+        monkeypatch.setattr(gp.GeoDataFrame, "plot", mock_plot)
 
         partition.plot(geodataframe, cmap="viridis")
 
         args, kwargs = mock_plot.call_args
         assert kwargs["cmap"] == "viridis"
 
-    def test_calls_with_column_as_a_string(self, geodataframe, partition):
+    def test_calls_with_column_as_a_string(
+        self, geodataframe: gp.GeoDataFrame, partition: Partition, monkeypatch: pytest.MonkeyPatch
+    ):
         mock_plot = MagicMock()
-        gp.GeoDataFrame.plot = mock_plot
+        monkeypatch.setattr(gp.GeoDataFrame, "plot", mock_plot)
 
         partition.plot(geodataframe)
 
         args, kwargs = mock_plot.call_args
         assert isinstance(kwargs["column"], str)
 
-    def test_uses_graph_geometries_by_default(self, geodataframe):
+    def test_uses_graph_geometries_by_default(
+        self, geodataframe: gp.GeoDataFrame, monkeypatch: pytest.MonkeyPatch
+    ):
         mock_plot = MagicMock()
-        gp.GeoDataFrame.plot = mock_plot
+        monkeypatch.setattr(gp.GeoDataFrame, "plot", mock_plot)
 
         graph = Graph.from_geodataframe(geodataframe)
         partition = Partition(graph=graph, assignment={node: 0 for node in graph})

--- a/tests/test_chain.py
+++ b/tests/test_chain.py
@@ -1,30 +1,44 @@
+import random
+from collections.abc import Callable
+from typing import Any, cast
 from unittest.mock import MagicMock
 
 import pytest
 
 from gerrychain.chain import MarkovChain
+from gerrychain.partition import Partition
 
 
 class MockState:
-    def flip(self, changes, flips_passed_in_use_original_nx_node_ids):
+    def flip(
+        self, changes: dict[int, int], flips_passed_in_use_original_nx_node_ids: bool
+    ) -> "MockState":
         return MockState()
 
 
-def mock_proposal(state, *, rng):
-    return state.flip({1: 2}, flips_passed_in_use_original_nx_node_ids=True)
+def mock_state() -> Partition:
+    # MockState stands in for Partition; the chain only ever calls flip() on the state.
+    return cast(Partition, MockState())
 
 
-def mock_accept(state, *, rng):
+def mock_proposal(state: Partition, *, rng: random.Random) -> Partition:
+    return cast(
+        Partition,
+        cast(MockState, state).flip({1: 2}, flips_passed_in_use_original_nx_node_ids=True),
+    )
+
+
+def mock_accept(state: Partition, *, rng: random.Random) -> bool:
     return True
 
 
-def mock_is_valid(state):
+def mock_is_valid(state: Partition) -> bool:
     return True
 
 
 def test_MarkovChain_runs_only_total_steps_times():
     for total_steps in range(1, 11):
-        initial = MockState()
+        initial = mock_state()
         chain = MarkovChain(mock_proposal, mock_is_valid, mock_accept, initial, total_steps)
         counter = 0
         for state in chain:
@@ -51,31 +65,31 @@ def test_MarkovChain_returns_the_initial_partition_first():
 
 def test_chain_only_yields_accepted_states():
     class Value:
-        def __init__(self, value):
+        def __init__(self, value: int):
             self.value = value
 
     values = list(reversed([Value(x) for x in [0, 1, 2, 3, -1, -2, -3, -4]]))
 
-    def accept(value, *, rng):
-        return value.value <= 0
+    def accept(value: Partition, *, rng: random.Random) -> bool:
+        return cast(Value, value).value <= 0
 
-    def proposal(value, *, rng):
-        return values.pop()
+    def proposal(value: Partition, *, rng: random.Random) -> Partition:
+        return cast(Partition, values.pop())
 
     chain = MarkovChain(
         proposal_fn=proposal,
         constraints=lambda x: True,
         acceptance_fn=accept,
-        initial_partition=Value(0),
+        initial_partition=cast(Partition, Value(0)),
         total_steps=4,
     )
 
     for state in chain:
-        assert state.value <= 0, "The chain yielded a non-accepted state"
+        assert cast(Value, state).value <= 0, "The chain yielded a non-accepted state"
 
 
 def test_incremental_construction_matches_constructor():
-    initial = MockState()
+    initial = mock_state()
     chain = MarkovChain(total_steps=5)
     chain.initial_partition = initial
     chain.proposal_fn = mock_proposal
@@ -95,35 +109,35 @@ def test_check_valid_names_missing_config():
 
 
 def test_iter_rejects_invalid_initial_partition():
-    def never_valid(state):
+    def never_valid(state: Partition) -> bool:
         return False
 
     chain = MarkovChain(proposal_fn=mock_proposal, acceptance_fn=mock_accept, total_steps=5)
     chain.constraints = never_valid  # no initial_partition yet, so this cannot validate
-    chain.initial_partition = MockState()
+    chain.initial_partition = mock_state()
     with pytest.raises(ValueError, match="never_valid"):
         next(iter(chain))
 
 
 def test_add_constraint_defers_check_until_iteration():
-    def never_valid(state):
+    def never_valid(state: Partition) -> bool:
         return False
 
     chain = MarkovChain(proposal_fn=mock_proposal, acceptance_fn=mock_accept, total_steps=3)
     chain.add_constraint(never_valid)  # no initial_partition yet: recorded, not checked
-    chain.initial_partition = MockState()
+    chain.initial_partition = mock_state()
     with pytest.raises(ValueError, match="never_valid"):
         next(iter(chain))
 
 
 def test_add_constraint_validates_immediately_with_initial_partition():
-    def never_valid(state):
+    def never_valid(state: Partition) -> bool:
         return False
 
     chain = MarkovChain(
         proposal_fn=mock_proposal,
         acceptance_fn=mock_accept,
-        initial_partition=MockState(),
+        initial_partition=mock_state(),
         total_steps=3,
     )
     with pytest.raises(ValueError, match="never_valid"):
@@ -134,19 +148,19 @@ def test_add_constraint_validates_immediately_with_initial_partition():
 
 def test_add_updater_applies_before_or_after_initial_partition():
     class StateWithUpdaters(MockState):
-        def __init__(self):
-            self.updaters = {}
+        def __init__(self) -> None:
+            self.updaters: dict[str, Callable[[Partition], Any]] = {}
 
-    def answer(partition):
+    def answer(partition: Partition) -> int:
         return 42
 
-    def zero(partition):
+    def zero(partition: Partition) -> int:
         return 0
 
     chain = MarkovChain(proposal_fn=mock_proposal, acceptance_fn=mock_accept, total_steps=3)
     chain.add_updater("answer", answer)  # before any initial_partition: applied on assignment
     initial = StateWithUpdaters()
-    chain.initial_partition = initial
+    chain.initial_partition = cast(Partition, initial)
     assert initial.updaters["answer"] is answer
 
     chain.add_updater("zero", zero)  # after: applied immediately
@@ -154,7 +168,7 @@ def test_add_updater_applies_before_or_after_initial_partition():
 
 
 def test_add_constraint_and_add_updater_rejected_while_locked():
-    chain = MarkovChain(mock_proposal, mock_is_valid, mock_accept, MockState(), total_steps=3)
+    chain = MarkovChain(mock_proposal, mock_is_valid, mock_accept, mock_state(), total_steps=3)
     it = iter(chain)
     next(it)
     with pytest.raises(AttributeError, match="locked"):
@@ -167,7 +181,7 @@ def test_constraints_setter_still_validates_eagerly():
     chain = MarkovChain(
         proposal_fn=mock_proposal,
         acceptance_fn=mock_accept,
-        initial_partition=MockState(),
+        initial_partition=mock_state(),
         total_steps=5,
     )
     with pytest.raises(ValueError, match="lambda"):
@@ -175,7 +189,7 @@ def test_constraints_setter_still_validates_eagerly():
 
 
 def test_config_locked_while_running_and_unlocked_after():
-    chain = MarkovChain(mock_proposal, mock_is_valid, mock_accept, MockState(), total_steps=3)
+    chain = MarkovChain(mock_proposal, mock_is_valid, mock_accept, mock_state(), total_steps=3)
     it = iter(chain)
     next(it)
     with pytest.raises(AttributeError, match="locked"):
@@ -190,7 +204,7 @@ def test_config_locked_while_running_and_unlocked_after():
 
 
 def test_chain_abandoned_by_break_unlocks_and_can_be_rerun():
-    chain = MarkovChain(mock_proposal, mock_is_valid, mock_accept, MockState(), total_steps=3)
+    chain = MarkovChain(mock_proposal, mock_is_valid, mock_accept, mock_state(), total_steps=3)
     for _ in chain:
         break
 
@@ -205,10 +219,10 @@ def test_chain_abandoned_by_break_unlocks_and_can_be_rerun():
 
 
 def test_chain_unlocks_when_a_step_raises():
-    def exploding_proposal(state, *, rng):
+    def exploding_proposal(state: Partition, *, rng: random.Random) -> Partition:
         raise RuntimeError("boom")
 
-    chain = MarkovChain(exploding_proposal, mock_is_valid, mock_accept, MockState(), total_steps=3)
+    chain = MarkovChain(exploding_proposal, mock_is_valid, mock_accept, mock_state(), total_steps=3)
     it = iter(chain)
     next(it)  # the initial state is yielded without calling the proposal
     with pytest.raises(RuntimeError, match="boom"):
@@ -220,7 +234,7 @@ def test_chain_unlocks_when_a_step_raises():
 
 def test_repr():
     chain = MarkovChain(
-        proposal_fn=lambda x, *, rng: None,
+        proposal_fn=lambda x, *, rng: x,
         constraints=[],
         acceptance_fn=lambda x, *, rng: True,
         initial_partition=None,

--- a/tests/test_docs_snippets.py
+++ b/tests/test_docs_snippets.py
@@ -198,7 +198,7 @@ def _page_id(page: Path) -> str:
     return str(page.relative_to(REPO))
 
 
-def _run_block(block: Block, namespace: dict) -> None:
+def _run_block(block: Block, namespace: dict[str, object]) -> None:
     # Pad the source so tracebacks and SyntaxErrors point at the real line in the docs page.
     padded = "\n" * (block.lineno - 1) + block.source
     exec(compile(padded, str(block.page), "exec"), namespace)
@@ -214,7 +214,7 @@ def docs_cwd(tmp_path_factory: pytest.TempPathFactory) -> Path:
     old = os.getcwd()
     os.chdir(cwd)
     try:
-        namespace: dict = {}
+        namespace: dict[str, object] = {}
         for page in PAGES:
             for block in ALL_BLOCKS[page]:
                 if block.marker == "setup":
@@ -231,7 +231,7 @@ def test_page_snippets(page: Path, docs_cwd: Path, monkeypatch: pytest.MonkeyPat
     # (the conftest fixture re-enables its previous state afterwards).
     set_runtime_checks(False)
     monkeypatch.chdir(docs_cwd)
-    namespace: dict = {}
+    namespace: dict[str, object] = {}
     try:
         for block in ALL_BLOCKS[page]:
             if block.marker in MARKERS:
@@ -472,7 +472,7 @@ class TestRstExtractor:
                 x = f() + 1
             """
         )
-        namespace: dict = {}
+        namespace: dict[str, object] = {}
         _run_block(blocks[0], namespace)
         assert namespace["x"] == 42
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,5 +1,9 @@
 """Tests for the bundled example graphs in :mod:`gerrychain.examples`."""
 
+import pathlib
+
+import pytest
+
 from gerrychain import Graph
 from gerrychain.examples import gerrymandria
 
@@ -25,7 +29,7 @@ def test_gerrymandria_has_region_attributes():
     ]
 
 
-def test_gerrymandria_is_self_contained(tmp_path, monkeypatch):
+def test_gerrymandria_is_self_contained(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch):
     # The point of shipping the data with the package is that it loads regardless of the working
     # directory (unlike the old Graph.from_json("./gerrymandria.json") relative-path loading).
     monkeypatch.chdir(tmp_path)

--- a/tests/test_frm_graph.py
+++ b/tests/test_frm_graph.py
@@ -1,3 +1,7 @@
+from collections.abc import Hashable, Iterable, Sequence
+from typing import Any, cast
+
+import networkx as nx
 import pytest
 import rustworkx as rx
 
@@ -9,13 +13,13 @@ from gerrychain import Graph
 
 
 @pytest.fixture
-def four_by_five_grid_rx(four_by_five_grid_nx):
+def four_by_five_grid_rx(four_by_five_grid_nx: "nx.Graph[int, dict[str, Any], dict[str, Any]]"):
     # Create an RX Graph object with attributes
     rx_graph = rx.networkx_converter(four_by_five_grid_nx, keep_attributes=True)
     return rx_graph
 
 
-def top_level_graph_is_properly_configured(graph):
+def top_level_graph_is_properly_configured(graph: Graph):
     # This routine tests that top-level graphs (not a subgraph)
     # are properly configured
     assert not graph._is_a_subgraph, "Top-level graph _is_a_subgraph is True"
@@ -27,7 +31,7 @@ def top_level_graph_is_properly_configured(graph):
     )
 
 
-def test_from_networkx(four_by_five_grid_nx):
+def test_from_networkx(four_by_five_grid_nx: "nx.Graph[int, dict[str, Any], dict[str, Any]]"):
     graph = Graph.from_networkx(four_by_five_grid_nx)
     assert len(graph.node_indices) == 20, f"Expected 20 nodes but got {len(graph.node_indices)}"
     assert len(graph.edge_indices) == 26, f"Expected 26 edges but got {len(graph.edge_indices)}"
@@ -37,7 +41,7 @@ def test_from_networkx(four_by_five_grid_nx):
     top_level_graph_is_properly_configured(graph)
 
 
-def test_from_rustworkx(four_by_five_grid_nx):
+def test_from_rustworkx(four_by_five_grid_nx: "nx.Graph[int, dict[str, Any], dict[str, Any]]"):
     rx_graph = rx.networkx_converter(four_by_five_grid_nx, keep_attributes=True)
     graph = Graph.from_rustworkx(rx_graph)
     assert len(graph.node_indices) == 20, f"Expected 20 nodes but got {len(graph.node_indices)}"
@@ -48,14 +52,14 @@ def test_from_rustworkx(four_by_five_grid_nx):
 
 
 @pytest.fixture
-def four_by_five_graph_nx(four_by_five_grid_nx):
+def four_by_five_graph_nx(four_by_five_grid_nx: "nx.Graph[int, dict[str, Any], dict[str, Any]]"):
     # Create an NX Graph object with attributes
     graph = Graph.from_networkx(four_by_five_grid_nx)
     return graph
 
 
 @pytest.fixture
-def four_by_five_graph_rx(four_by_five_grid_nx):
+def four_by_five_graph_rx(four_by_five_grid_nx: "nx.Graph[int, dict[str, Any], dict[str, Any]]"):
     # Create an NX Graph object with attributes
     #
     # Instead of using from_rustworkx(), we use
@@ -68,7 +72,7 @@ def four_by_five_graph_rx(four_by_five_grid_nx):
     return converted_graph
 
 
-def test_convert_from_nx_to_rx(four_by_five_graph_nx):
+def test_convert_from_nx_to_rx(four_by_five_graph_nx: Graph):
     graph = four_by_five_graph_nx  # more readable
     converted_graph = graph.convert_from_nx_to_rx()
 
@@ -116,7 +120,7 @@ def test_convert_from_nx_to_rx(four_by_five_graph_nx):
         assert converted_graph.node_data(node_id)["nx_node_id"] == nx_node_id
 
 
-def test_get_edge_from_edge_id(four_by_five_graph_nx, four_by_five_graph_rx):
+def test_get_edge_from_edge_id(four_by_five_graph_nx: Graph, four_by_five_graph_rx: Graph):
     # Test that get_edge_from_edge_id works for both NX and RX based Graph objects
 
     # NX edges and edge_ids are the same, so this first test is trivial
@@ -135,7 +139,7 @@ def test_get_edge_from_edge_id(four_by_five_graph_nx, four_by_five_graph_rx):
     assert isinstance(rx_edge[1], int), "RX edge does not exist (1)"
 
 
-def test_get_edge_id_from_edge(four_by_five_graph_nx, four_by_five_graph_rx):
+def test_get_edge_id_from_edge(four_by_five_graph_nx: Graph, four_by_five_graph_rx: Graph):
     # Test that get_edge_id_from_edge works for both NX and RX based Graph objects
 
     # NX edges and edge_ids are the same, so this first test is trivial
@@ -167,7 +171,7 @@ def test_add_edge():
     assert True
 
 
-def test_subgraph(four_by_five_graph_rx):
+def test_subgraph(four_by_five_graph_rx: Graph):
     """
     Subgraphs are one of the most dangerous areas of the code.
     In NX, subgraphs preserve node_ids - that is, the node_id
@@ -229,7 +233,9 @@ def test_subgraph(four_by_five_graph_rx):
         )
 
 
-def test_rx_neighbors_are_sorted_and_stable_across_subgraph_rebuilds(four_by_five_graph_rx):
+def test_rx_neighbors_are_sorted_and_stable_across_subgraph_rebuilds(
+    four_by_five_graph_rx: Graph,
+):
     """Regression test for a bug I encountered when updating ReCom class for 1.0.0 release.
 
     RX collects neighbors into a randomly seeded HashSet, so the raw rustworkx order varies call to
@@ -239,26 +245,30 @@ def test_rx_neighbors_are_sorted_and_stable_across_subgraph_rebuilds(four_by_fiv
     """
     parent = four_by_five_graph_rx
     for node_id in parent.node_indices:
-        assert list(parent.neighbors(node_id)) == sorted(parent.neighbors(node_id))
+        neighbors = cast("Sequence[int]", parent.neighbors(node_id))
+        assert list(neighbors) == sorted(neighbors)
 
     subgraph_node_ids = [2, 4, 5, 8, 11, 13]
     first = None
     for _ in range(20):
         subgraph = parent.subgraph(subgraph_node_ids)
-        orders = [tuple(subgraph.neighbors(n)) for n in sorted(subgraph.node_indices)]
+        subgraph_nodes = cast("set[int]", subgraph.node_indices)
+        orders = [tuple(subgraph.neighbors(n)) for n in sorted(subgraph_nodes)]
         if first is None:
             first = orders
         assert orders == first, "neighbor order changed between identical subgraph rebuilds"
 
 
-def test_num_connected_components(four_by_five_graph_nx, four_by_five_graph_rx):
+def test_num_connected_components(four_by_five_graph_nx: Graph, four_by_five_graph_rx: Graph):
     num_components_nx = four_by_five_graph_nx.num_connected_components()
     num_components_rx = four_by_five_graph_rx.num_connected_components()
     assert num_components_nx == 2, f"num_components: expected 2 but got {num_components_nx}"
     assert num_components_rx == 2, f"num_components: expected 2 but got {num_components_rx}"
 
 
-def test_subgraphs_for_connected_components(four_by_five_graph_nx, four_by_five_graph_rx):
+def test_subgraphs_for_connected_components(
+    four_by_five_graph_nx: Graph, four_by_five_graph_rx: Graph
+):
     subgraphs_nx = four_by_five_graph_nx.subgraphs_for_connected_components()
     subgraphs_rx = four_by_five_graph_rx.subgraphs_for_connected_components()
 
@@ -301,7 +311,7 @@ def test_add_data():
 ########################################################
 
 
-def graph_has_cycle(set_of_edges):
+def graph_has_cycle(set_of_edges: Iterable[tuple[Hashable, Hashable]]):
     #
     # Given a set of edges that define a graph, determine
     # if the graph has cycles.
@@ -327,22 +337,24 @@ def graph_has_cycle(set_of_edges):
     # is symetrical - edges go both ways...
     #
 
-    def add_edge(adj_matrix, s, t):
+    def add_edge(adj_matrix: list[list[int]], s: int, t: int):
         # Add an edge to an adjacency matrix
         adj_matrix[s][t] = 1
         adj_matrix[t][s] = 1  # Since it's an undirected graph
 
-    def delete_edge(adj_matrix, s, t):
+    def delete_edge(adj_matrix: list[list[int]], s: int, t: int):
         # Delete an edge from an adjacency matrix
         adj_matrix[s][t] = 0
         adj_matrix[t][s] = 0  # Since it's an undirected graph
 
-    def create_empty_adjacency_matrix(num_nodes):
+    def create_empty_adjacency_matrix(num_nodes: int):
         # create 2D array, num_nodes x num_nodes
         adj_matrix = [[0] * num_nodes for _ in range(num_nodes)]
         return adj_matrix
 
-    def create_adjacency_matrix_from_set_of_edges(set_of_edges):
+    def create_adjacency_matrix_from_set_of_edges(
+        set_of_edges: Iterable[tuple[Hashable, Hashable]],
+    ):
         # determine num_nodes
         #
         set_of_nodes = set()
@@ -376,7 +388,9 @@ def graph_has_cycle(set_of_edges):
 
         return adj_matrix
 
-    def inner_has_cycle(adj_matrix, visited, s, visit_list):
+    def inner_has_cycle(
+        adj_matrix: list[list[int]], visited: list[bool], s: int, visit_list: list[int]
+    ):
         # This routine does a depth first search looking
         # for cycles - if it encounters a node that it has
         # already seen then it returns True.
@@ -439,7 +453,7 @@ def test_graph_has_cycle():
     assert the_graph_has_a_cycle
 
 
-def test_generic_bfs_edges(four_by_five_graph_nx, four_by_five_graph_rx):
+def test_generic_bfs_edges(four_by_five_graph_nx: Graph, four_by_five_graph_rx: Graph):
     #
     # The routine, _generic_bfs_edges() returns an ordered list of
     # edges from a breadth-first traversal of a graph, starting

--- a/tests/test_laplacian.py
+++ b/tests/test_laplacian.py
@@ -1,9 +1,12 @@
 import random
+from typing import Any, cast
 
 import networkx as nx
 import numpy as np
+import numpy.typing as npt
 import pytest
 import rustworkx as rx
+import scipy.sparse
 
 from gerrychain.graph import Graph
 
@@ -23,13 +26,19 @@ to convert the NX version's result to have floating point values.
 """
 
 
-def _dense(matrix):
+def _dense(matrix: "scipy.sparse.sparray | scipy.sparse.spmatrix | npt.NDArray[Any]"):
     """Return a dense float ndarray for a scipy sparse array/matrix (or ndarray)."""
-    dense = matrix.todense() if hasattr(matrix, "todense") else matrix
+    # cast: pyright does not narrow the union on the hasattr check
+    dense = cast(scipy.sparse.csr_array, matrix).todense() if hasattr(matrix, "todense") else matrix
     return np.asarray(dense, dtype=float)
 
 
-def are_sparse_matrices_equal(sparse_matrix1, sparse_matrix2, rtol=1e-05, atol=1e-08):
+def are_sparse_matrices_equal(
+    sparse_matrix1: scipy.sparse.csr_array,
+    sparse_matrix2: scipy.sparse.csr_array,
+    rtol: float = 1e-05,
+    atol: float = 1e-08,
+):
     """
     Checks if two scipy.sparse.csr_matrix objects are equal, considering
     potential floating-point inaccuracies in the data.
@@ -71,14 +80,16 @@ def are_sparse_matrices_equal(sparse_matrix1, sparse_matrix2, rtol=1e-05, atol=1
 
 
 @pytest.fixture
-def nx_graph():
-    this_nx_graph = nx.Graph([(0, 1), (0, 2), (1, 2), (2, 3)])
+def nx_graph() -> "nx.Graph[int, dict[str, Any], dict[str, Any]]":
+    this_nx_graph: "nx.Graph[int, dict[str, Any], dict[str, Any]]" = nx.Graph(
+        [(0, 1), (0, 2), (1, 2), (2, 3)]
+    )
     return this_nx_graph
 
 
 @pytest.fixture
-def rx_graph():
-    this_rx_graph = rx.PyGraph()
+def rx_graph() -> "rx.PyGraph[dict[str, Any], dict[str, Any]]":
+    this_rx_graph: "rx.PyGraph[dict[str, Any], dict[str, Any]]" = rx.PyGraph()
     # argument to add_node_from() is the data to be associated with each node.
     # To be compatible with GerryChain, nodes need to have data values that are dictionaries
     # so we just have an empty dict for each node's data
@@ -87,7 +98,10 @@ def rx_graph():
     return this_rx_graph
 
 
-def test_nx_rx_laplacian_matrix_equality(nx_graph, rx_graph):
+def test_nx_rx_laplacian_matrix_equality(
+    nx_graph: "nx.Graph[int, dict[str, Any], dict[str, Any]]",
+    rx_graph: "rx.PyGraph[dict[str, Any], dict[str, Any]]",
+):
     # Create Graph objects from the NX and RX graphs
     gc_nx_graph = Graph.from_networkx(nx_graph)
     gc_rx_graph = Graph.from_rustworkx(rx_graph)
@@ -106,7 +120,7 @@ def test_nx_rx_laplacian_matrix_equality(nx_graph, rx_graph):
     assert matrices_are_equal
 
 
-def _random_connected_graph_edges(num_nodes: int, rng: int) -> list[tuple[int, int]]:
+def _random_connected_graph_edges(num_nodes: int, rng: random.Random) -> list[tuple[int, int]]:
     """Return a sorted edge list for a random connected graph on nodes ``0..num_nodes-1``.
 
     Builds a random spanning tree (which guarantees connectivity) by attaching each new node
@@ -158,7 +172,7 @@ def test_rx_normalized_laplacian_matches_networkx_reference(num_nodes: int, seed
     assert np.allclose(rx_result, rx_result.T)  # undirected => symmetric
 
 
-def test_normalized_laplacian_is_symmetric(rx_graph):
+def test_normalized_laplacian_is_symmetric(rx_graph: "rx.PyGraph[dict[str, Any], dict[str, Any]]"):
     gc_rx_graph = Graph.from_rustworkx(rx_graph)
     rx_result = _dense(gc_rx_graph.normalized_laplacian_matrix())
 

--- a/tests/test_make_graph.py
+++ b/tests/test_make_graph.py
@@ -1,5 +1,8 @@
+import os
 import pathlib
+from collections.abc import Iterator
 from tempfile import TemporaryDirectory
+from typing import Any, cast
 from unittest.mock import patch
 
 import geopandas as gp
@@ -19,7 +22,7 @@ from gerrychain.graph.graph import GraphValidationError
 
 
 @pytest.fixture
-def geodataframe():
+def geodataframe() -> gp.GeoDataFrame:
     a = Polygon([(0, 0), (0, 1), (1, 1), (1, 0)])
     b = Polygon([(0, 1), (0, 2), (1, 2), (1, 1)])
     c = Polygon([(1, 0), (1, 1), (2, 1), (2, 0)])
@@ -30,14 +33,14 @@ def geodataframe():
 
 
 @pytest.fixture
-def gdf_with_data(geodataframe):
+def gdf_with_data(geodataframe: gp.GeoDataFrame) -> gp.GeoDataFrame:
     geodataframe["data"] = list(range(len(geodataframe)))
     geodataframe["data2"] = list(range(len(geodataframe)))
     return geodataframe
 
 
 @pytest.fixture
-def geodataframe_with_boundary():
+def geodataframe_with_boundary() -> gp.GeoDataFrame:
     """
     abe
     ade
@@ -54,16 +57,17 @@ def geodataframe_with_boundary():
 
 
 @pytest.fixture
-def shapefile(gdf_with_data):
+def shapefile(gdf_with_data: gp.GeoDataFrame) -> Iterator[str]:
     with TemporaryDirectory() as d:
         filepath = pathlib.Path(d) / "temp.shp"
         filename = str(filepath.absolute())
-        gdf_with_data.to_file(filename)
+        # cast: geopandas annotates to_file as PathLike | IO, but str works at runtime
+        gdf_with_data.to_file(cast("os.PathLike[str]", filename))
         yield filename
 
 
 @pytest.fixture
-def target_file():
+def target_file() -> Iterator[str]:
     with TemporaryDirectory() as d:
         filepath = pathlib.Path(d) / "temp.shp"
         filename = str(filepath.absolute())
@@ -110,26 +114,26 @@ def test_join_can_handle_right_index():
     assert graph.node_data("03")["16SenDVote"] == 50
 
 
-def test_make_graph_from_dataframe_creates_graph(geodataframe):
+def test_make_graph_from_dataframe_creates_graph(geodataframe: gp.GeoDataFrame):
     graph = Graph.from_geodataframe(geodataframe)
     assert isinstance(graph, Graph)
 
 
-def test_make_graph_from_dataframe_preserves_df_index(geodataframe):
-    df = geodataframe.set_index("ID")
+def test_make_graph_from_dataframe_preserves_df_index(geodataframe: gp.GeoDataFrame):
+    df = cast(gp.GeoDataFrame, geodataframe.set_index("ID"))
     graph = Graph.from_geodataframe(df)
     assert set(graph.nodes) == {"a", "b", "c", "d"}
 
 
-def test_make_graph_from_dataframe_gives_correct_graph(geodataframe):
-    df = geodataframe.set_index("ID")
+def test_make_graph_from_dataframe_gives_correct_graph(geodataframe: gp.GeoDataFrame):
+    df = cast(gp.GeoDataFrame, geodataframe.set_index("ID"))
     graph = Graph.from_geodataframe(df)
 
     assert edge_set_equal(set(graph.edges), {("a", "b"), ("a", "c"), ("b", "d"), ("c", "d")})
 
 
-def test_make_graph_works_with_queen_adjacency(geodataframe):
-    df = geodataframe.set_index("ID")
+def test_make_graph_works_with_queen_adjacency(geodataframe: gp.GeoDataFrame):
+    df = cast(gp.GeoDataFrame, geodataframe.set_index("ID"))
     graph = Graph.from_geodataframe(df, adjacency="queen")
 
     assert edge_set_equal(
@@ -138,8 +142,8 @@ def test_make_graph_works_with_queen_adjacency(geodataframe):
     )
 
 
-def test_can_pass_queen_or_rook_strings_to_control_adjacency(geodataframe):
-    df = geodataframe.set_index("ID")
+def test_can_pass_queen_or_rook_strings_to_control_adjacency(geodataframe: gp.GeoDataFrame):
+    df = cast(gp.GeoDataFrame, geodataframe.set_index("ID"))
     graph = Graph.from_geodataframe(df, adjacency="queen")
 
     assert edge_set_equal(
@@ -148,8 +152,8 @@ def test_can_pass_queen_or_rook_strings_to_control_adjacency(geodataframe):
     )
 
 
-def test_can_insist_on_not_reprojecting(geodataframe):
-    df = geodataframe.set_index("ID")
+def test_can_insist_on_not_reprojecting(geodataframe: gp.GeoDataFrame):
+    df = cast(gp.GeoDataFrame, geodataframe.set_index("ID"))
     graph = Graph.from_geodataframe(df, reproject=False)
 
     for node in ("a", "b", "c", "d"):
@@ -159,8 +163,8 @@ def test_can_insist_on_not_reprojecting(geodataframe):
         assert graph.edge_data(edge)["shared_perim"] == 1
 
 
-def test_does_not_reproject_by_default(geodataframe):
-    df = geodataframe.set_index("ID")
+def test_does_not_reproject_by_default(geodataframe: gp.GeoDataFrame):
+    df = cast(gp.GeoDataFrame, geodataframe.set_index("ID"))
     graph = Graph.from_geodataframe(df)
 
     for node in ("a", "b", "c", "d"):
@@ -170,10 +174,10 @@ def test_does_not_reproject_by_default(geodataframe):
         assert graph.edge_data(edge)["shared_perim"] == 1.0
 
 
-def test_reproject(geodataframe):
+def test_reproject(geodataframe: gp.GeoDataFrame):
     # I don't know what the areas and perimeters are in UTM for these made-up polygons,
     # but I'm pretty sure they're not 1.
-    df = geodataframe.set_index("ID")
+    df = cast(gp.GeoDataFrame, geodataframe.set_index("ID"))
     graph = Graph.from_geodataframe(df, reproject=True)
 
     for node in ("a", "b", "c", "d"):
@@ -183,8 +187,8 @@ def test_reproject(geodataframe):
         assert graph.edge_data(edge)["shared_perim"] != 1
 
 
-def test_identifies_boundary_nodes(geodataframe_with_boundary):
-    df = geodataframe_with_boundary.set_index("ID")
+def test_identifies_boundary_nodes(geodataframe_with_boundary: gp.GeoDataFrame):
+    df = cast(gp.GeoDataFrame, geodataframe_with_boundary.set_index("ID"))
     graph = Graph.from_geodataframe(df)
 
     for node in ("a", "b", "c", "e"):
@@ -192,8 +196,8 @@ def test_identifies_boundary_nodes(geodataframe_with_boundary):
     assert not graph.node_data("d")["boundary_node"]
 
 
-def test_computes_boundary_perims(geodataframe_with_boundary):
-    df = geodataframe_with_boundary.set_index("ID")
+def test_computes_boundary_perims(geodataframe_with_boundary: gp.GeoDataFrame):
+    df = cast(gp.GeoDataFrame, geodataframe_with_boundary.set_index("ID"))
     graph = Graph.from_geodataframe(df, reproject=False)
 
     expected = {"a": 5, "e": 5, "b": 1, "c": 1}
@@ -202,7 +206,7 @@ def test_computes_boundary_perims(geodataframe_with_boundary):
         assert graph.node_data(node)["boundary_perim"] == value
 
 
-def edge_set_equal(set1, set2):
+def edge_set_equal(set1: set[tuple[Any, Any]], set2: set[tuple[Any, Any]]):
     """
     Returns true if the two sets have the same edges.
 
@@ -215,7 +219,7 @@ def edge_set_equal(set1, set2):
     return canonical_set1 == canonical_set2
 
 
-def test_from_file_adds_all_data_by_default(shapefile):
+def test_from_file_adds_all_data_by_default(shapefile: str):
     graph = Graph.from_file(shapefile)
 
     nx_graph = graph.get_nx_graph()
@@ -224,7 +228,7 @@ def test_from_file_adds_all_data_by_default(shapefile):
     assert all("data2" in node_data for node_data in nx_graph.nodes.values())
 
 
-def test_from_file_and_then_to_json_does_not_error(shapefile, target_file):
+def test_from_file_and_then_to_json_does_not_error(shapefile: str, target_file: str):
     graph = Graph.from_file(shapefile)
 
     nx_graph = graph.get_nx_graph()
@@ -235,7 +239,7 @@ def test_from_file_and_then_to_json_does_not_error(shapefile, target_file):
     graph.to_json(target_file)
 
 
-def test_from_file_and_then_to_json_with_geometries(shapefile, target_file):
+def test_from_file_and_then_to_json_with_geometries(shapefile: str, target_file: str):
     graph = Graph.from_file(shapefile)
 
     nx_graph = graph.get_nx_graph()
@@ -256,27 +260,27 @@ def test_graph_warns_for_islands():
         graph.warn_for_islands()
 
 
-def test_graph_raises_if_crs_is_missing_when_reprojecting(geodataframe):
+def test_graph_raises_if_crs_is_missing_when_reprojecting(geodataframe: gp.GeoDataFrame):
     geodataframe.crs = None
 
     with pytest.raises(ValueError):
         Graph.from_geodataframe(geodataframe, reproject=True)
 
 
-def test_raises_geometry_error_if_invalid_geometry(shapefile):
+def test_raises_geometry_error_if_invalid_geometry(shapefile: str):
     with patch("gerrychain.graph.geo.explain_validity") as explain:
         explain.return_value = "Invalid geometry"
         with pytest.raises(GeometryError):
             Graph.from_file(shapefile, ignore_errors=False)
 
 
-def test_can_ignore_errors_while_making_graph(shapefile):
+def test_can_ignore_errors_while_making_graph(shapefile: str):
     with patch("gerrychain.graph.geo.explain_validity") as explain:
         explain.return_value = "Invalid geometry"
         assert Graph.from_file(shapefile, ignore_errors=True)
 
 
-def test_data_and_geometry(gdf_with_data):
+def test_data_and_geometry(gdf_with_data: gp.GeoDataFrame):
     df = gdf_with_data
     graph = Graph.from_geodataframe(df, cols_to_add=["data", "data2"])
     assert graph.geometry is df.geometry
@@ -286,12 +290,12 @@ def test_data_and_geometry(gdf_with_data):
     assert list(graph.data.columns) == ["data", "data2"]
 
 
-def test_make_graph_from_dataframe_has_crs(gdf_with_data):
+def test_make_graph_from_dataframe_has_crs(gdf_with_data: gp.GeoDataFrame):
     graph = Graph.from_geodataframe(gdf_with_data)
     assert CRS.from_json(graph.graph["crs"]).equals(gdf_with_data.crs)
 
 
-def test_make_graph_from_shapefile_has_crs(shapefile):
+def test_make_graph_from_shapefile_has_crs(shapefile: str):
     graph = Graph.from_file(shapefile)
     df = gp.read_file(shapefile)
     assert CRS.from_json(graph.graph["crs"]).equals(df.crs)
@@ -313,7 +317,9 @@ def test_from_rustworkx_rejects_directed_graph():
         Graph.from_rustworkx(rx_graph)
 
 
-def test_graph_is_directed_returns_false_for_undirected_backends(four_by_five_grid_nx):
+def test_graph_is_directed_returns_false_for_undirected_backends(
+    four_by_five_grid_nx: "nx.Graph[int, dict[str, Any], dict[str, Any]]",
+):
     nx_graph = Graph.from_networkx(four_by_five_grid_nx)
     rx_graph = Graph.from_rustworkx(
         rx.networkx_converter(four_by_five_grid_nx, keep_attributes=True)

--- a/tests/test_metagraph.py
+++ b/tests/test_metagraph.py
@@ -1,6 +1,6 @@
 import pytest
 
-from gerrychain import Partition, updaters
+from gerrychain import Graph, Partition, updaters
 from gerrychain.metagraph import (
     all_cut_edge_flips,
     all_valid_flips,
@@ -9,12 +9,12 @@ from gerrychain.metagraph import (
 
 
 @pytest.fixture
-def partition(graph):
+def partition(graph: Graph) -> Partition:
     assignment = dict(zip(range(9), [1, 1, 1, 1, 1, 1, 2, 2, 2]))
     return Partition(graph, assignment, {"cut_edges": updaters.cut_edges})
 
 
-def test_all_cut_edge_flips(partition):
+def test_all_cut_edge_flips(partition: Partition):
     # frm: TODO: Testing:  Maybe change all_cut_edge_flips to return a dict
     #
     # At present, it returns an iterator, which makes the code below
@@ -41,22 +41,23 @@ def test_all_cut_edge_flips(partition):
 
 
 class TestAllValidStatesOneFlipAway:
-    def test_accepts_callable_for_constraints(self, partition):
+    def test_accepts_callable_for_constraints(self, partition: Partition):
         constraints = lambda p: True
         result = all_valid_states_one_flip_away(partition, constraints)
 
         assert all(isinstance(state, Partition) for state in result)
 
-    def test_accepts_list_of_constraints(self, partition):
+    def test_accepts_list_of_constraints(self, partition: Partition):
         constraints = [lambda p: True]
         result = all_valid_states_one_flip_away(partition, constraints)
 
         assert all(isinstance(state, Partition) for state in result)
 
 
-def test_all_valid_flips(partition):
+def test_all_valid_flips(partition: Partition):
     # frm: TODO: Testing:  NX vs. RX node_id issues...
-    def disallow_six_to_one(partition):
+    def disallow_six_to_one(partition: Partition) -> bool:
+        assert partition.flips is not None
         for node, part in partition.flips.items():
             if node == 6 and part == 1:
                 return False

--- a/tests/test_proposals.py
+++ b/tests/test_proposals.py
@@ -1,14 +1,18 @@
 import random
+from collections.abc import Callable
 from functools import partial
+from typing import Any, cast
 
 import pytest
 
-from gerrychain import Partition, proposals, updaters
+from gerrychain import Graph, Partition, proposals, updaters
+from gerrychain.proposals import ProposalFn
+from gerrychain.proposals.tree_proposals import PairSelection
 from gerrychain.tree import bipartition_tree, uniform_spanning_tree
 
 
 @pytest.fixture
-def partition(graph):
+def partition(graph: Graph) -> Partition:
     return Partition(
         graph,
         {0: 1, 1: 1, 2: 1, 3: 2, 4: 2, 5: 2, 6: 3, 7: 3, 8: 3},
@@ -38,12 +42,12 @@ def partition(graph):
         proposals.build_spectral_recom_proposal_fn(),
     ],
 )
-def test_proposal_returns_a_partition(proposal, partition):
+def test_proposal_returns_a_partition(proposal: ProposalFn, partition: Partition):
     proposed = proposal(partition, rng=random.Random(0))
     assert isinstance(proposed, partition.__class__)
 
 
-def test_proposals_support_mixed_type_part_labels(graph):
+def test_proposals_support_mixed_type_part_labels(graph: Graph):
     for node in graph:
         graph.node_data(node)["population"] = 1
     partition = Partition(
@@ -68,7 +72,7 @@ def test_proposals_support_mixed_type_part_labels(graph):
 
 
 @pytest.fixture
-def populated_partition(graph):
+def populated_partition(graph: Graph) -> Partition:
     for node in graph:
         graph.node_data(node)["population"] = 1
     return Partition(
@@ -103,7 +107,9 @@ def test_recom_letter_aliases_match_named_variants():
         proposals.ReCom.district_pairs_ust,
     ],
 )
-def test_recom_variants_return_balanced_partitions(build_proposal, populated_partition):
+def test_recom_variants_return_balanced_partitions(
+    build_proposal: Callable[..., ProposalFn], populated_partition: Partition
+):
     proposal = build_proposal(pop_col="population", pop_target=3, epsilon=0)
     proposed = proposal(populated_partition, rng=random.Random(0))
     assert isinstance(proposed, Partition)
@@ -119,7 +125,9 @@ def test_recom_variants_return_balanced_partitions(build_proposal, populated_par
         proposals.ReCom.district_pairs_ust,
     ],
 )
-def test_recom_variants_run_with_pair_reselection(build_proposal, populated_partition):
+def test_recom_variants_run_with_pair_reselection(
+    build_proposal: Callable[..., ProposalFn], populated_partition: Partition
+):
     proposal = build_proposal(
         pop_col="population", pop_target=3, epsilon=0, allow_pair_reselection=True
     )
@@ -153,7 +161,11 @@ def test_recom_variants_run_with_pair_reselection(build_proposal, populated_part
         ),
     ],
 )
-def test_recom_variants_match_direct_recom_calls(build_proposal, recom_kwargs, populated_partition):
+def test_recom_variants_match_direct_recom_calls(
+    build_proposal: Callable[..., ProposalFn],
+    recom_kwargs: dict[str, Any],
+    populated_partition: Partition,
+):
     """Pin each builder's wiring: same seed, same trajectory as recom with the bound options.
 
     A builder that binds the wrong pair_selection or forgets the uniform spanning tree consumes
@@ -172,7 +184,7 @@ def test_recom_variants_match_direct_recom_calls(build_proposal, recom_kwargs, p
     assert proposed.assignment.mapping == expected.assignment.mapping
 
 
-def test_reversible_variant_matches_direct_reversible_recom_call(populated_partition):
+def test_reversible_variant_matches_direct_reversible_recom_call(populated_partition: Partition):
     proposal = proposals.ReCom.reversible(
         pop_col="population", pop_target=3, epsilon=0, max_balanced_edge_cuts=100
     )
@@ -188,7 +200,7 @@ def test_reversible_variant_matches_direct_reversible_recom_call(populated_parti
     assert proposed.assignment.mapping == expected.assignment.mapping
 
 
-def test_recom_reversible_variant_runs(populated_partition):
+def test_recom_reversible_variant_runs(populated_partition: Partition):
     proposal = proposals.ReCom.reversible(
         pop_col="population", pop_target=3, epsilon=0, max_balanced_edge_cuts=100
     )
@@ -196,19 +208,19 @@ def test_recom_reversible_variant_runs(populated_partition):
     assert isinstance(proposed, Partition)
 
 
-def test_recom_rejects_unknown_pair_selection(populated_partition):
+def test_recom_rejects_unknown_pair_selection(populated_partition: Partition):
     with pytest.raises(ValueError, match="pair_selection"):
         proposals.recom(
             populated_partition,
             pop_col="population",
             pop_target=3,
             epsilon=0,
-            pair_selection="nope",
+            pair_selection=cast(PairSelection, "nope"),
             rng=0,
         )
 
 
-def test_cut_edges_pair_selection_weights_by_shared_boundary(graph):
+def test_cut_edges_pair_selection_weights_by_shared_boundary(graph: Graph):
     """District pairs sharing more cut edges should be tried first more often.
 
     On the 3x3 grid with districts a={0}, b={1,2}, c={3..8}, the pair (b,c) shares two cut
@@ -224,7 +236,7 @@ def test_cut_edges_pair_selection_weights_by_shared_boundary(graph):
         {"cut_edges": updaters.cut_edges},
     )
 
-    def count_bc_first(pair_selection):
+    def count_bc_first(pair_selection: PairSelection) -> int:
         count = 0
         for seed in range(600):
             pairs = list(_candidate_district_pairs(partition, pair_selection, random.Random(seed)))

--- a/tests/test_region_aware.py
+++ b/tests/test_region_aware.py
@@ -1,5 +1,6 @@
 import random
 import warnings
+from collections.abc import Iterable
 from concurrent.futures import ProcessPoolExecutor
 from functools import partial
 
@@ -16,11 +17,19 @@ from gerrychain import (
     tree,
 )
 from gerrychain import updaters as gc_updaters
+from gerrychain.graph.graph import FrozenGraph
 from gerrychain.proposals import build_recom_proposal_fn
 from gerrychain.tree import BipartitionWarning
 
 
-def run_chain_single(seed, category, steps, surcharge, max_attempts=100000, reselect=False):
+def run_chain_single(
+    seed: int,
+    category: str,
+    steps: int,
+    surcharge: float,
+    max_attempts: int = 100000,
+    reselect: bool = False,
+) -> int:
     from functools import partial
 
     graph = Graph.from_json("tests/graphs_for_test/8x8_with_muni.json")
@@ -137,7 +146,9 @@ def test_region_aware_county():
     assert (float(tot_splits) / (n_samples * n_regions)) < 0.10
 
 
-def straddled_regions(partition, region_attr, all_region_names):
+def straddled_regions(
+    partition: Partition, region_attr: str, all_region_names: Iterable[str]
+) -> int:
     """Returns the total number of district that straddle two regions in the partition."""
     split = {name: 0 for name in all_region_names}
 
@@ -150,7 +161,12 @@ def straddled_regions(partition, region_attr, all_region_names):
     return sum(1 for value in split.values() if value > 0)
 
 
-def run_chain_dual(seed, steps, surcharges={"muni": 0.5, "county": 0.5}, warn_attempts=1000):
+def run_chain_dual(
+    seed: int,
+    steps: int,
+    surcharges: dict[str, float] = {"muni": 0.5, "county": 0.5},
+    warn_attempts: int = 1000,
+) -> tuple[int, int]:
     from functools import partial
 
     graph = Graph.from_json("tests/graphs_for_test/8x8_with_muni.json")
@@ -244,8 +260,12 @@ def test_spanning_tree_fn_kwargs_forwarded_to_spanning_tree_fn():
     captured = []
 
     def spy_spanning_tree_fn(
-        graph, region_surcharge=None, treat_unassigned_as_single_region=False, *, rng
-    ):
+        graph: Graph | FrozenGraph,
+        region_surcharge: dict[str, float] | None = None,
+        treat_unassigned_as_single_region: bool = False,
+        *,
+        rng: random.Random,
+    ) -> Graph:
         captured.append(treat_unassigned_as_single_region)
         return tree.random_spanning_tree(
             graph,

--- a/tests/test_reproducibility.py
+++ b/tests/test_reproducibility.py
@@ -12,8 +12,12 @@ Two guarantees are pinned here:
 import os
 import subprocess
 import sys
+from collections.abc import Hashable, Sequence
+from typing import Any
 
 import pytest
+
+from gerrychain import Graph
 
 # Run in a subprocess so each execution gets its own string-hash seed. String part labels on
 # purpose: they exercise the sorted() set-to-sequence conversions in recom and the two
@@ -147,7 +151,7 @@ print(hashlib.sha256(json.dumps(assignment).encode()).hexdigest())
 """
 
 
-def run_with_hashseed(hashseed, script=HASHSEED_SCRIPT):
+def run_with_hashseed(hashseed: str | None, script: str = HASHSEED_SCRIPT) -> str:
     env = dict(os.environ)
     if hashseed is None:
         env.pop("PYTHONHASHSEED", None)
@@ -186,7 +190,9 @@ def test_random_assignment_method_receives_original_graph_and_node_labels():
     graph = Graph.from_networkx(nx_graph)
     received = {}
 
-    def partition_fn(*, graph, parts, **kwargs):
+    def partition_fn(
+        *, graph: Graph, parts: Sequence[Hashable], **kwargs: Any
+    ) -> dict[Hashable, Hashable]:
         received["graph"] = graph
         received["nodes"] = graph.nodes
         part_labels = list(parts)
@@ -204,7 +210,7 @@ def test_random_assignment_method_receives_original_graph_and_node_labels():
     assert received == {"graph": graph, "nodes": ["node-c", "node-a", "node-b", "node-d"]}
 
 
-def test_repeatable(three_by_three_grid):
+def test_repeatable(three_by_three_grid: Graph):
     from gerrychain import (
         MarkovChain,
         Partition,
@@ -255,7 +261,7 @@ def test_repeatable(three_by_three_grid):
     assert flips == expected_flips
 
 
-def test_ust_recom_is_repeatable_in_process(three_by_three_grid):
+def test_ust_recom_is_repeatable_in_process(three_by_three_grid: Graph):
     import random
 
     from gerrychain import Partition, proposals, updaters

--- a/tests/test_rng.py
+++ b/tests/test_rng.py
@@ -1,12 +1,14 @@
 """Tests for explicitly owned GerryChain RNGs."""
 
 import random
+from collections.abc import Hashable, Iterable
 from functools import partial
+from typing import cast
 
 import numpy as np
 import pytest
 
-from gerrychain import MarkovChain, Partition
+from gerrychain import Graph, MarkovChain, Partition
 from gerrychain._rng import make_rng
 from gerrychain.accept import always_accept
 from gerrychain.constraints import contiguous
@@ -19,7 +21,7 @@ from gerrychain.updaters import Tally, cut_edges
 PART_LABELS = ["a", "b", "c", "d"]
 
 
-def initial_partition(graph):
+def initial_partition(graph: Graph) -> Partition:
     # Each row of the 4x5 grid is one district: connected, population 50 each.
     assignment = {node: PART_LABELS[node // 5] for node in range(20)}
     return Partition(
@@ -29,18 +31,20 @@ def initial_partition(graph):
     )
 
 
-def make_recom_chain(graph, rng=None, total_steps=25):
+def make_recom_chain(
+    graph: Graph, rng: random.Random | int | None = None, total_steps: int = 25
+) -> MarkovChain:
     proposal = partial(recom, pop_col="population", pop_target=50, epsilon=0.0)
     return MarkovChain(
         proposal, [contiguous], always_accept, initial_partition(graph), total_steps, rng=rng
     )
 
 
-def trajectory(chain):
+def trajectory(chain: Iterable[Partition]) -> list[dict[Hashable, Hashable]]:
     return [dict(part.assignment.mapping) for part in chain]
 
 
-def make_optimizer(graph, rng=None):
+def make_optimizer(graph: Graph, rng: random.Random | int | None = None) -> SingleMetricOptimizer:
     proposal = partial(recom, pop_col="population", pop_target=50, epsilon=0.0)
     return SingleMetricOptimizer(
         proposal_fn=proposal,
@@ -52,30 +56,30 @@ def make_optimizer(graph, rng=None):
     )
 
 
-def run_bursts(optimizer):
+def run_bursts(optimizer: SingleMetricOptimizer) -> list[dict[Hashable, Hashable]]:
     return [
         dict(part.assignment.mapping)
         for part in optimizer.short_bursts(burst_length=5, num_bursts=4)
     ]
 
 
-def test_same_int_seed_reproduces(four_by_five_grid_for_opt):
+def test_same_int_seed_reproduces(four_by_five_grid_for_opt: Graph):
     first = trajectory(make_recom_chain(four_by_five_grid_for_opt, rng=5))
     second = trajectory(make_recom_chain(four_by_five_grid_for_opt, rng=5))
     assert first == second
 
 
-def test_different_seeds_differ(four_by_five_grid_for_opt):
+def test_different_seeds_differ(four_by_five_grid_for_opt: Graph):
     first = trajectory(make_recom_chain(four_by_five_grid_for_opt, rng=5))
     second = trajectory(make_recom_chain(four_by_five_grid_for_opt, rng=6))
     assert first != second
 
 
-def test_random_instance_is_passed_to_proposal(four_by_five_grid_for_opt):
+def test_random_instance_is_passed_to_proposal(four_by_five_grid_for_opt: Graph):
     instance = random.Random(3)
-    seen = []
+    seen: list[random.Random] = []
 
-    def proposal(partition, *, rng):
+    def proposal(partition: Partition, *, rng: random.Random) -> Partition:
         seen.append(rng)
         return partition
 
@@ -92,10 +96,10 @@ def test_random_instance_is_passed_to_proposal(four_by_five_grid_for_opt):
     assert seen == [instance]
 
 
-def test_proposal_error_propagates(four_by_five_grid_for_opt):
+def test_proposal_error_propagates(four_by_five_grid_for_opt: Graph):
     instance = random.Random(3)
 
-    def proposal(_partition, *, rng):
+    def proposal(_partition: Partition, *, rng: random.Random) -> Partition:
         assert rng is instance
         raise RuntimeError("proposal failed")
 
@@ -116,7 +120,7 @@ def test_proposal_error_propagates(four_by_five_grid_for_opt):
 
 def test_make_rng_rejects_unsupported_types():
     with pytest.raises(TypeError):
-        make_rng("2018")
+        make_rng(cast(int, "2018"))
 
     with pytest.raises(TypeError):
         make_rng(True)
@@ -127,20 +131,20 @@ def test_make_rng_accepts_numpy_integer_seed():
     assert numpy_seeded.random() == random.Random(5).random()
 
 
-def test_chain_without_rng_owns_an_independent_instance(four_by_five_grid_for_opt):
+def test_chain_without_rng_owns_an_independent_instance(four_by_five_grid_for_opt: Graph):
     first = make_recom_chain(four_by_five_grid_for_opt)
     second = make_recom_chain(four_by_five_grid_for_opt)
     assert first.rng is not second.rng
 
 
-def test_later_construction_does_not_reseed_earlier_chain(four_by_five_grid_for_opt):
+def test_later_construction_does_not_reseed_earlier_chain(four_by_five_grid_for_opt: Graph):
     baseline = trajectory(make_recom_chain(four_by_five_grid_for_opt, rng=1))
     chain_a = make_recom_chain(four_by_five_grid_for_opt, rng=1)
     make_recom_chain(four_by_five_grid_for_opt, rng=2)  # constructed, never run
     assert trajectory(chain_a) == baseline
 
 
-def test_interleaved_chains_keep_separate_streams(four_by_five_grid_for_opt):
+def test_interleaved_chains_keep_separate_streams(four_by_five_grid_for_opt: Graph):
     baseline_a = trajectory(make_recom_chain(four_by_five_grid_for_opt, rng=1, total_steps=15))
     baseline_b = trajectory(make_recom_chain(four_by_five_grid_for_opt, rng=2, total_steps=15))
     chain_a = iter(make_recom_chain(four_by_five_grid_for_opt, rng=1, total_steps=15))
@@ -156,17 +160,17 @@ def test_interleaved_chains_keep_separate_streams(four_by_five_grid_for_opt):
     assert actual_b == baseline_b
 
 
-def test_reiterating_with_int_seed_continues_stream(four_by_five_grid_for_opt):
+def test_reiterating_with_int_seed_continues_stream(four_by_five_grid_for_opt: Graph):
     chain = make_recom_chain(four_by_five_grid_for_opt, rng=5)
     assert trajectory(chain) != trajectory(chain)
 
 
-def test_reiterating_with_random_instance_continues_stream(four_by_five_grid_for_opt):
+def test_reiterating_with_random_instance_continues_stream(four_by_five_grid_for_opt: Graph):
     chain = make_recom_chain(four_by_five_grid_for_opt, rng=random.Random(5))
     assert trajectory(chain) != trajectory(chain)
 
 
-def test_optimizer_rerun_continues_stream(four_by_five_grid_for_opt):
+def test_optimizer_rerun_continues_stream(four_by_five_grid_for_opt: Graph):
     optimizer = make_optimizer(four_by_five_grid_for_opt, rng=11)
     first = run_bursts(optimizer)
     # Consecutive bursts continue one stream, so re-running the same optimizer does

--- a/tests/test_tally.py
+++ b/tests/test_tally.py
@@ -1,5 +1,7 @@
 import random
 from collections import defaultdict
+from collections.abc import Callable, Hashable, Iterable
+from typing import cast
 
 import networkx
 
@@ -13,11 +15,11 @@ from gerrychain.updaters.tally import DataTally, Tally
 random.seed(2018)
 
 
-def random_assignment(graph, num_districts):
+def random_assignment(graph: Graph, num_districts: int) -> dict[Hashable, int]:
     return {node: random.choice(range(num_districts)) for node in graph.nodes}
 
 
-def test_data_tally_works_as_an_updater(three_by_three_grid):
+def test_data_tally_works_as_an_updater(three_by_three_grid: Graph):
     # Simple test that a DataTally creates an attribute on a partition.
     # Another test (below) checks that the computed "tally" is correct.
     assignment = random_assignment(three_by_three_grid, 4)
@@ -32,7 +34,7 @@ def test_data_tally_works_as_an_updater(three_by_three_grid):
     assert new_partition["tally"]
 
 
-def test_data_tally_gives_expected_value(three_by_three_grid):
+def test_data_tally_gives_expected_value(three_by_three_grid: Graph):
     # Put all but one of the nodes in part #1, and put the one "first_node"
     # into part #2.
 
@@ -60,7 +62,9 @@ def test_data_tally_gives_expected_value(three_by_three_grid):
     assert new_partition["tally"][1] == partition["tally"][1] + 1
 
 
-def test_data_tally_mimics_old_tally_usage(graph_with_random_data_factory):
+def test_data_tally_mimics_old_tally_usage(
+    graph_with_random_data_factory: Callable[[Iterable[str]], Graph],
+):
     graph = graph_with_random_data_factory(["total"])
 
     # Make a DataTally the same way you make a Tally
@@ -84,8 +88,8 @@ def test_tally_matches_naive_tally_at_every_step():
         rng=2018,
     )
 
-    def get_expected_tally(partition):
-        expected = defaultdict(int)
+    def get_expected_tally(partition: Partition) -> defaultdict[Hashable, int]:
+        expected: defaultdict[Hashable, int] = defaultdict(int)
         for node in partition.graph.nodes:
             part = partition.assignment[node]
             expected[part] += partition.graph.node_data(node)["population"]
@@ -100,7 +104,7 @@ def test_works_when_no_flips_occur():
     nx_graph = networkx.Graph([(0, 1), (1, 2), (2, 3), (3, 0)])
     graph = Graph.from_networkx(nx_graph)
     for node in graph:
-        graph.node_data(node)["pop"] = node + 1
+        graph.node_data(node)["pop"] = cast(int, node) + 1
     partition = Partition(graph, {0: 0, 1: 0, 2: 1, 3: 1}, {"pop": Tally("pop")})
 
     chain = MarkovChain(lambda p, *, rng: p.flip({}), [], always_accept, partition, 10)

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -2,7 +2,9 @@
 import inspect
 import random
 import warnings
+from collections.abc import Callable, Hashable, Sequence
 from functools import partial
+from typing import cast
 
 import networkx
 import pytest
@@ -33,7 +35,11 @@ from gerrychain.tree import (
 )
 
 # Need to explicitly import "internal" class
-from gerrychain.tree.bipartition_tree import _PopulatedGraph
+from gerrychain.tree.bipartition_tree import (
+    FindBalancedEdgeCutsFn,
+    GraphLike,
+    _PopulatedGraph,
+)
 from gerrychain.updaters import Tally, cut_edges
 
 #
@@ -53,7 +59,7 @@ from gerrychain.updaters import Tally, cut_edges
 
 
 @pytest.fixture
-def graph_with_pop_nx(three_by_three_grid):
+def graph_with_pop_nx(three_by_three_grid: Graph) -> Graph:
     # NX-based Graph object
     for node in three_by_three_grid:
         three_by_three_grid.node_data(node)["pop"] = 1
@@ -61,14 +67,14 @@ def graph_with_pop_nx(three_by_three_grid):
 
 
 @pytest.fixture
-def graph_with_pop_rx(graph_with_pop_nx):
+def graph_with_pop_rx(graph_with_pop_nx: Graph) -> Graph:
     # RX-based Graph object (same data as NX-based version)
     graph_rx = graph_with_pop_nx.convert_from_nx_to_rx()
     return graph_rx
 
 
 @pytest.fixture
-def partition_with_pop(graph_with_pop_nx):
+def partition_with_pop(graph_with_pop_nx: Graph) -> Partition:
     # No need for an RX-based Graph here because creating the
     # Partition object converts the graph to be RX-based if
     # it is not already RX-based
@@ -81,7 +87,7 @@ def partition_with_pop(graph_with_pop_nx):
 
 
 @pytest.fixture
-def twelve_by_twelve_with_pop_nx():
+def twelve_by_twelve_with_pop_nx() -> Graph:
     # NX-based Graph object
 
     xy_grid = networkx.grid_graph([12, 12])
@@ -100,7 +106,7 @@ def twelve_by_twelve_with_pop_nx():
 
 
 @pytest.fixture
-def twelve_by_twelve_with_pop_rx(twelve_by_twelve_with_pop_nx):
+def twelve_by_twelve_with_pop_rx(twelve_by_twelve_with_pop_nx: Graph) -> Graph:
     # RX-based Graph object (same data as NX-based version)
     graph_rx = twelve_by_twelve_with_pop_nx.convert_from_nx_to_rx()
     return graph_rx
@@ -109,14 +115,16 @@ def twelve_by_twelve_with_pop_rx(twelve_by_twelve_with_pop_nx):
 # ---------------------------------------------------------------------
 
 
-def do_test_bipartition_tree_returns_a_subset_of_nodes(graph):
+def do_test_bipartition_tree_returns_a_subset_of_nodes(graph: Graph):
     ideal_pop = sum(graph.node_data(node)["pop"] for node in graph) / 2
     result = bipartition_tree(graph, "pop", ideal_pop, 0.25, rng=random.Random(2018))
     assert isinstance(result, frozenset)
     assert all(node in graph.nodes for node in result)
 
 
-def test_bipartition_tree_returns_a_subset_of_nodes(graph_with_pop_nx, graph_with_pop_rx):
+def test_bipartition_tree_returns_a_subset_of_nodes(
+    graph_with_pop_nx: Graph, graph_with_pop_rx: Graph
+):
     # Test both NX-based and RX-based Graph objects
     do_test_bipartition_tree_returns_a_subset_of_nodes(graph_with_pop_nx)
     do_test_bipartition_tree_returns_a_subset_of_nodes(graph_with_pop_rx)
@@ -139,7 +147,9 @@ def test_node_repeats_public_defaults_are_zero():
     "cut_finder",
     [find_balanced_edge_cuts_memoization, partial(find_balanced_edge_cuts_memoization)],
 )
-def test_node_repeats_warns_with_memoized_cut_finder(graph_with_pop_nx, cut_finder):
+def test_node_repeats_warns_with_memoized_cut_finder(
+    graph_with_pop_nx: Graph, cut_finder: FindBalancedEdgeCutsFn
+):
     with pytest.warns(UserWarning, match="node_repeats is not beneficial"):
         bipartition_tree(
             graph_with_pop_nx,
@@ -159,7 +169,9 @@ def test_node_repeats_warns_with_memoized_cut_finder(graph_with_pop_nx, cut_find
         lambda *args, **kwargs: find_balanced_edge_cuts_memoization(*args, **kwargs),
     ],
 )
-def test_node_repeats_does_not_warn_with_other_cut_finders(graph_with_pop_nx, cut_finder):
+def test_node_repeats_does_not_warn_with_other_cut_finders(
+    graph_with_pop_nx: Graph, cut_finder: FindBalancedEdgeCutsFn
+):
     with warnings.catch_warnings():
         warnings.simplefilter("error", UserWarning)
         bipartition_tree(
@@ -176,7 +188,7 @@ def test_node_repeats_does_not_warn_with_other_cut_finders(graph_with_pop_nx, cu
 # ---------------------------------------------------------------------
 
 
-def do_test_bipartition_tree_returns_within_epsilon_of_target_pop(graph):
+def do_test_bipartition_tree_returns_within_epsilon_of_target_pop(graph: Graph):
     ideal_pop = sum(graph.node_data(node)["pop"] for node in graph) / 2
     epsilon = 0.25
     result = bipartition_tree(graph, "pop", ideal_pop, epsilon, rng=random.Random(2018))
@@ -186,7 +198,7 @@ def do_test_bipartition_tree_returns_within_epsilon_of_target_pop(graph):
 
 
 def test_bipartition_tree_returns_within_epsilon_of_target_pop(
-    graph_with_pop_nx, graph_with_pop_rx
+    graph_with_pop_nx: Graph, graph_with_pop_rx: Graph
 ):
     # Test both NX-based and RX-based Graph objects
     do_test_bipartition_tree_returns_within_epsilon_of_target_pop(graph_with_pop_nx)
@@ -197,7 +209,7 @@ def test_bipartition_tree_returns_within_epsilon_of_target_pop(
 
 
 def do_test_recursive_tree_part_returns_within_epsilon_of_target_pop(
-    twelve_by_twelve_with_pop_graph,
+    twelve_by_twelve_with_pop_graph: Graph,
 ):
     n_districts = 7  # 144/7 ≈ 20.5 nodes/subgraph (1 person/node)
     ideal_pop = (
@@ -222,7 +234,7 @@ def do_test_recursive_tree_part_returns_within_epsilon_of_target_pop(
 
 
 def test_recursive_tree_part_returns_within_epsilon_of_target_pop(
-    twelve_by_twelve_with_pop_nx, twelve_by_twelve_with_pop_rx
+    twelve_by_twelve_with_pop_nx: Graph, twelve_by_twelve_with_pop_rx: Graph
 ):
     # Test both NX-based and RX-based Graph objects
     do_test_recursive_tree_part_returns_within_epsilon_of_target_pop(twelve_by_twelve_with_pop_nx)
@@ -233,7 +245,7 @@ def test_recursive_tree_part_returns_within_epsilon_of_target_pop(
 
 
 def do_test_recursive_tree_part_returns_within_epsilon_of_target_pop_using_contraction(
-    twelve_by_twelve_with_pop_graph,
+    twelve_by_twelve_with_pop_graph: Graph,
 ):
     n_districts = 7  # 144/7 ≈ 20.5 nodes/subgraph (1 person/node)
     ideal_pop = (
@@ -263,7 +275,7 @@ def do_test_recursive_tree_part_returns_within_epsilon_of_target_pop_using_contr
 
 
 def test_recursive_tree_part_returns_within_epsilon_of_target_pop_using_contraction(
-    twelve_by_twelve_with_pop_nx, twelve_by_twelve_with_pop_rx
+    twelve_by_twelve_with_pop_nx: Graph, twelve_by_twelve_with_pop_rx: Graph
 ):
     # Test both NX-based and RX-based Graph objects
     do_test_recursive_tree_part_returns_within_epsilon_of_target_pop_using_contraction(
@@ -278,7 +290,7 @@ def test_recursive_tree_part_returns_within_epsilon_of_target_pop_using_contract
 
 
 def do_test_recursive_seed_part_returns_within_epsilon_of_target_pop(
-    twelve_by_twelve_with_pop_graph,
+    twelve_by_twelve_with_pop_graph: Graph,
 ):
     n_districts = 7  # 144/7 ≈ 20.5 nodes/subgraph (1 person/node)
     ideal_pop = (
@@ -305,7 +317,7 @@ def do_test_recursive_seed_part_returns_within_epsilon_of_target_pop(
 
 
 def test_recursive_seed_part_returns_within_epsilon_of_target_pop(
-    twelve_by_twelve_with_pop_nx, twelve_by_twelve_with_pop_rx
+    twelve_by_twelve_with_pop_nx: Graph, twelve_by_twelve_with_pop_rx: Graph
 ):
     # Test both NX-based and RX-based Graph objects
     do_test_recursive_seed_part_returns_within_epsilon_of_target_pop(twelve_by_twelve_with_pop_nx)
@@ -316,7 +328,7 @@ def test_recursive_seed_part_returns_within_epsilon_of_target_pop(
 
 
 def do_test_recursive_seed_part_returns_within_epsilon_of_target_pop_using_contraction(
-    twelve_by_twelve_with_pop_graph,
+    twelve_by_twelve_with_pop_graph: Graph,
 ):
     n_districts = 7  # 144/7 ≈ 20.5 nodes/subgraph (1 person/node)
     ideal_pop = (
@@ -348,7 +360,7 @@ def do_test_recursive_seed_part_returns_within_epsilon_of_target_pop_using_contr
 
 
 def test_recursive_seed_part_returns_within_epsilon_of_target_pop_using_contraction(
-    twelve_by_twelve_with_pop_nx, twelve_by_twelve_with_pop_rx
+    twelve_by_twelve_with_pop_nx: Graph, twelve_by_twelve_with_pop_rx: Graph
 ):
     # Test both NX-based and RX-based Graph objects
     do_test_recursive_seed_part_returns_within_epsilon_of_target_pop_using_contraction(
@@ -362,11 +374,19 @@ def test_recursive_seed_part_returns_within_epsilon_of_target_pop_using_contract
 # ---------------------------------------------------------------------
 
 
-def do_test_recursive_seed_part_uses_bipartition_tree_fn(twelve_by_twelve_with_pop_graph):
+def do_test_recursive_seed_part_uses_bipartition_tree_fn(twelve_by_twelve_with_pop_graph: Graph):
     calls = 0
 
     def dummy_bipartition_tree_fn(
-        graph, pop_col, pop_target, epsilon, node_repeats, one_sided_cut, *, rng
+        graph: GraphLike,
+        pop_col: str,
+        pop_target: float,
+        epsilon: float,
+        node_repeats: int = 0,
+        one_sided_cut: bool = False,
+        region_surcharge: dict[str, float] | None = None,
+        *,
+        rng: random.Random,
     ):
         nonlocal calls
         calls += 1
@@ -408,7 +428,7 @@ def do_test_recursive_seed_part_uses_bipartition_tree_fn(twelve_by_twelve_with_p
 
 
 def test_recursive_seed_part_uses_bipartition_tree_fn(
-    twelve_by_twelve_with_pop_nx, twelve_by_twelve_with_pop_rx
+    twelve_by_twelve_with_pop_nx: Graph, twelve_by_twelve_with_pop_rx: Graph
 ):
     # Test both NX-based and RX-based Graph objects
     do_test_recursive_seed_part_uses_bipartition_tree_fn(twelve_by_twelve_with_pop_nx)
@@ -419,7 +439,7 @@ def test_recursive_seed_part_uses_bipartition_tree_fn(
 
 
 def do_test_recursive_seed_part_with_n_unspecified_within_epsilon(
-    twelve_by_twelve_with_pop_graph,
+    twelve_by_twelve_with_pop_graph: Graph,
 ):
     n_districts = 6  # This should set n=3
     ideal_pop = (
@@ -445,7 +465,7 @@ def do_test_recursive_seed_part_with_n_unspecified_within_epsilon(
 
 
 def test_recursive_seed_part_with_n_unspecified_within_epsilon(
-    twelve_by_twelve_with_pop_nx, twelve_by_twelve_with_pop_rx
+    twelve_by_twelve_with_pop_nx: Graph, twelve_by_twelve_with_pop_rx: Graph
 ):
     # Test both NX-based and RX-based Graph objects
     do_test_recursive_seed_part_with_n_unspecified_within_epsilon(twelve_by_twelve_with_pop_nx)
@@ -455,12 +475,14 @@ def test_recursive_seed_part_with_n_unspecified_within_epsilon(
 # ---------------------------------------------------------------------
 
 
-def do_test_random_spanning_tree_returns_tree_with_pop_attribute(graph):
+def do_test_random_spanning_tree_returns_tree_with_pop_attribute(graph: Graph):
     tree = random_spanning_tree(graph, rng=random.Random(2018))
     assert tree.is_a_tree()
 
 
-def test_random_spanning_tree_returns_tree_with_pop_attribute(graph_with_pop_nx, graph_with_pop_rx):
+def test_random_spanning_tree_returns_tree_with_pop_attribute(
+    graph_with_pop_nx: Graph, graph_with_pop_rx: Graph
+):
     # Test both NX-based and RX-based Graph objects
     do_test_random_spanning_tree_returns_tree_with_pop_attribute(graph_with_pop_nx)
     do_test_random_spanning_tree_returns_tree_with_pop_attribute(graph_with_pop_rx)
@@ -469,13 +491,13 @@ def test_random_spanning_tree_returns_tree_with_pop_attribute(graph_with_pop_nx,
 # ---------------------------------------------------------------------
 
 
-def do_test_uniform_spanning_tree_returns_tree_with_pop_attribute(graph):
+def do_test_uniform_spanning_tree_returns_tree_with_pop_attribute(graph: Graph):
     tree = uniform_spanning_tree(graph, rng=random.Random(2018))
     assert tree.is_a_tree()
 
 
 def test_uniform_spanning_tree_returns_tree_with_pop_attribute(
-    graph_with_pop_nx, graph_with_pop_rx
+    graph_with_pop_nx: Graph, graph_with_pop_rx: Graph
 ):
     # Test both NX-based and RX-based Graph objects
     do_test_uniform_spanning_tree_returns_tree_with_pop_attribute(graph_with_pop_nx)
@@ -485,7 +507,7 @@ def test_uniform_spanning_tree_returns_tree_with_pop_attribute(
 # ---------------------------------------------------------------------
 
 
-def do_test_bipartition_tree_returns_a_tree(graph, spanning_tree):
+def do_test_bipartition_tree_returns_a_tree(graph: Graph, spanning_tree: Graph):
     ideal_pop = sum(graph.node_data(node)["pop"] for node in graph) / 2
 
     result = bipartition_tree(
@@ -505,15 +527,20 @@ def do_test_bipartition_tree_returns_a_tree(graph, spanning_tree):
     ).is_a_tree()
 
 
-def test_bipartition_tree_threads_rng_to_custom_balanced_cut_fn(graph_with_pop_nx):
-    seen_rngs = []
-    default_root_calls = []
+def test_bipartition_tree_threads_rng_to_custom_balanced_cut_fn(graph_with_pop_nx: Graph):
+    seen_rngs: list[random.Random] = []
+    default_root_calls: list[bool] = []
 
-    def choose_root(nodes):
+    def choose_root(nodes: Sequence[Hashable]) -> Hashable:
         default_root_calls.append(True)
         return nodes[0]
 
-    def find_cuts(h, rootnode_choice_fn=choose_root, *, rng):
+    def find_cuts(
+        h: _PopulatedGraph,
+        rootnode_choice_fn: Callable[[Sequence[Hashable]], Hashable] = choose_root,
+        *,
+        rng: random.Random,
+    ):
         seen_rngs.append(rng)
         return find_balanced_edge_cuts_memoization(
             h,
@@ -536,7 +563,11 @@ def test_bipartition_tree_threads_rng_to_custom_balanced_cut_fn(graph_with_pop_n
     assert default_root_calls
 
 
-def create_graphs_from_nx_edges(num_nodes, list_of_edges_nx, nx_to_rx_node_id_map):
+def create_graphs_from_nx_edges(
+    num_nodes: int,
+    list_of_edges_nx: list[tuple[int, int]],
+    nx_to_rx_node_id_map: dict[Hashable, Hashable],
+) -> tuple[Graph, Graph]:
     # NX is easy - just use the list of NX edges
     graph_nx = Graph.from_networkx(networkx.Graph(list_of_edges_nx))
 
@@ -571,8 +602,8 @@ def create_graphs_from_nx_edges(num_nodes, list_of_edges_nx, nx_to_rx_node_id_ma
     # translate the NX edges into the appropriate node_ids for the derived RX graph
     list_of_edges_rx = [
         (
-            nx_to_rx_node_id_map[edge[0]],
-            nx_to_rx_node_id_map[edge[1]],
+            cast(int, nx_to_rx_node_id_map[edge[0]]),
+            cast(int, nx_to_rx_node_id_map[edge[1]]),
             {},  # empty data dict for edge_data
         )
         for edge in list_of_edges_nx
@@ -585,7 +616,7 @@ def create_graphs_from_nx_edges(num_nodes, list_of_edges_nx, nx_to_rx_node_id_ma
     return graph_nx, graph_rx
 
 
-def test_bipartition_tree_returns_a_tree(graph_with_pop_nx, graph_with_pop_rx):
+def test_bipartition_tree_returns_a_tree(graph_with_pop_nx: Graph, graph_with_pop_rx: Graph):
     # Test both NX-based and RX-based Graph objects
 
     spanning_tree_edges_nx = [
@@ -599,8 +630,11 @@ def test_bipartition_tree_returns_a_tree(graph_with_pop_nx, graph_with_pop_rx):
         (6, 8),
     ]
 
+    nx_to_rx_node_id_map = graph_with_pop_rx.nx_to_rx_node_id_map
+    assert nx_to_rx_node_id_map is not None
+
     spanning_tree_nx, spanning_tree_rx = create_graphs_from_nx_edges(
-        9, spanning_tree_edges_nx, graph_with_pop_rx.nx_to_rx_node_id_map
+        9, spanning_tree_edges_nx, nx_to_rx_node_id_map
     )
 
     # Give the nodes a population
@@ -613,7 +647,7 @@ def test_bipartition_tree_returns_a_tree(graph_with_pop_nx, graph_with_pop_rx):
     do_test_bipartition_tree_returns_a_tree(graph_with_pop_rx, spanning_tree_rx)
 
 
-def test_recom_works_as_a_proposal(partition_with_pop):
+def test_recom_works_as_a_proposal(partition_with_pop: Partition):
     graph = partition_with_pop.graph
     ideal_pop = sum(graph.node_data(node)["pop"] for node in graph) / 2
 
@@ -628,7 +662,7 @@ def test_recom_works_as_a_proposal(partition_with_pop):
         assert contiguous(state)
 
 
-def test_reversible_recom_works_as_a_proposal(partition_with_pop):
+def test_reversible_recom_works_as_a_proposal(partition_with_pop: Partition):
     graph = partition_with_pop.graph
     ideal_pop = sum(graph.node_data(node)["pop"] for node in graph) / 2
 
@@ -713,7 +747,7 @@ def test_find_balanced_cuts_contraction():
 
     populated_tree = _PopulatedGraph(tree, {node: 1 for node in tree}, len(tree) / 2, 0.5)
     cuts = find_balanced_edge_cuts_contraction(populated_tree, rng=random.Random(2018))
-    edges = set(tuple(sorted(cut.edge)) for cut in cuts)
+    edges = set(tuple(sorted(cast("tuple[int, int]", cut.edge))) for cut in cuts)
     assert edges == {(1, 4), (3, 4), (3, 6)}
 
 
@@ -724,12 +758,12 @@ def test_no_balanced_cuts_contraction_when_one_side_okay():
     # that is derived fromn an NX-based Graph object, so the
     # nx_to_rx_node_id_map can just be the identity map...
     #
-    nx_to_rx_node_id_map = {node: node for node in range(5)}
+    nx_to_rx_node_id_map: dict[Hashable, Hashable] = {node: node for node in range(5)}
 
     tree_nx, tree_rx = create_graphs_from_nx_edges(5, list_of_nodes_nx, nx_to_rx_node_id_map)
 
     # OK to use the same populations for NX and RX graphs
-    populations = {0: 4, 1: 4, 2: 3, 3: 3, 4: 3}
+    populations: dict[Hashable, int | float] = {0: 4, 1: 4, 2: 3, 3: 3, 4: 3}
 
     populated_tree_nx = _PopulatedGraph(
         graph=tree_nx, populations=populations, ideal_pop=10, epsilon=0.1
@@ -756,7 +790,7 @@ def test_find_balanced_cuts_memo():
     # that is derived fromn an NX-based Graph object, so the
     # nx_to_rx_node_id_map can just be the identity map...
     #
-    nx_to_rx_node_id_map = {node: node for node in range(9)}
+    nx_to_rx_node_id_map: dict[Hashable, Hashable] = {node: node for node in range(9)}
 
     tree_nx, tree_rx = create_graphs_from_nx_edges(9, list_of_nodes_nx, nx_to_rx_node_id_map)
 
@@ -776,11 +810,11 @@ def test_find_balanced_cuts_memo():
     )
 
     cuts_nx = find_balanced_edge_cuts_memoization(populated_tree_nx, rng=random.Random(2018))
-    edges_nx = set(tuple(sorted(cut.edge)) for cut in cuts_nx)
+    edges_nx = set(tuple(sorted(cast("tuple[int, int]", cut.edge))) for cut in cuts_nx)
     assert edges_nx == {(1, 4), (3, 4), (3, 6)}
 
     cuts_rx = find_balanced_edge_cuts_memoization(populated_tree_rx, rng=random.Random(2018))
-    edges_rx = set(tuple(sorted(cut.edge)) for cut in cuts_rx)
+    edges_rx = set(tuple(sorted(cast("tuple[int, int]", cut.edge))) for cut in cuts_rx)
     assert edges_rx == {(1, 4), (3, 4), (3, 6)}
 
 
@@ -791,12 +825,12 @@ def test_no_balanced_cuts_memo_when_one_side_okay():
     # that is derived fromn an NX-based Graph object, so the
     # nx_to_rx_node_id_map can just be the identity map...
     #
-    nx_to_rx_node_id_map = {node: node for node in range(5)}
+    nx_to_rx_node_id_map: dict[Hashable, Hashable] = {node: node for node in range(5)}
 
     tree_nx, tree_rx = create_graphs_from_nx_edges(5, list_of_nodes_nx, nx_to_rx_node_id_map)
 
     # OK to use the same populations with both NX and RX Graphs
-    populations = {0: 4, 1: 4, 2: 3, 3: 3, 4: 3}
+    populations: dict[Hashable, int | float] = {0: 4, 1: 4, 2: 3, 3: 3, 4: 3}
 
     populated_tree_nx = _PopulatedGraph(
         graph=tree_nx, populations=populations, ideal_pop=10, epsilon=0.1

--- a/tests/updaters/dbg.py
+++ b/tests/updaters/dbg.py
@@ -1,5 +1,6 @@
 import math
 import random
+from typing import cast
 
 import networkx
 
@@ -36,7 +37,7 @@ def create_three_by_three_grid():
     return Graph.from_networkx(nx_graph)
 
 
-def random_assignment(graph, num_districts):
+def random_assignment(graph: Graph, num_districts: int):
     assignment = {node: random.choice(range(num_districts)) for node in graph.nodes}
     # Make sure that there are cut edges:
     while len(set(assignment.values())) == 1:
@@ -44,12 +45,12 @@ def random_assignment(graph, num_districts):
     return assignment
 
 
-def test_vote_proportion_returns_nan_if_total_votes_is_zero(three_by_three_grid):
+def test_vote_proportion_returns_nan_if_total_votes_is_zero(three_by_three_grid: Graph):
     election = Election("Mock Election", ["D", "R"], alias="election")
     graph = three_by_three_grid
 
     for node in graph.nodes:
-        for col in election.columns:
+        for col in cast("list[str]", election.node_attribute_names):
             graph.node_data(node)[col] = 0
 
     updaters = {"election": election}

--- a/tests/updaters/test_cut_edges.py
+++ b/tests/updaters/test_cut_edges.py
@@ -1,22 +1,28 @@
 import functools
+from collections.abc import Hashable
+from collections.abc import Set as AbstractSet
 
 import pytest
 
-from gerrychain import MarkovChain, Partition, proposals
+from gerrychain import Graph, MarkovChain, Partition, proposals
 from gerrychain.accept import always_accept
 from gerrychain.constraints import no_vanishing_districts, single_flip_contiguous
 from gerrychain.grid import Grid
+from gerrychain.proposals import ProposalFn
 from gerrychain.updaters import cut_edges, cut_edges_by_part
 
 # This is copied and pasted, but should be done with some proper
 # pytest configuration instead:
 
 
-def edge_set_equal(set1, set2):
+def edge_set_equal(
+    set1: AbstractSet[tuple[Hashable, Hashable]],
+    set2: AbstractSet[tuple[Hashable, Hashable]],
+) -> bool:
     return {(y, x) for x, y in set1} | set1 == {(y, x) for x, y in set2} | set2
 
 
-def invalid_cut_edges(partition):
+def invalid_cut_edges(partition: Partition) -> list[tuple[int, int]]:
     invalid = [
         edge
         for edge in partition["cut_edges"]
@@ -25,9 +31,11 @@ def invalid_cut_edges(partition):
     return invalid
 
 
-def translate_flips_to_internal_node_ids(partition, flips):
+def translate_flips_to_internal_node_ids(
+    partition: Partition, flips: dict[int, int]
+) -> dict[Hashable, int]:
     # Translate flips into the internal_node_ids for the partition
-    internal_flips = {}
+    internal_flips: dict[Hashable, int] = {}
     for original_nx_node_id, part in flips.items():
         internal_node_id = partition.graph.internal_node_id_for_original_nx_node_id(
             original_nx_node_id
@@ -37,7 +45,7 @@ def translate_flips_to_internal_node_ids(partition, flips):
 
 
 def test_cut_edges_doesnt_duplicate_edges_with_different_order_of_nodes(
-    three_by_three_grid,
+    three_by_three_grid: Graph,
 ):
     graph = three_by_three_grid
     assignment = {0: 1, 1: 1, 2: 2, 3: 1, 4: 1, 5: 2, 6: 2, 7: 2, 8: 2}
@@ -58,7 +66,7 @@ def test_cut_edges_doesnt_duplicate_edges_with_different_order_of_nodes(
         assert (edge[1], edge[0]) not in result
 
 
-def test_cut_edges_can_handle_multiple_flips(three_by_three_grid):
+def test_cut_edges_can_handle_multiple_flips(three_by_three_grid: Graph):
     graph = three_by_three_grid
     assignment = {0: 1, 1: 1, 2: 2, 3: 1, 4: 1, 5: 2, 6: 2, 7: 2, 8: 2}
     partition = Partition(graph, assignment, {"cut_edges": cut_edges})
@@ -81,7 +89,7 @@ def test_cut_edges_can_handle_multiple_flips(three_by_three_grid):
 
 
 def test_cut_edges_by_part_doesnt_duplicate_edges_with_opposite_order_of_nodes(
-    three_by_three_grid,
+    three_by_three_grid: Graph,
 ):
     graph = three_by_three_grid
     assignment = {0: 1, 1: 1, 2: 2, 3: 1, 4: 1, 5: 2, 6: 2, 7: 2, 8: 2}
@@ -103,7 +111,7 @@ def test_cut_edges_by_part_doesnt_duplicate_edges_with_opposite_order_of_nodes(
             assert (edge[1], edge[0]) not in result
 
 
-def test_cut_edges_by_part_gives_same_total_edges_as_naive_method(three_by_three_grid):
+def test_cut_edges_by_part_gives_same_total_edges_as_naive_method(three_by_three_grid: Graph):
     graph = three_by_three_grid
     assignment = {0: 1, 1: 1, 2: 2, 3: 1, 4: 1, 5: 2, 6: 2, 7: 2, 8: 2}
     updaters = {"cut_edges_by_part": cut_edges_by_part}
@@ -125,7 +133,7 @@ def test_cut_edges_by_part_gives_same_total_edges_as_naive_method(three_by_three
     assert naive_cut_edges == {tuple(sorted(edge)) for part in result for edge in result[part]}
 
 
-def test_implementation_of_cut_edges_matches_naive_method(three_by_three_grid):
+def test_implementation_of_cut_edges_matches_naive_method(three_by_three_grid: Graph):
     graph = three_by_three_grid
     assignment = {0: 1, 1: 1, 2: 2, 3: 1, 4: 1, 5: 2, 6: 2, 7: 2, 8: 2}
     partition = Partition(graph, assignment, {"cut_edges": cut_edges})
@@ -166,7 +174,9 @@ def test_implementation_of_cut_edges_matches_naive_method(three_by_three_grid):
         ),
     ],
 )
-def test_cut_edges_matches_naive_cut_edges_at_every_step(proposal, number_of_steps):
+def test_cut_edges_matches_naive_cut_edges_at_every_step(
+    proposal: ProposalFn, number_of_steps: int
+):
     partition = Grid((10, 10), with_diagonals=True)
 
     chain = MarkovChain(

--- a/tests/updaters/test_election.py
+++ b/tests/updaters/test_election.py
@@ -6,7 +6,7 @@ from gerrychain.updaters.election import ElectionResults
 
 
 @pytest.fixture
-def mock_election():
+def mock_election() -> ElectionResults:
     election = MagicMock()
     election.parties = ["B", "A"]
 
@@ -20,25 +20,25 @@ def mock_election():
     )
 
 
-def test_election_results_can_compute_mm(mock_election):
+def test_election_results_can_compute_mm(mock_election: ElectionResults):
     assert mock_election.mean_median() is not None
 
 
-def test_election_results_can_compute_mt(mock_election):
+def test_election_results_can_compute_mt(mock_election: ElectionResults):
     assert mock_election.mean_thirdian() is not None
 
 
-def test_election_results_can_compute_eg(mock_election):
+def test_election_results_can_compute_eg(mock_election: ElectionResults):
     assert mock_election.efficiency_gap() is not None
 
 
-def test_election_results_can_copmute_bias(mock_election):
+def test_election_results_can_copmute_bias(mock_election: ElectionResults):
     assert mock_election.partisan_bias() is not None
 
 
-def test_election_results_can_compute_gini(mock_election):
+def test_election_results_can_compute_gini(mock_election: ElectionResults):
     assert mock_election.partisan_gini() is not None
 
 
-def test_election_results_can_compute_percents(mock_election):
+def test_election_results_can_compute_percents(mock_election: ElectionResults):
     assert mock_election.percent("A") > 0

--- a/tests/updaters/test_perimeters.py
+++ b/tests/updaters/test_perimeters.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 
-from gerrychain import MarkovChain
+from gerrychain import MarkovChain, Partition
 from gerrychain.accept import always_accept
 from gerrychain.constraints import no_vanishing_districts, single_flip_contiguous
 from gerrychain.grid import Grid
@@ -117,7 +117,7 @@ def test_perimeter_match_naive_perimeter_at_every_step():
         1000,
     )
 
-    def get_exterior_boundaries(partition):
+    def get_exterior_boundaries(partition: Partition):
         graph_boundary = partition["boundary_nodes"]
         exterior = defaultdict(lambda: 0)
         for node_id in graph_boundary:
@@ -125,7 +125,7 @@ def test_perimeter_match_naive_perimeter_at_every_step():
             exterior[part] += partition.graph.node_data(node_id)["boundary_perim"]
         return exterior
 
-    def get_interior_boundaries(partition):
+    def get_interior_boundaries(partition: Partition):
         cut_edges = {edge for edge in partition.graph.edges if partition.crosses_parts(edge)}
         interior = defaultdict(int)
         for edge in cut_edges:
@@ -135,7 +135,7 @@ def test_perimeter_match_naive_perimeter_at_every_step():
                 )["shared_perim"]
         return interior
 
-    def expected_perimeter(partition):
+    def expected_perimeter(partition: Partition):
         interior_boundaries = get_interior_boundaries(partition)
         exterior_boundaries = get_exterior_boundaries(partition)
         expected = {

--- a/tests/updaters/test_spanning_trees.py
+++ b/tests/updaters/test_spanning_trees.py
@@ -1,8 +1,8 @@
-from gerrychain import Partition
+from gerrychain import Graph, Partition
 from gerrychain.updaters import num_spanning_trees
 
 
-def test_get_num_spanning_trees(three_by_three_grid):
+def test_get_num_spanning_trees(three_by_three_grid: Graph):
     assignment = {0: 1, 1: 1, 2: 1, 3: 1, 4: 1, 5: 1, 6: 1, 7: 1, 8: 1}
     partition = Partition(
         three_by_three_grid, assignment, {"num_spanning_trees": num_spanning_trees}

--- a/tests/updaters/test_split_scores.py
+++ b/tests/updaters/test_split_scores.py
@@ -1,3 +1,5 @@
+from typing import cast
+
 import networkx
 import pytest
 
@@ -7,7 +9,7 @@ from gerrychain.updaters.locality_split_scores import LocalitySplits
 
 
 @pytest.fixture
-def three_by_three_grid():
+def three_by_three_grid() -> Graph:
     """Returns a graph that looks like this:
     0 1 2
     3 4 5
@@ -35,7 +37,7 @@ def three_by_three_grid():
 
 
 @pytest.fixture
-def graph_with_counties(three_by_three_grid):
+def graph_with_counties(three_by_three_grid: Graph) -> Graph:
     for node in [0, 1, 2]:
         three_by_three_grid.node_data(node)["county"] = "a"
         three_by_three_grid.node_data(node)["pop"] = 1
@@ -49,7 +51,7 @@ def graph_with_counties(three_by_three_grid):
 
 
 @pytest.fixture
-def partition(graph_with_counties):
+def partition(graph_with_counties: Graph) -> Partition:
     partition = Partition(
         graph_with_counties,
         assignment={0: 1, 1: 1, 2: 1, 3: 2, 4: 2, 5: 2, 6: 3, 7: 3, 8: 3},
@@ -75,7 +77,7 @@ def partition(graph_with_counties):
 
 
 @pytest.fixture
-def split_partition(graph_with_counties):
+def split_partition(graph_with_counties: Graph) -> Partition:
     partition = Partition(
         graph_with_counties,
         assignment={0: 1, 1: 2, 2: 3, 3: 1, 4: 2, 5: 3, 6: 1, 7: 2, 8: 3},
@@ -101,9 +103,10 @@ def split_partition(graph_with_counties):
 
 
 class TestSplittingScores:
-    def test_not_split(self, partition):
-        _ = partition.updaters["splits"](partition)
-        result = partition.updaters["splits"].scores
+    def test_not_split(self, partition: Partition):
+        splits = cast(LocalitySplits, partition.updaters["splits"])
+        _ = splits(partition)
+        result = splits.scores
 
         assert result["num_parts"] == 3
         assert result["num_pieces"] == 3
@@ -113,14 +116,21 @@ class TestSplittingScores:
         assert result["symmetric_entropy"] == 18
         assert result["num_split_localities"] == 0
 
-    def test_is_split(self, split_partition):
-        _ = split_partition.updaters["splits"](split_partition)
-        result = split_partition.updaters["splits"].scores
+    def test_is_split(self, split_partition: Partition):
+        splits = cast(LocalitySplits, split_partition.updaters["splits"])
+        _ = splits(split_partition)
+        result = splits.scores
 
         assert result["num_parts"] == 9
         assert result["num_pieces"] == 9
         assert result["naked_boundary"] == 6
-        assert 1.2 > result["shannon_entropy"] > 1
-        assert 0.6 > result["power_entropy"] > 0.5
-        assert 32 > result["symmetric_entropy"] > 31
+        shannon_entropy = result["shannon_entropy"]
+        power_entropy = result["power_entropy"]
+        symmetric_entropy = result["symmetric_entropy"]
+        assert shannon_entropy is not None
+        assert power_entropy is not None
+        assert symmetric_entropy is not None
+        assert 1.2 > shannon_entropy > 1
+        assert 0.6 > power_entropy > 0.5
+        assert 32 > symmetric_entropy > 31
         assert result["num_split_localities"] == 3

--- a/tests/updaters/test_splits.py
+++ b/tests/updaters/test_splits.py
@@ -1,6 +1,6 @@
 import pytest
 
-from gerrychain import Partition
+from gerrychain import Graph, Partition
 from gerrychain.updaters.county_splits import (
     CountySplit,
     compute_county_splits,
@@ -9,7 +9,7 @@ from gerrychain.updaters.county_splits import (
 
 
 @pytest.fixture
-def graph_with_counties(three_by_three_grid):
+def graph_with_counties(three_by_three_grid: Graph) -> Graph:
     for node in [0, 1, 2]:
         three_by_three_grid.node_data(node)["county"] = "a"
     for node in [3, 4, 5]:
@@ -20,7 +20,7 @@ def graph_with_counties(three_by_three_grid):
 
 
 @pytest.fixture
-def partition(graph_with_counties):
+def partition(graph_with_counties: Graph) -> Partition:
     partition = Partition(
         graph_with_counties,
         assignment={0: 1, 1: 1, 2: 1, 3: 2, 4: 2, 5: 2, 6: 3, 7: 3, 8: 3},
@@ -30,7 +30,7 @@ def partition(graph_with_counties):
 
 
 @pytest.fixture
-def split_partition(graph_with_counties):
+def split_partition(graph_with_counties: Graph) -> Partition:
     partition = Partition(
         graph_with_counties,
         assignment={0: 1, 1: 1, 2: 1, 3: 1, 4: 2, 5: 2, 6: 3, 7: 3, 8: 3},
@@ -40,7 +40,7 @@ def split_partition(graph_with_counties):
 
 
 class TestComputeCountySplits:
-    def test_describes_splits_for_all_counties(self, partition):
+    def test_describes_splits_for_all_counties(self, partition: Partition):
         result = partition["splits"]
 
         assert set(result.keys()) == {"a", "b", "c"}
@@ -50,16 +50,16 @@ class TestComputeCountySplits:
 
         assert set(second_result.keys()) == {"a", "b", "c"}
 
-    def test_no_splits(self, graph_with_counties):
+    def test_no_splits(self, graph_with_counties: Graph):
         # frm: TODO: Testing:  Why does this not just use "split_partition"?  Isn't it the same?
         partition = Partition(graph_with_counties, assignment="county")
 
-        result = compute_county_splits(partition, "county", None)
+        result = compute_county_splits(partition, "county", "unused_partition_field")
 
         for splits_info in result.values():
             assert splits_info.split == CountySplit.NOT_SPLIT
 
-    def test_new_split(self, partition):
+    def test_new_split(self, partition: Partition):
         # Do a flip, using the node_ids of the original assignment (rather than the
         # node_ids used internally in the RX-based graph)
         after_a_flip = partition.flip({3: 1}, flips_passed_in_use_original_nx_node_ids=True)
@@ -70,7 +70,7 @@ class TestComputeCountySplits:
         assert result["b"].split == CountySplit.NEW_SPLIT
         assert result["c"].split == CountySplit.NOT_SPLIT
 
-    def test_initial_split(self, split_partition):
+    def test_initial_split(self, split_partition: Partition):
         result = split_partition["splits"]
 
         # County b starts out split, but a and c are not
@@ -78,7 +78,7 @@ class TestComputeCountySplits:
         assert result["b"].split == CountySplit.OLD_SPLIT
         assert result["c"].split == CountySplit.NOT_SPLIT
 
-    def test_old_split(self, split_partition):
+    def test_old_split(self, split_partition: Partition):
         # Do a flip, using the node_ids of the original assignment (rather than the
         # node_ids used internally in the RX-based graph)
         after_a_flip = split_partition.flip({4: 1}, flips_passed_in_use_original_nx_node_ids=True)
@@ -93,7 +93,7 @@ class TestComputeCountySplits:
         reason="county_splits only remembers the splits from the "
         "previous partition, which is not the intuitive behavior."
     )
-    def test_initial_split_that_disappears_and_comes_back(self, split_partition):
+    def test_initial_split_that_disappears_and_comes_back(self, split_partition: Partition):
         no_splits = split_partition.flip({3: 2}, flips_passed_in_use_original_nx_node_ids=True)
         result = no_splits["splits"]
         assert all(info.split == CountySplit.NOT_SPLIT for info in result.values())

--- a/tests/updaters/test_updaters.py
+++ b/tests/updaters/test_updaters.py
@@ -1,5 +1,7 @@
 import math
 import random
+from collections.abc import Callable, Hashable, Iterable
+from typing import cast
 
 import networkx
 import pytest
@@ -26,11 +28,13 @@ random.seed(2018)
 
 
 @pytest.fixture
-def graph_with_d_and_r_cols(graph_with_random_data_factory):
+def graph_with_d_and_r_cols(
+    graph_with_random_data_factory: Callable[[Iterable[str]], Graph],
+) -> Graph:
     return graph_with_random_data_factory(["D", "R"])
 
 
-def random_assignment(graph, num_districts):
+def random_assignment(graph: Graph, num_districts: int) -> dict[Hashable, int]:
     assignment = {node: random.choice(range(num_districts)) for node in graph.nodes}
     # Make sure that there are cut edges:
     while len(set(assignment.values())) == 1:
@@ -39,7 +43,7 @@ def random_assignment(graph, num_districts):
 
 
 @pytest.fixture
-def partition_with_election(graph_with_d_and_r_cols):
+def partition_with_election(graph_with_d_and_r_cols: Graph) -> Partition:
     graph = graph_with_d_and_r_cols
     assignment = random_assignment(graph, 3)
 
@@ -51,7 +55,7 @@ def partition_with_election(graph_with_d_and_r_cols):
 
 
 @pytest.fixture
-def chain_with_election(partition_with_election):
+def chain_with_election(partition_with_election: Partition) -> MarkovChain:
     return MarkovChain(
         propose_random_flip,
         Validator([no_vanishing_districts]),
@@ -92,7 +96,7 @@ def test_Partition_can_update_stats():
     assert new_partition["total_stat"][2] == 9
 
 
-def test_tally_multiple_node_attribute_names(graph_with_d_and_r_cols):
+def test_tally_multiple_node_attribute_names(graph_with_d_and_r_cols: Graph):
     graph = graph_with_d_and_r_cols
 
     updaters = {"total": Tally(["D", "R"], alias="total")}
@@ -105,12 +109,12 @@ def test_tally_multiple_node_attribute_names(graph_with_d_and_r_cols):
     assert partition["total"][1] == expected_total_in_district_one
 
 
-def test_vote_totals_are_nonnegative(partition_with_election):
+def test_vote_totals_are_nonnegative(partition_with_election: Partition):
     partition = partition_with_election
     assert all(count >= 0 for count in partition["Mock Election"].totals.values())
 
 
-def test_vote_proportion_updater_returns_percentage_or_nan(partition_with_election):
+def test_vote_proportion_updater_returns_percentage_or_nan(partition_with_election: Partition):
     partition = partition_with_election
 
     election_view = partition["Mock Election"]
@@ -123,12 +127,13 @@ def test_vote_proportion_updater_returns_percentage_or_nan(partition_with_electi
     )
 
 
-def test_vote_proportion_returns_nan_if_total_votes_is_zero(three_by_three_grid):
+def test_vote_proportion_returns_nan_if_total_votes_is_zero(three_by_three_grid: Graph):
     election = Election("Mock Election", ["D", "R"], alias="election")
     graph = three_by_three_grid
 
+    # Built from a list of party names, so every attribute name is a str column key
     for node in graph.nodes:
-        for col in election.node_attribute_names:
+        for col in cast(list[str], election.node_attribute_names):
             graph.node_data(node)[col] = 0
 
     updaters = {"election": election}
@@ -143,12 +148,12 @@ def test_vote_proportion_returns_nan_if_total_votes_is_zero(three_by_three_grid)
     )
 
 
-def is_percentage_or_nan(value):
+def is_percentage_or_nan(value: float) -> bool:
     return (0 <= value and value <= 1) or math.isnan(value)
 
 
 def test_vote_proportion_updater_returns_percentage_or_nan_on_later_steps(
-    chain_with_election,
+    chain_with_election: MarkovChain,
 ):
     for partition in chain_with_election:
         election_view = partition["Mock Election"]
@@ -159,13 +164,13 @@ def test_vote_proportion_updater_returns_percentage_or_nan_on_later_steps(
         )
 
 
-def test_vote_proportion_field_has_key_for_each_district(partition_with_election):
+def test_vote_proportion_field_has_key_for_each_district(partition_with_election: Partition):
     partition = partition_with_election
     for percents in partition["Mock Election"].percents_for_party.values():
         assert set(percents.keys()) == set(partition.parts)
 
 
-def test_vote_proportions_sum_to_one(partition_with_election):
+def test_vote_proportions_sum_to_one(partition_with_election: Partition):
     partition = partition_with_election
     election_view = partition["Mock Election"]
 
@@ -199,8 +204,9 @@ def test_election_result_has_a_cute_str_method():
 
 
 def _convert_dict_of_set_of_rx_node_ids_to_set_of_nx_node_ids(
-    dict_of_set_of_rx_nodes, nx_to_rx_node_id_map
-):
+    dict_of_set_of_rx_nodes: dict[Hashable, set[Hashable]],
+    nx_to_rx_node_id_map: dict[Hashable, Hashable] | None,
+) -> dict[Hashable, set[Hashable]]:
     # frm: TODO: Testing:  This way to convert node_ids is clumsy and inconvenient.  Think of something better...
 
     # When we create a partition from an NX based Graph we convert it to be an
@@ -213,7 +219,7 @@ def _convert_dict_of_set_of_rx_node_ids_to_set_of_nx_node_ids(
     # This routine converts the data that some updaters create - namely a mapping from
     # partitions to a set of node_ids.
 
-    converted_set = {}
+    converted_set: dict[Hashable, set[Hashable]] = {}
     if nx_to_rx_node_id_map is not None:  # means graph was converted from NX
         # reverse the map
         rx_to_nx_node_id_map = {value: key for key, value in nx_to_rx_node_id_map.items()}
@@ -231,7 +237,7 @@ def _convert_dict_of_set_of_rx_node_ids_to_set_of_nx_node_ids(
     return converted_set
 
 
-def test_exterior_boundaries_as_a_set(three_by_three_grid):
+def test_exterior_boundaries_as_a_set(three_by_three_grid: Graph):
     graph = three_by_three_grid
 
     for i in [0, 1, 2, 3, 5, 6, 7, 8]:
@@ -254,11 +260,8 @@ def test_exterior_boundaries_as_a_set(three_by_three_grid):
     # then we need to convert the RX node_ids in the partition's graph
     # back to what they were in the NX graph.
     nx_to_rx_node_id_map = partition.graph.get_nx_to_rx_node_id_map()
-    if nx_to_rx_node_id_map is not None:
-        converted_result = _convert_dict_of_set_of_rx_node_ids_to_set_of_nx_node_ids(
-            result, nx_to_rx_node_id_map
-        )
-        result = converted_result
+    assert nx_to_rx_node_id_map is not None
+    result = _convert_dict_of_set_of_rx_node_ids_to_set_of_nx_node_ids(result, nx_to_rx_node_id_map)
 
     assert result[1] == {0, 1, 3} and result[2] == {2, 5, 6, 7, 8}
 
@@ -297,7 +300,7 @@ def test_exterior_boundaries_as_a_set(three_by_three_grid):
     assert result[1] == {0, 1, 2, 3, 5} and result[2] == {6, 7, 8}
 
 
-def test_exterior_boundaries(three_by_three_grid):
+def test_exterior_boundaries(three_by_three_grid: Graph):
     graph = three_by_three_grid
 
     for i in [0, 1, 2, 3, 5, 6, 7, 8]:
@@ -333,7 +336,7 @@ def test_exterior_boundaries(three_by_three_grid):
     assert result[1] == 10 and result[2] == 6
 
 
-def test_perimeter(three_by_three_grid):
+def test_perimeter(three_by_three_grid: Graph):
     graph = three_by_three_grid
     for i in [0, 1, 2, 3, 5, 6, 7, 8]:
         graph.node_data(i)["boundary_node"] = True
@@ -364,13 +367,13 @@ def test_perimeter(three_by_three_grid):
     assert result[2] == 5 + 4  # 5 nodes + 4 edges
 
 
-def reject_half_of_all_flips(partition):
+def reject_half_of_all_flips(partition: Partition) -> bool:
     if partition.parent is None:
         return True
     return random.random() > 0.5
 
 
-def test_elections_match_the_naive_computation(partition_with_election):
+def test_elections_match_the_naive_computation(partition_with_election: Partition):
     chain = MarkovChain(
         propose_random_flip,
         Validator([no_vanishing_districts, reject_half_of_all_flips]),
@@ -389,7 +392,7 @@ def test_elections_match_the_naive_computation(partition_with_election):
         assert expected_party_totals == election_view.totals_for_party
 
 
-def expected_tally(partition, node_attribute_name):
+def expected_tally(partition: Partition, node_attribute_name: str) -> dict[Hashable, float]:
     return {
         part: sum(partition.graph.node_data(node)[node_attribute_name] for node in nodes)
         for part, nodes in partition.parts.items()


### PR DESCRIPTION
Mostly mechanical changes to the public API surface. No review necesasay. Don't worry about docs for now.

## Summary

Annotates and adjusts the tests so `ty` and `pyright` pass over `gerrychain` **and** `tests`, and
widens the type-check tooling to cover the tests. Almost entirely test-only. Stacks on
`misc/odds-and-ends-for-1p0p0`.

## Why

The library already type-checked cleanly, but the test tree did not, so the type-check target
excluded it. That left the tests free to drift and meant refactors could not lean on the checkers
for the code that exercises the library hardest.

## Changes

- Added type annotations throughout `tests/`, resolving the errors both checkers raised once the
  test tree was included.
- Made small annotation corrections in the library modules the tests pin: `_rng.py`,
  `graph/graph.py`, `partition/partition.py`, `tree/bipartition_tree.py`, `tree/spanning_tree.py`,
  `updaters/election.py`, and `updaters/tally.py`.
- Updated `Makefile` and `pyproject.toml` so the type-check target covers the tests.

## Testing

- [x] Tests pass locally
- [x] Type checks pass locally

Verified with `make type-check` (ty then pyright, over `gerrychain` and `tests`) and `make test`.
Both checkers report no errors over the combined tree.