### PR TITLE
Misc/odds and ends pt2

### DIFF
--- a/gerrychain/partition/initial_partition_generators.py
+++ b/gerrychain/partition/initial_partition_generators.py
@@ -127,7 +127,7 @@ def recursive_tree_part(
     # function, whose job it is to produce a connected set of
     # nodes that has the desired population target.
     #
-    # Note that it sets one_sided_cut=True which tells the
+    # Note that it sets single_district_cut=True which tells the
     # "bipartition_tree_fn" function that it is NOT bisecting the graph
     # but is rather supposed to just find one connected
     # set of nodes of the correct population size.
@@ -144,7 +144,7 @@ def recursive_tree_part(
                 pop_target=new_pop_target,
                 epsilon=(max_pop - min_pop) / (2 * new_pop_target),
                 node_repeats=node_repeats,
-                one_sided_cut=True,
+                single_district_cut=True,
                 rng=rng,
             )
         except Exception:
@@ -164,7 +164,7 @@ def recursive_tree_part(
     # After making n-2 districts, we need to make sure that the last
     # two districts are both balanced.
 
-    # For the last call to "bipartition_tree_fn", set one_sided_cut=False to
+    # For the last call to "bipartition_tree_fn", set single_district_cut=False to
     # request that "bipartition_tree_fn" create two equal sized districts
     # with the given population goal by bisecting the graph.
     node_ids = bipartition_tree_fn(
@@ -173,7 +173,7 @@ def recursive_tree_part(
         pop_target=pop_target,
         epsilon=epsilon,
         node_repeats=node_repeats,
-        one_sided_cut=False,
+        single_district_cut=False,
         rng=rng,
     )
 
@@ -481,7 +481,7 @@ def _recursive_seed_part_inner(
         return translated_assignment
 
     # frm: In the case when there are exactly 2 districts, split the graph by setting
-    #       one_sided_cut to be False.
+    #       single_district_cut to be False.
     if num_dists == 2:
         nodes = bipartition_tree_fn(
             graph.subgraph(graph.node_indices),  # needs to be a subgraph
@@ -489,7 +489,7 @@ def _recursive_seed_part_inner(
             pop_target=pop_target,
             epsilon=epsilon,
             node_repeats=node_repeats,
-            one_sided_cut=False,  # flag to say we want to bisect graph
+            single_district_cut=False,  # flag to say we want to bisect graph
             rng=rng,
         )
 
@@ -522,7 +522,7 @@ def _recursive_seed_part_inner(
             pop_target=pop_target,
             epsilon=epsilon,
             node_repeats=node_repeats,
-            one_sided_cut=True,
+            single_district_cut=True,
             rng=rng,
         )
         remaining_nodes -= nodes
@@ -550,7 +550,7 @@ def _recursive_seed_part_inner(
             pop_target,
             pop_col,
             epsilon,
-            bipartition_tree_fn=partial(bipartition_tree_fn, one_sided_cut=True),
+            bipartition_tree_fn=partial(bipartition_tree_fn, single_district_cut=True),
             rng=rng,
         )
 

--- a/gerrychain/proposals/multi_member_tree_proposals.py
+++ b/gerrychain/proposals/multi_member_tree_proposals.py
@@ -117,7 +117,7 @@ def epsilon_tree_bipartition_multi_member(
         pop_target=cut_target,
         epsilon=cut_epsilon,
         node_repeats=node_repeats,
-        one_sided_cut=True,
+        single_district_cut=True,
         rng=rng,
     )
 

--- a/gerrychain/proposals/tree_proposals.py
+++ b/gerrychain/proposals/tree_proposals.py
@@ -95,7 +95,7 @@ def epsilon_tree_bipartition(
         pop_target=pop_target,
         epsilon=epsilon,
         node_repeats=node_repeats,
-        one_sided_cut=False,
+        single_district_cut=False,
         rng=rng,
     )
 
@@ -308,6 +308,32 @@ def build_recom_proposal_fn(
     bipartition_tree_fn: ReComBipartitionTreeFn = bipartition_tree,
     pair_selection: PairSelection = "district_pairs",
 ) -> ProposalFn:
+    """Build a ReCom proposal function with its configuration bound.
+
+    This is the configurable form of the :class:`ReCom` namespace methods: it exposes every
+    :func:`recom` option except ``partition`` and ``rng``, which :class:`~gerrychain.MarkovChain`
+    supplies at each step.
+
+    Args:
+        pop_col (str): The name of the population column.
+        pop_target (int | float): The target population for each district.
+        epsilon (float): Allowed population deviation as a percentage of the target population.
+        node_repeats (int, optional): Additional roots to try on each spanning tree before drawing
+            a new tree. Defaults to 0. Positive values help only with cut finders whose result
+            depends on the root; see :func:`~gerrychain.tree.bipartition_tree`.
+        region_surcharge (dict | None, optional): Surcharges for region-aware chains; see
+            :func:`~gerrychain.tree.random_spanning_tree`. Default is None.
+        bipartition_tree_fn (ReComBipartitionTreeFn, optional): The function used to split the
+            merged district pair. To configure the bipartition or spanning-tree step (for example
+            ``max_attempts``, ``allow_pair_reselection``, or a uniform spanning tree), pass a
+            pre-bound function such as ``partial(bipartition_tree, max_attempts=100)``.
+        pair_selection ("district_pairs" | "cut_edges", optional): How to choose the adjacent
+            district pair to merge. ``"district_pairs"`` (default) draws uniformly among adjacent
+            pairs; ``"cut_edges"`` weights each pair by the number of cut edges it shares.
+
+    Returns:
+        ProposalFn: A proposal function for use with :class:`~gerrychain.MarkovChain`.
+    """
     proposal_fn = partial(
         recom,
         pop_col=pop_col,
@@ -375,7 +401,7 @@ def reversible_recom(
 
     def _bounded_find_balanced_edge_cuts_fn(
         h: _PopulatedGraph,
-        one_sided_cut: bool = False,
+        single_district_cut: bool = False,
         rootnode_choice_fn: Callable[[Sequence[Hashable]], Hashable] | None = None,
         *,
         rng: random.Random,
@@ -384,7 +410,7 @@ def reversible_recom(
             rootnode_choice_fn = rng.choice
         cuts = find_balanced_edge_cuts_fn(
             h,
-            one_sided_cut=one_sided_cut,
+            single_district_cut=single_district_cut,
             rootnode_choice_fn=rootnode_choice_fn,
             rng=rng,
         )
@@ -492,6 +518,27 @@ def build_reversible_recom_proposal_fn(
     find_balanced_edge_cuts_fn: FindBalancedEdgeCutsFn = find_balanced_edge_cuts_memoization,
     repeat_until_valid: bool = False,
 ) -> ProposalFn:
+    """Build a reversible ReCom proposal function with its configuration bound.
+
+    Reversible ReCom samples exactly from the spanning-tree distribution rather than an
+    approximation of it; see :func:`reversible_recom`. This builder exposes every option except
+    ``partition`` and ``rng``, which :class:`~gerrychain.MarkovChain` supplies at each step.
+
+    Args:
+        pop_col (str): The name of the population column.
+        pop_target (int | float): The target population for each district.
+        epsilon (float): Allowed population deviation as a percentage of the target population.
+        max_balanced_edge_cuts (int): The number of balanced edge cuts to draw from the spanning
+            tree before selecting one, which is what makes the proposal reversible. The proposal
+            raises :class:`ReversibilityError` if a tree exceeds this bound.
+        find_balanced_edge_cuts_fn (FindBalancedEdgeCutsFn, optional): The balanced-cut finder.
+            Default is :func:`~gerrychain.tree.find_balanced_edge_cuts_memoization`.
+        repeat_until_valid (bool, optional): Whether to keep drawing until a valid partition is
+            found. Default is False.
+
+    Returns:
+        ProposalFn: A proposal function for use with :class:`~gerrychain.MarkovChain`.
+    """
     proposal_fn = partial(
         reversible_recom,
         pop_col=pop_col,

--- a/gerrychain/tree/bipartition_tree.py
+++ b/gerrychain/tree/bipartition_tree.py
@@ -169,22 +169,23 @@ class _PopulatedGraph:
 
     # frm: only ever used inside this file
     #       But maybe this is intended to be used externally...
-    def has_ideal_population(self, node: Hashable, one_sided_cut: bool = False) -> bool:
+    def has_ideal_population(self, node: Hashable, single_district_cut: bool = False) -> bool:
         """Checks if a merged node is within epsilon of the ideal population.
 
         Args:
             node (Hashable): The node to check.
-            one_sided_cut (bool, optional): Whether or not we are cutting off a single district.
-                When set to False, we check if the node we are cutting and the remaining graph are
-                both within epsilon of the ideal population. When set to True, we only check if the
-                node we are cutting is within epsilon of the ideal population. Defaults to False.
+            single_district_cut (bool, optional): Whether or not we are cutting off a single
+                district. When set to False, we check if the node we are cutting and the remaining
+                graph are both within epsilon of the ideal population. When set to True, we only
+                check if the node we are cutting is within epsilon of the ideal population.
+                Defaults to False.
 
         Returns:
             bool: True if the node has an ideal population within the graph up to epsilon.
         """
 
-        if one_sided_cut:
-            return abs(self.population[node] - self.ideal_pop) < self.epsilon * self.ideal_pop
+        if single_district_cut:
+            return abs(self.population[node] - self.ideal_pop) <= self.epsilon * self.ideal_pop
 
         return (
             abs(self.population[node] - self.ideal_pop) <= self.epsilon * self.ideal_pop
@@ -229,21 +230,53 @@ class _Cut(NamedTuple):
     subset: frozenset[Hashable]
 
 
-# Define an interface for find_balanced_edge_cut functions
-#
-# frm: TODO: Documentation: Add documentation for find_balanced_edge_cut_fn()
-#
-# The whole point is to make it clear to the user that this is a thing, so tell
-# them what kind of thing it is - and what the params are for...
-#
 class FindBalancedEdgeCutsFn(Protocol):
+    """Enumerates the population-balanced cuts of an already-drawn spanning tree.
+
+    A bipartition function draws a spanning tree, calls one of these to find every edge whose
+    removal leaves acceptable populations, and then hands the result to a :class:`CutChoiceFn` to
+    pick one. :func:`find_balanced_edge_cuts_memoization` and
+    :func:`find_balanced_edge_cuts_contraction` both match this shape.
+
+    Args:
+        h (_PopulatedGraph): The spanning tree annotated with node populations, the ideal
+            population, and the allowed epsilon.
+        single_district_cut (bool, optional): When False, both sides of the cut must be within
+            epsilon of the ideal population. When True, only the returned side must be, which is
+            what lets callers peel off a single district of a given size. Default is False.
+        rootnode_choice_fn (Callable | None, optional): Chooses the root to hang the tree from,
+            given the candidate nodes. Defaults to a uniform random choice. Finders that examine
+            every edge regardless of root ignore this.
+        rng (random.Random): The RNG supplied by the owning operation.
+
+    Returns:
+        list[_Cut]: Every balanced cut found, which may be empty if the tree admits none.
+    """
+
     def __call__(
         self,
         h: _PopulatedGraph,
-        one_sided_cut: bool = False,
-        rootnode_choice_fn: Callable[[Sequence[Hashable]], Hashable] | None = None,
+        /,
         *,
+        single_district_cut: bool = False,
+        rootnode_choice_fn: Callable[[Sequence[Hashable]], Hashable] | None = None,
         rng: random.Random,
+    ) -> list[_Cut]: ...
+
+
+class _BoundFindBalancedEdgeCutsFn(Protocol):
+    """A :class:`FindBalancedEdgeCutsFn` with ``single_district_cut`` and ``rng`` already bound.
+
+    :func:`bipartition_tree` binds those two before handing the finder to the retry loop, which
+    then varies only the root choice between attempts.
+    """
+
+    def __call__(
+        self,
+        h: _PopulatedGraph,
+        /,
+        *,
+        rootnode_choice_fn: Callable[[Sequence[Hashable]], Hashable] | None = None,
     ) -> list[_Cut]: ...
 
 
@@ -264,7 +297,7 @@ class BipartitionTreeFn(Protocol):
         pop_target: float,
         epsilon: float,
         node_repeats: int = 0,
-        one_sided_cut: bool = False,
+        single_district_cut: bool = False,
         rng: random.Random,
     ) -> AbstractSet[Hashable]: ...
 
@@ -285,7 +318,7 @@ class ReComBipartitionTreeFn(Protocol):
         pop_target: float,
         epsilon: float,
         node_repeats: int = 0,
-        one_sided_cut: bool = False,
+        single_district_cut: bool = False,
         region_surcharge: dict[str, float] | None = None,
         rng: random.Random,
     ) -> AbstractSet[Hashable]: ...
@@ -370,7 +403,7 @@ def _bfs_predecessors_and_successors_for_tree(
 
 def find_balanced_edge_cuts_contraction(
     h: _PopulatedGraph,
-    one_sided_cut: bool = False,
+    single_district_cut: bool = False,
     rootnode_choice_fn: Callable[[Sequence[Hashable]], Hashable] | None = None,
     *,
     rng: random.Random | int | None = None,
@@ -380,8 +413,8 @@ def find_balanced_edge_cuts_contraction(
 
     Args:
         h (_PopulatedGraph): The populated graph.
-        one_sided_cut (bool, optional): Whether or not we are cutting off a single district. When
-            set to False, we check if the node we are cutting and the remaining graph are both
+        single_district_cut (bool, optional): Whether or not we are cutting off a single district.
+            When set to False, we check if the node we are cutting and the remaining graph are both
             within epsilon of the ideal population. When set to True, we only check if the node we
             are cutting is within epsilon of the ideal population. Defaults to False.
         rootnode_choice_fn (Callable | None): The function used to select the root node_id.
@@ -421,9 +454,9 @@ def find_balanced_edge_cuts_contraction(
     leaves = deque(node_id for node_id in node_ids if h.degree(node_id) == 1)
     while len(leaves) > 0:
         leaf = leaves.popleft()
-        if h.has_ideal_population(leaf, one_sided_cut=one_sided_cut):
+        if h.has_ideal_population(leaf, single_district_cut=single_district_cut):
             # frm: If the population of the subtree rooted in this node is the correct
-            #       size, then add it to the cut list.  Note that if one_sided_cut == False,
+            #       size, then add it to the cut list.  Note that if single_district_cut == False,
             #       then the cut means the cut bisects the graph of the spanning tree.
             e = (leaf, pred[leaf])
             cuts.append(
@@ -552,7 +585,7 @@ def _nodes_in_subtree(start: Hashable, succ: dict[Hashable, list[Hashable]]) -> 
 # frm: used externally by tree_proposals.py
 def find_balanced_edge_cuts_memoization(
     h: _PopulatedGraph,
-    one_sided_cut: bool = False,
+    single_district_cut: bool = False,
     rootnode_choice_fn: Callable[[Sequence[Hashable]], Hashable] | None = None,
     *,
     rng: random.Random | int | None = None,
@@ -566,8 +599,8 @@ def find_balanced_edge_cuts_memoization(
 
     Args:
         h (_PopulatedGraph): The _PopulatedGraph object representing the graph.
-        one_sided_cut (bool, optional): Whether or not we are cutting off a single district. When
-            set to False, we check if the node we are cutting and the remaining graph are both
+        single_district_cut (bool, optional): Whether or not we are cutting off a single district.
+            When set to False, we check if the node we are cutting and the remaining graph are both
             within epsilon of the ideal population. When set to True, we only check if the node we
             are cutting is within epsilon of the ideal population. Defaults to False.
         rootnode_choice_fn (Callable | None): The choice function used to select the root
@@ -583,7 +616,7 @@ def find_balanced_edge_cuts_memoization(
     frm: ???: confused...
 
     This function seems to be used for two very different purposes, depending on the
-    value of the parameter, one_sided_cut.  When true, the code looks for lots of cuts
+    value of the parameter, single_district_cut.  When true, the code looks for lots of cuts
     that would create a district with the right population - both above and below the
     node being considered.  Given that it is operating on a tree, one would assume that
     there is only one (or perhaps two if one node's population was tiny) cut for the top
@@ -623,7 +656,7 @@ def find_balanced_edge_cuts_memoization(
 
     cuts = []
 
-    if one_sided_cut:
+    if single_district_cut:
         for node, tree_pop in subtree_pops.items():
             if abs(tree_pop - h.ideal_pop) <= h.ideal_pop * h.epsilon:
                 # frm: If the subtree for this node has a population within epsilon
@@ -658,7 +691,7 @@ def find_balanced_edge_cuts_memoization(
 
         return cuts
 
-    # We are looking for a way to bisect the graph (one_sided_cut is False)
+    # We are looking for a way to bisect the graph (single_district_cut is False)
     for node, tree_pop in subtree_pops.items():
         if (abs(tree_pop - h.ideal_pop) <= h.ideal_pop * h.epsilon) and (
             abs((total_pop - tree_pop) - h.ideal_pop) <= h.ideal_pop * h.epsilon
@@ -882,8 +915,8 @@ def _internal_bipartition_tree(
     spanning_tree_fn: SpanningTreeFn = random_spanning_tree,
     region_surcharge: dict[str, float] | None = None,
     spanning_tree_fn_kwargs: Mapping[str, object] | None = None,
-    find_balanced_edge_cuts_fn: Callable[..., list[_Cut]] = find_balanced_edge_cuts_memoization,
-    one_sided_cut: bool = False,
+    find_balanced_edge_cuts_fn: FindBalancedEdgeCutsFn = find_balanced_edge_cuts_memoization,
+    single_district_cut: bool = False,
     rootnode_choice_fn: Callable[[Sequence[Hashable]], Hashable] | None = None,
     max_attempts: int = 100000,
     warn_attempts: int = 1000,
@@ -926,10 +959,12 @@ def _internal_bipartition_tree(
             verbatim to ``spanning_tree_fn``. Use this to set function-specific options that are
             not named here, e.g. ``{"treat_unassigned_as_single_region": True}`` for
             ``random_spanning_tree``. Defaults to None.
-        find_balanced_edge_cuts_fn (Callable, optional): The function to find balanced edge cuts.
-            Defaults to `find_balanced_edge_cuts_memoization`.
-        one_sided_cut (bool, optional): Passed to the ``find_balanced_edge_cuts_fn``. Determines
-            whether or not we are cutting off a single district when partitioning the tree. When
+        find_balanced_edge_cuts_fn (FindBalancedEdgeCutsFn, optional): The function to find
+            balanced edge cuts. Defaults to `find_balanced_edge_cuts_memoization`. A custom
+            finder must accept ``single_district_cut``, ``rootnode_choice_fn``, and ``rng`` as
+            keyword arguments; see :class:`FindBalancedEdgeCutsFn`.
+        single_district_cut (bool, optional): Passed to the ``find_balanced_edge_cuts_fn``.
+            Determines whether we are cutting off a single district when partitioning the tree. When
             set to False, we check if the node we are cutting and the remaining graph are both
             within epsilon of the ideal population. When set to True, we only check if the node we
             are cutting is within epsilon of the ideal population. Defaults to False.
@@ -1001,11 +1036,9 @@ def _internal_bipartition_tree(
         **(spanning_tree_fn_kwargs or {}),
     )
 
-    if "one_sided_cut" in signature(find_balanced_edge_cuts_fn).parameters:
-        find_balanced_edge_cuts_fn = partial(
-            find_balanced_edge_cuts_fn, one_sided_cut=one_sided_cut
-        )
-    find_balanced_edge_cuts_fn = partial(find_balanced_edge_cuts_fn, rng=rng)
+    bound_find_balanced_edge_cuts_fn: _BoundFindBalancedEdgeCutsFn = partial(
+        find_balanced_edge_cuts_fn, single_district_cut=single_district_cut, rng=rng
+    )
 
     # Find possible edge cuts if they exist.
     #
@@ -1020,7 +1053,7 @@ def _internal_bipartition_tree(
         node_repeats=node_repeats,
         spanning_tree=spanning_tree,
         spanning_tree_fn=spanning_tree_fn,
-        find_balanced_edge_cuts_fn=find_balanced_edge_cuts_fn,
+        find_balanced_edge_cuts_fn=bound_find_balanced_edge_cuts_fn,
         rootnode_choice_fn=rootnode_choice_fn,
         max_attempts=max_attempts,
         warn_attempts=warn_attempts,
@@ -1085,8 +1118,8 @@ def bipartition_tree(
     spanning_tree_fn: SpanningTreeFn = random_spanning_tree,
     region_surcharge: dict[str, float] | None = None,
     spanning_tree_fn_kwargs: Mapping[str, object] | None = None,
-    find_balanced_edge_cuts_fn: Callable[..., list[_Cut]] = find_balanced_edge_cuts_memoization,
-    one_sided_cut: bool = False,
+    find_balanced_edge_cuts_fn: FindBalancedEdgeCutsFn = find_balanced_edge_cuts_memoization,
+    single_district_cut: bool = False,
     rootnode_choice_fn: Callable[[Sequence[Hashable]], Hashable] | None = None,
     repeat_until_valid: bool = True,
     max_attempts: int = 100000,
@@ -1129,10 +1162,12 @@ def bipartition_tree(
             to ``spanning_tree_fn``. Use this to set function-specific options that are not named
             here, e.g. ``{"treat_unassigned_as_single_region": True}`` for ``random_spanning_tree``.
             Defaults to None.
-        find_balanced_edge_cuts_fn (Callable, optional): The function to find balanced edge cuts.
-            Defaults to `find_balanced_edge_cuts_memoization`.
-        one_sided_cut (bool, optional): Passed to the ``find_balanced_edge_cuts_fn``. Determines
-            whether or not we are cutting off a single district when partitioning the tree. When
+        find_balanced_edge_cuts_fn (FindBalancedEdgeCutsFn, optional): The function to find
+            balanced edge cuts. Defaults to `find_balanced_edge_cuts_memoization`. A custom
+            finder must accept ``single_district_cut``, ``rootnode_choice_fn``, and ``rng`` as
+            keyword arguments; see :class:`FindBalancedEdgeCutsFn`.
+        single_district_cut (bool, optional): Passed to the ``find_balanced_edge_cuts_fn``.
+            Determines whether we are cutting off a single district when partitioning the tree. When
             set to False, we check if the node we are cutting and the remaining graph are both
             within epsilon of the ideal population. When set to True, we only check if the node we
             are cutting is within epsilon of the ideal population. Defaults to False.
@@ -1177,7 +1212,7 @@ def bipartition_tree(
         region_surcharge=region_surcharge,
         spanning_tree_fn_kwargs=spanning_tree_fn_kwargs,
         find_balanced_edge_cuts_fn=find_balanced_edge_cuts_fn,
-        one_sided_cut=one_sided_cut,
+        single_district_cut=single_district_cut,
         rootnode_choice_fn=rootnode_choice_fn,
         max_attempts=max_attempts,
         warn_attempts=warn_attempts,
@@ -1218,7 +1253,7 @@ def _get_possible_edge_cuts_and_populated_graph(
     node_repeats: int = 0,
     spanning_tree: GraphLike | None = None,
     spanning_tree_fn: SpanningTreeFn = random_spanning_tree,
-    find_balanced_edge_cuts_fn: Callable[..., list[_Cut]] = find_balanced_edge_cuts_memoization,
+    find_balanced_edge_cuts_fn: _BoundFindBalancedEdgeCutsFn = find_balanced_edge_cuts_memoization,
     rootnode_choice_fn: Callable[[Sequence[Hashable]], Hashable] | None = None,
     repeat_until_valid: bool = True,
     warn_attempts: int = 1000,
@@ -1296,6 +1331,8 @@ def _get_possible_edge_cuts_and_populated_graph(
         # each time...
         #
 
+        # Only forward rootnode_choice_fn when the caller set one: passing None explicitly would
+        # override a custom finder's own default root chooser.
         kwargs = {}
         if rootnode_choice_fn is not None:
             kwargs["rootnode_choice_fn"] = rootnode_choice_fn
@@ -1363,8 +1400,8 @@ def bipartition_tree_random_with_num_cuts(
     repeat_until_valid: bool = True,
     spanning_tree: GraphLike | None = None,
     spanning_tree_fn: SpanningTreeFn = random_spanning_tree,
-    find_balanced_edge_cuts_fn: Callable[..., list[_Cut]] = find_balanced_edge_cuts_memoization,
-    one_sided_cut: bool = False,
+    find_balanced_edge_cuts_fn: FindBalancedEdgeCutsFn = find_balanced_edge_cuts_memoization,
+    single_district_cut: bool = False,
     rootnode_choice_fn: Callable[[Sequence[Hashable]], Hashable] | None = None,
     max_attempts: int = 100000,
     cut_choice_fn: CutChoiceFn | RegionAwareCutChoiceFn | None = None,
@@ -1397,10 +1434,12 @@ def bipartition_tree_random_with_num_cuts(
             when the algorithm chooses a new root and for testing). Defaults to None.
         spanning_tree_fn (Callable, optional): The random spanning tree algorithm to use if a
             spanning tree is not provided. Defaults to `random_spanning_tree`.
-        find_balanced_edge_cuts_fn (Callable, optional): The algorithm used to find balanced cut
-            edges. Defaults to `find_balanced_edge_cuts_memoization`.
-        one_sided_cut (bool, optional): Passed to the ``find_balanced_edge_cuts_fn``. Determines
-            whether or not we are cutting off a single district when partitioning the tree. When
+        find_balanced_edge_cuts_fn (FindBalancedEdgeCutsFn, optional): The algorithm used to find
+            balanced cut edges. Defaults to `find_balanced_edge_cuts_memoization`. A custom finder
+            must accept ``single_district_cut``, ``rootnode_choice_fn``, and ``rng`` as keyword
+            arguments; see :class:`FindBalancedEdgeCutsFn`.
+        single_district_cut (bool, optional): Passed to the ``find_balanced_edge_cuts_fn``.
+            Determines whether we are cutting off a single district when partitioning the tree. When
             set to False, we check if the node we are cutting and the remaining graph are both
             within epsilon of the ideal population. When set to True, we only check if the node we
             are cutting is within epsilon of the ideal population. Defaults to False.
@@ -1436,7 +1475,7 @@ def bipartition_tree_random_with_num_cuts(
         spanning_tree_fn=spanning_tree_fn,
         # region_surcharge: dict[str, float] | None = None,
         find_balanced_edge_cuts_fn=find_balanced_edge_cuts_fn,
-        one_sided_cut=one_sided_cut,
+        single_district_cut=single_district_cut,
         rootnode_choice_fn=rootnode_choice_fn,
         max_attempts=max_attempts,
         # warn_attempts: int = 1000,

--- a/gerrychain/tree/bipartition_tree.py
+++ b/gerrychain/tree/bipartition_tree.py
@@ -167,6 +167,21 @@ class _PopulatedGraph:
         self.subsets[parent] |= self.subsets[node]
         self._degrees[parent] -= 1
 
+    def is_within_epsilon(self, population: int | float) -> bool:
+        """Return whether a population is within epsilon of the ideal district population.
+
+        This is the single definition of "balanced" used by both cut finders. Keeping it in one
+        place matters: the bound is inclusive, and when the two finders spelled the comparison out
+        separately they disagreed about whether an exactly-on-target cut counted.
+
+        Args:
+            population (int | float): The population to test.
+
+        Returns:
+            bool: True if the population is acceptable.
+        """
+        return abs(population - self.ideal_pop) <= self.epsilon * self.ideal_pop
+
     # frm: only ever used inside this file
     #       But maybe this is intended to be used externally...
     def has_ideal_population(self, node: Hashable, single_district_cut: bool = False) -> bool:
@@ -183,14 +198,12 @@ class _PopulatedGraph:
         Returns:
             bool: True if the node has an ideal population within the graph up to epsilon.
         """
-
+        node_population = self.population[node]
         if single_district_cut:
-            return abs(self.population[node] - self.ideal_pop) <= self.epsilon * self.ideal_pop
+            return self.is_within_epsilon(node_population)
 
-        return (
-            abs(self.population[node] - self.ideal_pop) <= self.epsilon * self.ideal_pop
-            and abs((self.tot_pop - self.population[node]) - self.ideal_pop)
-            <= self.epsilon * self.ideal_pop
+        return self.is_within_epsilon(node_population) and self.is_within_epsilon(
+            self.tot_pop - node_population
         )
 
     def __repr__(self) -> str:
@@ -430,6 +443,11 @@ def find_balanced_edge_cuts_contraction(
         rootnode_choice_fn = rng.choice
 
     node_ids = h.graph.nodes if h.graph.is_nx_graph() else h.graph.node_indices
+
+    # NOTE: The root must have degree > 1 here: the loop below seeds its queue from every degree-1
+    # node and then looks up `pred[leaf]`. A leaf root would land in that queue without having a
+    # parent, raising KeyError. On a two-node tree both nodes are leaves, so nothing qualifies and
+    # `rng.choice` raises IndexError.
     root = rootnode_choice_fn([node_id for node_id in node_ids if h.degree(node_id) > 1])
     # Parent map for iteratively contracting leaves. This used to call h.graph.predecessors(root)
     pred, _ = _bfs_predecessors_and_successors_for_tree(h.graph, root)
@@ -612,37 +630,19 @@ def find_balanced_edge_cuts_memoization(
         list[_Cut]: A list of balanced edge cuts.
     """
 
-    """
-    frm: ???: confused...
-
-    This function seems to be used for two very different purposes, depending on the
-    value of the parameter, single_district_cut.  When true, the code looks for lots of cuts
-    that would create a district with the right population - both above and below the
-    node being considered.  Given that it is operating on a tree, one would assume that
-    there is only one (or perhaps two if one node's population was tiny) cut for the top
-    of the tree, but there should be many for the bottom of the tree.
-
-    However, if the paramter is set to false (the default), then the code checks to see
-    whether a cut would produce two districts - on above and one below the tree that
-    have the right populations.  In this case, the code is presumatly looking for the
-    single node (again there might be two if one node's population was way below epsilon)
-    that would bisect the graph into two districts with a tolerable population.
-
-    If I am correct, then there is an opportunity to clarify these two uses - perhaps
-    with wrapper functions.  I am also a bit surprised that snippets of code are repeated.
-    Again - this causes mental load for the reader, and it is an opportunity for bugs to
-    creep in later (you fix it in one place but not the other).  Not sure this "clarification"
-    is desired, but it is worth considering...
-    """
-
-    # frm: ???:  Why does a root have to have degree > 1?  I would think that any node would do...
-
     rng = make_rng(rng)
     if rootnode_choice_fn is None:
         rootnode_choice_fn = rng.choice
 
     node_ids = h.graph.nodes if h.graph.is_nx_graph() else h.graph.node_indices
-    root = rootnode_choice_fn([node_id for node_id in node_ids if h.degree(node_id) > 1])
+
+    # NOTE: Any node may serve as the root. Every non-root node contributes the one edge joining it
+    # to its parent, and a tree on n nodes has n - 1 of each, so the candidate edges are all of them
+    # wherever we root. The root only decides which side of an edge counts as "below", and so which
+    # side a cut hands back. `find_balanced_edge_cuts_contraction` is different: it requires a root
+    # of degree > 1, because it seeds its worklist from every degree-1 node and then looks up
+    # `pred[leaf]`, which a leaf root would not have.
+    root = rootnode_choice_fn(list(node_ids))
 
     # Parent and child maps for the tree rooted at `root`. For a tree each non-root node has a
     # unique parent, so `pred` is identical to the old map; the order of children within
@@ -654,60 +654,49 @@ def find_balanced_edge_cuts_memoization(
     # Calculate the population of each subtree in the "succ" tree
     subtree_pops = _calc_pops(succ, root, h)
 
+    def cut_at(node: Hashable, subset: AbstractSet[Hashable]) -> _Cut:
+        """Build the cut that removes the edge joining ``node`` to its parent.
+
+        ``subset`` is the side of that edge the cut hands back. The edge keeps whatever
+        ``random_weight`` the spanning tree gave it, falling back to a fresh draw. Note that the
+        draw happens either way, so the RNG advances once per cut found.
+        """
+        edge = (node, pred[node])
+        fallback_weight = rng.random()
+        return _Cut(
+            edge=edge,
+            weight=h.graph.edge_data(h.graph.get_edge_id_from_edge(edge)).get(
+                "random_weight", fallback_weight
+            ),
+            subset=frozenset(subset),
+        )
+
+    def below(node: Hashable) -> AbstractSet[Hashable]:
+        """The subtree hanging below ``node``, including ``node`` itself."""
+        return _nodes_in_subtree(node, succ)
+
+    def above(node: Hashable) -> AbstractSet[Hashable]:
+        """Everything except the subtree below ``node``."""
+        return set(h.graph.node_indices) - _nodes_in_subtree(node, succ)
+
     cuts = []
 
     if single_district_cut:
+        # Peeling off one district: only the side we hand back has to be balanced, so a node
+        # qualifies if either the subtree below it or everything above it hits the target. The
+        # remainder is left for later cuts to divide.
         for node, tree_pop in subtree_pops.items():
-            if abs(tree_pop - h.ideal_pop) <= h.ideal_pop * h.epsilon:
-                # frm: If the subtree for this node has a population within epsilon
-                #       of the ideal, then add it to the cuts list.
-                e = (node, pred[node])  # get the edge from the parent to this node
-                wt = rng.random()
-                # frm: Add the cut - set its weight if it does not already have one
-                #       and remember all of the nodes in the subtree in the frozenset
-                cuts.append(
-                    _Cut(
-                        edge=e,
-                        weight=h.graph.edge_data(h.graph.get_edge_id_from_edge(e)).get(
-                            "random_weight", wt
-                        ),
-                        subset=frozenset(_nodes_in_subtree(node, succ)),
-                    )
-                )
-            elif abs((total_pop - tree_pop) - h.ideal_pop) <= h.ideal_pop * h.epsilon:
-                # frm: If the population of everything ABOVE this node in the tree is
-                #       within epsilon of the ideal, then add it to the cut list too.
-                e = (node, pred[node])
-                wt = rng.random()
-                cuts.append(
-                    _Cut(
-                        edge=e,
-                        weight=h.graph.edge_data(h.graph.get_edge_id_from_edge(e)).get(
-                            "random_weight", wt
-                        ),
-                        subset=frozenset(set(h.graph.node_indices) - _nodes_in_subtree(node, succ)),
-                    )
-                )
+            if h.is_within_epsilon(tree_pop):
+                cuts.append(cut_at(node, below(node)))
+            elif h.is_within_epsilon(total_pop - tree_pop):
+                cuts.append(cut_at(node, above(node)))
+    else:
+        # Bisecting the tree: both sides have to be balanced at once, which is a much stricter
+        # test and typically admits far fewer cuts.
+        for node, tree_pop in subtree_pops.items():
+            if h.is_within_epsilon(tree_pop) and h.is_within_epsilon(total_pop - tree_pop):
+                cuts.append(cut_at(node, above(node)))
 
-        return cuts
-
-    # We are looking for a way to bisect the graph (single_district_cut is False)
-    for node, tree_pop in subtree_pops.items():
-        if (abs(tree_pop - h.ideal_pop) <= h.ideal_pop * h.epsilon) and (
-            abs((total_pop - tree_pop) - h.ideal_pop) <= h.ideal_pop * h.epsilon
-        ):
-            e = (node, pred[node])
-            wt = rng.random()
-            # frm: TODO: Performance: Think if code below can be made faster...
-            cuts.append(
-                _Cut(
-                    edge=e,
-                    weight=h.graph.edge_data(h.graph.get_edge_id_from_edge(e)).get(
-                        "random_weight", wt
-                    ),
-                    subset=frozenset(set(h.graph.node_indices) - _nodes_in_subtree(node, succ)),
-                )
-            )
     return cuts
 
 

--- a/tests/test_proposals.py
+++ b/tests/test_proposals.py
@@ -413,7 +413,7 @@ def test_multi_member_recom_passes_region_surcharge_to_tree():
         pop_target: float,
         epsilon: float,
         node_repeats: int = 0,
-        one_sided_cut: bool = False,
+        single_district_cut: bool = False,
         region_surcharge: dict[str, float] | None = None,
         rng: random.Random,
     ) -> AbstractSet[Hashable]:
@@ -424,7 +424,7 @@ def test_multi_member_recom_passes_region_surcharge_to_tree():
             pop_target=pop_target,
             epsilon=epsilon,
             node_repeats=node_repeats,
-            one_sided_cut=one_sided_cut,
+            single_district_cut=single_district_cut,
             region_surcharge=region_surcharge,
             rng=rng,
         )
@@ -529,7 +529,7 @@ def test_multi_member_bipartition_rejects_out_of_range_custom_cut():
         pop_target: float,
         epsilon: float,
         node_repeats: int = 0,
-        one_sided_cut: bool = False,
+        single_district_cut: bool = False,
         rng: random.Random,
     ) -> AbstractSet[Hashable]:
         return frozenset()
@@ -567,7 +567,7 @@ def test_multi_member_recom_reselects_after_tree_failure(
         pop_target: float,
         epsilon: float,
         node_repeats: int = 0,
-        one_sided_cut: bool = False,
+        single_district_cut: bool = False,
         region_surcharge: dict[str, float] | None = None,
         allow_pair_reselection: bool = False,
         rng: random.Random,

--- a/tests/test_reproducibility.py
+++ b/tests/test_reproducibility.py
@@ -334,5 +334,5 @@ def test_pa_freeze():
     # tests around. Captured with rng=2018; independent of PYTHONHASHSEED.
     assert (
         hashlib.sha256(result.encode()).hexdigest()
-        == "9308a9251f89c58630b68fb4aefadb5923a8c566d129ad4c20af63d53075e8ae"
+        == "2e164b86345d27f905e4f4fad7d54fb7d140908be60ac7e43e93e616ce7931f5"
     )

--- a/tests/test_tree.py
+++ b/tests/test_tree.py
@@ -38,6 +38,7 @@ from gerrychain.tree import (
 from gerrychain.tree.bipartition_tree import (
     FindBalancedEdgeCutsFn,
     GraphLike,
+    _Cut,
     _PopulatedGraph,
 )
 from gerrychain.updaters import Tally, cut_edges
@@ -383,7 +384,7 @@ def do_test_recursive_seed_part_uses_bipartition_tree_fn(twelve_by_twelve_with_p
         pop_target: float,
         epsilon: float,
         node_repeats: int = 0,
-        one_sided_cut: bool = False,
+        single_district_cut: bool = False,
         region_surcharge: dict[str, float] | None = None,
         *,
         rng: random.Random,
@@ -397,7 +398,7 @@ def do_test_recursive_seed_part_uses_bipartition_tree_fn(twelve_by_twelve_with_p
             epsilon=epsilon,
             node_repeats=node_repeats,
             max_attempts=10000,
-            one_sided_cut=one_sided_cut,
+            single_district_cut=single_district_cut,
             rng=rng,
         )
 
@@ -537,13 +538,16 @@ def test_bipartition_tree_threads_rng_to_custom_balanced_cut_fn(graph_with_pop_n
 
     def find_cuts(
         h: _PopulatedGraph,
-        rootnode_choice_fn: Callable[[Sequence[Hashable]], Hashable] = choose_root,
+        /,
         *,
+        single_district_cut: bool = False,
+        rootnode_choice_fn: Callable[[Sequence[Hashable]], Hashable] | None = choose_root,
         rng: random.Random,
-    ):
+    ) -> list[_Cut]:
         seen_rngs.append(rng)
         return find_balanced_edge_cuts_memoization(
             h,
+            single_district_cut=single_district_cut,
             rootnode_choice_fn=rootnode_choice_fn,
             rng=rng,
         )
@@ -773,14 +777,34 @@ def test_no_balanced_cuts_contraction_when_one_side_okay():
     )
 
     cuts_nx = find_balanced_edge_cuts_contraction(
-        populated_tree_nx, one_sided_cut=False, rng=random.Random(2018)
+        populated_tree_nx, single_district_cut=False, rng=random.Random(2018)
     )
     assert cuts_nx == []
 
     cuts_rx = find_balanced_edge_cuts_contraction(
-        populated_tree_rx, one_sided_cut=False, rng=random.Random(2018)
+        populated_tree_rx, single_district_cut=False, rng=random.Random(2018)
     )
     assert cuts_rx == []
+
+
+def test_exact_population_cut_is_accepted_on_both_branches():
+    """An exactly-on-target cut must be accepted whether or not the complement is checked.
+
+    The two branches of `_PopulatedGraph.has_ideal_population` once disagreed here: the
+    single-district branch used a strict `<`, so at epsilon=0 a perfectly even split passed the
+    two-sided check but failed the single-district one.
+    """
+    pair = Graph.from_networkx(networkx.Graph([(0, 1)]))
+    # Both nodes sit exactly on the ideal population, so either side is a perfect cut.
+    populated = _PopulatedGraph(
+        graph=pair,
+        populations={0: 5, 1: 5},
+        ideal_pop=5,
+        epsilon=0,
+    )
+
+    assert populated.has_ideal_population(0, single_district_cut=False)
+    assert populated.has_ideal_population(0, single_district_cut=True)
 
 
 def test_find_balanced_cuts_memo():

--- a/tests/typing_assertions.py
+++ b/tests/typing_assertions.py
@@ -104,7 +104,7 @@ def assert_callable_types() -> None:
         pop_target: float,
         epsilon: float,
         node_repeats: int = 0,
-        one_sided_cut: bool = False,
+        single_district_cut: bool = False,
         rng: random.Random,
     ) -> frozenset[Hashable]:
         return frozenset()


### PR DESCRIPTION
## Summary

Don't worry about the docs failing for now.

Correctness and readability work on the balanced-edge-cut finders in `bipartition_tree.py`: renames
`one_sided_cut` to `single_district_cut`, fixes a comparison that disagreed between the two finders,
refactors the memoized finder, and finishes the `FindBalancedEdgeCutsFn` typing and docs. Stacks on
`feat/multi-member-recom`.

## Why

The two cut finders had drifted apart in a way that was easy to miss because the balanced-population
test was spelled out separately in each. The `one_sided_cut` parameter also described the cut rather
than what the flag actually controls, and the memoized finder was hard to follow (a mid-function
return and three near-identical `_Cut` constructions).

## Changes

- Renamed `one_sided_cut` to `single_district_cut` everywhere. The flag controls whether only the
  returned side must be balanced (peeling off one district) or both sides must be (bisecting); the
  new name matches what the docstrings already said.
- Fixed `_PopulatedGraph.has_ideal_population`, whose single-district branch used a strict `<` while
  its two-sided branch used `<=`, so an exactly-on-target cut at `epsilon=0` was accepted when
  bisecting but rejected when peeling. The single test is now defined once as
  `_PopulatedGraph.is_within_epsilon` and used by both finders.
- Refactored `find_balanced_edge_cuts_memoization` into a single `if`/`else` with one return, one
  `_Cut` helper, and named `below(node)`/`above(node)` sides, replacing the mid-function return and
  the duplicated construction.
- Applied `FindBalancedEdgeCutsFn` to the public `find_balanced_edge_cuts_fn` parameters, added a
  private `_BoundFindBalancedEdgeCutsFn` for the post-`partial` shape, and documented the
  degree-1 root requirement (needed by the contraction finder, not the memoized one).
- Dropped the memoized finder's root-degree filter, since any root yields the same candidate edges;
  this also lets it handle two-node trees the filter used to reject (very much an edge case).

## Testing

- [x] Tests pass locally
- [x] Added/updated tests
- [x] Type checks pass locally

Verified with `make test` (including the `--runslow` Pennsylvania freeze), `make lint`, and
`make type-check`. The memoization refactor was checked by diffing cut output (edges, subsets, and
RNG-derived weights) against the pre-refactor code across many seeds and graph shapes.

## Reviewer Notes

- **Breaking:** callers passing `one_sided_cut`, and custom cut finders accepting it, must use
  `single_district_cut`. Custom finders must now accept it unconditionally; the `inspect.signature`
  probe that made it optional has been removed. Will put in release notes.