### PR TITLE
Misc/add deprecation shims

### DIFF
--- a/gerrychain/_deprecated.py
+++ b/gerrychain/_deprecated.py
@@ -205,17 +205,28 @@ def allow_legacy_missing_rng(fn: Callable[P, R]) -> Callable[P, R]:
     return wrapped
 
 
-def deprecated_property(old_name: str, new_name: str) -> property:
+def deprecated_property(old_name: str, new_name: str, *, writable: bool = False) -> property:
     """Return a property forwarding a deprecated attribute name to its replacement."""
 
-    def get(instance: object) -> Any:
+    def warn() -> None:
         _warn(
             f"{old_name} is deprecated; use {new_name} instead. The legacy name will be removed "
-            "in GerryChain 2.0."
+            "in GerryChain 2.0.",
+            stacklevel=4,
         )
+
+    def get(instance: object) -> Any:
+        warn()
         return getattr(instance, new_name)
 
-    return property(get)
+    if not writable:
+        return property(get)
+
+    def set_(instance: object, value: Any) -> None:
+        warn()
+        setattr(instance, new_name, value)
+
+    return property(get, set_)
 
 
 def deprecated_lazy_alias(

--- a/gerrychain/_deprecated.py
+++ b/gerrychain/_deprecated.py
@@ -1,0 +1,301 @@
+"""Compatibility helpers for APIs deprecated after GerryChain 0.3.2."""
+
+from __future__ import annotations
+
+import functools
+import importlib
+import inspect
+import random
+import warnings
+from collections.abc import Callable, Collection, Mapping
+from typing import Any, ParamSpec, TypeVar, cast
+
+P = ParamSpec("P")
+R = TypeVar("R")
+
+
+def _warn(message: str, stacklevel: int = 3) -> None:
+    warnings.warn(message, DeprecationWarning, stacklevel=stacklevel)
+
+
+def deprecated_parameters(
+    renamed: Mapping[str, str] | None = None,
+    ignored: Mapping[str, str] | None = None,
+    defaults: Mapping[str, Any] | None = None,
+) -> Callable[[Callable[P, R]], Callable[P, R]]:
+    """Translate legacy keywords before calling a function with its canonical signature."""
+    renamed = {} if renamed is None else renamed
+    ignored = {} if ignored is None else ignored
+    defaults = {} if defaults is None else defaults
+
+    def decorate(fn: Callable[P, R]) -> Callable[P, R]:
+        signature = inspect.signature(fn)
+        fn_name = getattr(fn, "__qualname__", type(fn).__qualname__)
+
+        @functools.wraps(fn)
+        def wrapped(*args: P.args, **kwargs: P.kwargs) -> R:
+            mutable_kwargs = cast(dict[str, Any], kwargs)
+            for old_name, new_name in renamed.items():
+                if old_name not in mutable_kwargs:
+                    continue
+                if new_name in mutable_kwargs:
+                    raise TypeError(
+                        f"{fn_name} received both {old_name!r} and {new_name!r}; "
+                        f"use only {new_name!r}."
+                    )
+                mutable_kwargs[new_name] = mutable_kwargs.pop(old_name)
+                _warn(
+                    f"{fn_name}(..., {old_name}=...) is deprecated; use "
+                    f"{new_name}=... instead. The legacy name will be removed in GerryChain 2.0."
+                )
+
+            for name, reason in ignored.items():
+                if name not in mutable_kwargs:
+                    continue
+                mutable_kwargs.pop(name)
+                _warn(
+                    f"{fn_name}(..., {name}=...) is deprecated and ignored. {reason} "
+                    "The argument will be rejected in GerryChain 2.0."
+                )
+
+            if defaults:
+                bound = signature.bind_partial(*args, **mutable_kwargs)
+                for name, value in defaults.items():
+                    if name in bound.arguments:
+                        continue
+                    mutable_kwargs[name] = value
+                    _warn(
+                        f"{fn_name}() omitted {name!r}; using the legacy default {value!r}. "
+                        f"Pass {name}=... explicitly. The implicit default will be removed in "
+                        "GerryChain 2.0."
+                    )
+
+            return fn(*args, **mutable_kwargs)
+
+        return wrapped
+
+    return decorate
+
+
+def adapt_legacy_callable(
+    fn: Callable[..., R],
+    role: str,
+    renamed: Mapping[str, str] | None = None,
+    dropped: Collection[str] = (),
+) -> Callable[..., R]:
+    """Adapt an old callback to current keyword names and the keyword-only ``rng`` protocol."""
+    if getattr(fn, "__gerrychain_legacy_adapter__", False):
+        return fn
+
+    try:
+        parameters = inspect.signature(fn).parameters
+    except (TypeError, ValueError):
+        return fn
+
+    accepts_kwargs = any(
+        parameter.kind is inspect.Parameter.VAR_KEYWORD for parameter in parameters.values()
+    )
+    accepts_rng = accepts_kwargs or (
+        "rng" in parameters and parameters["rng"].kind is not inspect.Parameter.POSITIONAL_ONLY
+    )
+    reverse_renames = {
+        current: legacy
+        for current, legacy in ({} if renamed is None else renamed).items()
+        if not accepts_kwargs and current not in parameters and legacy in parameters
+    }
+    dropped_parameters = {name for name in dropped if not accepts_kwargs and name not in parameters}
+    if accepts_rng and not reverse_renames and not dropped_parameters:
+        return fn
+
+    changes = [f"{current!r} as {legacy!r}" for current, legacy in reverse_renames.items()]
+    changes.extend(f"without {name!r}" for name in dropped_parameters)
+    if not accepts_rng:
+        changes.append("without the keyword-only 'rng' parameter")
+    _warn(
+        f"{role} {getattr(fn, '__name__', type(fn).__name__)!r} uses the pre-1.0 callback "
+        f"signature ({', '.join(changes)}). Update it for the 1.0 callback protocol; legacy "
+        "callbacks will stop working in GerryChain 2.0.",
+        stacklevel=4,
+    )
+
+    @functools.wraps(fn)
+    def wrapped(*args: Any, **kwargs: Any) -> R:
+        if not accepts_rng:
+            kwargs.pop("rng", None)
+        for name in dropped_parameters:
+            kwargs.pop(name, None)
+        for current, legacy in reverse_renames.items():
+            if current in kwargs:
+                kwargs[legacy] = kwargs.pop(current)
+        return fn(*args, **kwargs)
+
+    cast(Any, wrapped).__gerrychain_legacy_adapter__ = True
+    return wrapped
+
+
+def adapt_legacy_cut_choice(fn: Callable[..., R]) -> Callable[..., R]:
+    """Adapt both legacy cut-choice signatures without changing the tree implementation."""
+    try:
+        parameters = inspect.signature(fn).parameters
+    except (TypeError, ValueError):
+        return fn
+
+    names = list(parameters)
+    if names[:3] != ["populated_graph", "region_surcharge", "cut_edge_list"] or "rng" in parameters:
+        return adapt_legacy_callable(fn, "Cut-choice function")
+
+    _warn(
+        f"Cut-choice function {getattr(fn, '__name__', type(fn).__name__)!r} uses the pre-1.0 "
+        "(populated_graph, region_surcharge, cut_edge_list) signature. Put cut_edge_list first and "
+        "accept populated_graph, region_surcharge, and rng by keyword; the legacy signature will "
+        "stop working in GerryChain 2.0.",
+        stacklevel=4,
+    )
+
+    @functools.wraps(fn)
+    def wrapped(
+        cut_edge_list: Any,
+        /,
+        *,
+        populated_graph: Any,
+        region_surcharge: Any,
+        rng: Any,
+    ) -> R:
+        return fn(populated_graph, region_surcharge, cut_edge_list)
+
+    cast(Any, wrapped).__gerrychain_legacy_adapter__ = True
+    return wrapped
+
+
+def deprecated_alias(
+    old_name: str,
+    new_name: str,
+    fn: Callable[P, R],
+) -> Callable[P, R]:
+    """Return a warning wrapper for a renamed public callable."""
+
+    @functools.wraps(fn)
+    def wrapped(*args: P.args, **kwargs: P.kwargs) -> R:
+        _warn(
+            f"{old_name} is deprecated; use {new_name} instead. The legacy name will be removed "
+            "in GerryChain 2.0."
+        )
+        return fn(*args, **kwargs)
+
+    wrapped.__name__ = old_name.rsplit(".", 1)[-1]
+    wrapped.__qualname__ = wrapped.__name__
+    return wrapped
+
+
+def allow_legacy_missing_rng(fn: Callable[P, R]) -> Callable[P, R]:
+    """Allow a direct pre-1.0 call that omits the now-required ``rng`` keyword."""
+    fn_name = getattr(fn, "__qualname__", type(fn).__qualname__)
+
+    @functools.wraps(fn)
+    def wrapped(*args: P.args, **kwargs: P.kwargs) -> R:
+        mutable_kwargs = cast(dict[str, Any], kwargs)
+        if "rng" not in mutable_kwargs:
+            mutable_kwargs["rng"] = random.Random()
+            _warn(
+                f"{fn_name}() now requires the keyword-only 'rng' argument. Omitting it "
+                "is deprecated and will fail in GerryChain 2.0."
+            )
+        return fn(*args, **mutable_kwargs)
+
+    return wrapped
+
+
+def deprecated_property(old_name: str, new_name: str) -> property:
+    """Return a property forwarding a deprecated attribute name to its replacement."""
+
+    def get(instance: object) -> Any:
+        _warn(
+            f"{old_name} is deprecated; use {new_name} instead. The legacy name will be removed "
+            "in GerryChain 2.0."
+        )
+        return getattr(instance, new_name)
+
+    return property(get)
+
+
+def deprecated_lazy_alias(
+    old_name: str,
+    new_name: str,
+    module_name: str,
+    attribute_name: str,
+) -> Callable[..., Any]:
+    """Return a warning wrapper that resolves a moved callable without creating import cycles."""
+
+    def wrapped(*args: Any, **kwargs: Any) -> Any:
+        _warn(
+            f"{old_name} is deprecated; use {new_name} instead. The legacy import will be removed "
+            "in GerryChain 2.0."
+        )
+        fn = getattr(importlib.import_module(module_name), attribute_name)
+        return fn(*args, **kwargs)
+
+    wrapped.__name__ = old_name.rsplit(".", 1)[-1]
+    wrapped.__qualname__ = wrapped.__name__
+    return wrapped
+
+
+def legacy_epsilon_tree_bipartition(*args: Any, **kwargs: Any) -> Any:
+    """Compatibility entry point for the function moved out of ``gerrychain.tree``."""
+    _warn(
+        "gerrychain.tree.epsilon_tree_bipartition is deprecated; import it from "
+        "gerrychain.proposals.tree_proposals instead. The legacy import will be removed in "
+        "GerryChain 2.0."
+    )
+    from .proposals.tree_proposals import epsilon_tree_bipartition
+
+    return epsilon_tree_bipartition(*args, **kwargs)
+
+
+def legacy_bipartition_tree_random(*args: Any, **kwargs: Any) -> Any:
+    """Compatibility wrapper for the renamed random bipartition function."""
+    _warn(
+        "gerrychain.tree.bipartition_tree_random is deprecated; use "
+        "bipartition_tree_random_with_num_cuts instead. The legacy name will be removed in "
+        "GerryChain 2.0."
+    )
+    from .tree.bipartition_tree import bipartition_tree_random_with_num_cuts
+
+    num_cuts, nodes = bipartition_tree_random_with_num_cuts(*args, **kwargs)
+    return nodes if num_cuts else None
+
+
+def legacy_predecessors(graph: Any, root: Any) -> dict[Any, Any]:
+    """Compatibility wrapper for ``Graph.predecessors``."""
+    _warn(
+        "gerrychain.tree.predecessors is deprecated; use graph.predecessors instead. The legacy "
+        "function will be removed in GerryChain 2.0."
+    )
+    return graph.predecessors(root)
+
+
+def legacy_successors(graph: Any, root: Any) -> dict[Any, list[Any]]:
+    """Compatibility wrapper for ``Graph.successors``."""
+    _warn(
+        "gerrychain.tree.successors is deprecated; use graph.successors instead. The legacy "
+        "function will be removed in GerryChain 2.0."
+    )
+    return graph.successors(root)
+
+
+def legacy_flips(partition: Any) -> Any:
+    """Compatibility updater returning ``Partition.flips``."""
+    _warn(
+        "gerrychain.updaters.flips is deprecated; use partition.flips directly. The legacy "
+        "updater will be removed in GerryChain 2.0."
+    )
+    return partition.flips
+
+
+def legacy_give_constant_attribute(graph: Any, attribute: Any, value: Any) -> None:
+    """Compatibility wrapper for the removed grid helper."""
+    _warn(
+        "gerrychain.grid.give_constant_attribute is deprecated; set node data directly instead. "
+        "The helper will be removed in GerryChain 2.0."
+    )
+    for node in graph.node_indices:
+        graph.node_data(node)[attribute] = value

--- a/gerrychain/_deprecated.py
+++ b/gerrychain/_deprecated.py
@@ -1,4 +1,9 @@
-"""Compatibility helpers for APIs deprecated after GerryChain 0.3.2."""
+"""Compatibility helpers for APIs deprecated after GerryChain 0.3.2.
+
+The adapters in this module keep legacy handling outside the canonical implementations and
+signatures. Every compatibility path emits a :class:`DeprecationWarning` that identifies the
+replacement API and its planned removal in GerryChain 2.0.
+"""
 
 from __future__ import annotations
 
@@ -15,6 +20,13 @@ R = TypeVar("R")
 
 
 def _warn(message: str, stacklevel: int = 3) -> None:
+    """Emit a deprecation warning attributed to the compatibility helper's caller.
+
+    Args:
+        message (str): Warning text shown to the user.
+        stacklevel (int, optional): Number of stack frames for :func:`warnings.warn` to skip when
+            reporting the warning location. Defaults to 3.
+    """
     warnings.warn(message, DeprecationWarning, stacklevel=stacklevel)
 
 
@@ -23,7 +35,29 @@ def deprecated_parameters(
     ignored: Mapping[str, str] | None = None,
     defaults: Mapping[str, Any] | None = None,
 ) -> Callable[[Callable[P, R]], Callable[P, R]]:
-    """Translate legacy keywords before calling a function with its canonical signature."""
+    """Translate legacy keywords before calling a function with its canonical signature.
+
+    Renamed arguments are translated to their canonical names, ignored arguments are removed, and
+    legacy defaults are supplied when their canonical argument is absent. Each compatibility
+    action emits a :class:`DeprecationWarning`. The decorated callable retains the wrapped
+    function's metadata and canonical signature.
+
+    Args:
+        renamed (Mapping[str, str] | None, optional): Mapping from legacy keyword names to
+            canonical keyword names.
+        ignored (Mapping[str, str] | None, optional): Mapping from removed keyword names to the
+            explanation appended to their warning. Supplied values are discarded.
+        defaults (Mapping[str, Any] | None, optional): Mapping from canonical keyword names to
+            legacy default values. A default is supplied only when the argument was not otherwise
+            bound.
+
+    Returns:
+        Callable[[Callable[P, R]], Callable[P, R]]: A decorator that adds the requested legacy
+            argument handling.
+
+    Raises:
+        TypeError: When a caller supplies both a legacy keyword and its canonical replacement.
+    """
     renamed = {} if renamed is None else renamed
     ignored = {} if ignored is None else ignored
     defaults = {} if defaults is None else defaults
@@ -83,7 +117,28 @@ def adapt_legacy_callable(
     renamed: Mapping[str, str] | None = None,
     dropped: Collection[str] = (),
 ) -> Callable[..., R]:
-    """Adapt an old callback to current keyword names and the keyword-only ``rng`` protocol."""
+    """Adapt an old callback to current keyword names and the keyword-only ``rng`` protocol.
+
+    The returned wrapper removes an unsupported ``rng`` keyword, translates current keyword names
+    back to names declared by the legacy callback, and drops selected unsupported keywords. A
+    warning is emitted when the adapter is created, not on every callback invocation. Callbacks
+    that already satisfy the protocol are returned unchanged.
+
+    Args:
+        fn (Callable[..., R]): Callback to inspect and, if necessary, wrap.
+        role (str): Human-readable callback role used in the warning message.
+        renamed (Mapping[str, str] | None, optional): Mapping from current keyword names to their
+            pre-1.0 names.
+        dropped (Collection[str], optional): Current keyword names to omit when the callback does
+            not accept them.
+
+    Returns:
+        Callable[..., R]: The original callback when it is compatible or cannot be inspected;
+            otherwise, a metadata-preserving compatibility wrapper.
+
+    Note:
+        Exceptions raised by the callback propagate directly. The adapter never retries a call.
+    """
     if getattr(fn, "__gerrychain_legacy_adapter__", False):
         return fn
 
@@ -134,7 +189,19 @@ def adapt_legacy_callable(
 
 
 def adapt_legacy_cut_choice(fn: Callable[..., R]) -> Callable[..., R]:
-    """Adapt both legacy cut-choice signatures without changing the tree implementation."""
+    """Adapt both legacy cut-choice signatures without changing the tree implementation.
+
+    The three-argument legacy form accepted ``populated_graph``, ``region_surcharge``, and
+    ``cut_edge_list`` positionally. Its wrapper accepts the current form, where
+    ``cut_edge_list`` is positional and the remaining inputs, including ``rng``, are keyword-only.
+    Other callback shapes are handled by :func:`adapt_legacy_callable`.
+
+    Args:
+        fn (Callable[..., R]): Cut-choice callback to inspect and, if necessary, wrap.
+
+    Returns:
+        Callable[..., R]: A callback compatible with the current cut-choice protocol.
+    """
     try:
         parameters = inspect.signature(fn).parameters
     except (TypeError, ValueError):
@@ -172,7 +239,18 @@ def deprecated_alias(
     new_name: str,
     fn: Callable[P, R],
 ) -> Callable[P, R]:
-    """Return a warning wrapper for a renamed public callable."""
+    """Return a warning wrapper for a renamed public callable.
+
+    Args:
+        old_name (str): Fully qualified legacy name shown in warnings and exposed as the wrapper's
+            name.
+        new_name (str): Fully qualified replacement name shown in warnings.
+        fn (Callable[P, R]): Canonical callable to invoke.
+
+    Returns:
+        Callable[P, R]: A metadata-preserving wrapper that warns on every call before forwarding
+            all arguments to ``fn``.
+    """
 
     @functools.wraps(fn)
     def wrapped(*args: P.args, **kwargs: P.kwargs) -> R:
@@ -188,7 +266,17 @@ def deprecated_alias(
 
 
 def allow_legacy_missing_rng(fn: Callable[P, R]) -> Callable[P, R]:
-    """Allow a direct pre-1.0 call that omits the now-required ``rng`` keyword."""
+    """Allow a direct pre-1.0 call that omits the now-required ``rng`` keyword.
+
+    Calls that omit ``rng`` receive a new, independently seeded :class:`random.Random` instance
+    and emit a :class:`DeprecationWarning`. Calls that supply ``rng`` pass through unchanged.
+
+    Args:
+        fn (Callable[P, R]): Callable whose current protocol requires keyword-only ``rng``.
+
+    Returns:
+        Callable[P, R]: A metadata-preserving wrapper that supplies ``rng`` when necessary.
+    """
     fn_name = getattr(fn, "__qualname__", type(fn).__qualname__)
 
     @functools.wraps(fn)
@@ -206,7 +294,21 @@ def allow_legacy_missing_rng(fn: Callable[P, R]) -> Callable[P, R]:
 
 
 def deprecated_property(old_name: str, new_name: str, *, writable: bool = False) -> property:
-    """Return a property forwarding a deprecated attribute name to its replacement."""
+    """Return a property forwarding a deprecated attribute name to its replacement.
+
+    Reading the property warns and returns the canonical attribute. When ``writable`` is true,
+    assignment also warns and delegates to the canonical attribute so its setter and validation
+    behavior remain in effect.
+
+    Args:
+        old_name (str): Fully qualified legacy attribute name shown in warnings.
+        new_name (str): Replacement attribute name on the same instance.
+        writable (bool, optional): Whether the deprecated property should forward assignments.
+            Defaults to ``False``.
+
+    Returns:
+        property: A deprecated forwarding property.
+    """
 
     def warn() -> None:
         _warn(
@@ -235,7 +337,21 @@ def deprecated_lazy_alias(
     module_name: str,
     attribute_name: str,
 ) -> Callable[..., Any]:
-    """Return a warning wrapper that resolves a moved callable without creating import cycles."""
+    """Return a warning wrapper that resolves a moved callable without creating import cycles.
+
+    Lazy resolution avoids import cycles for public functions that moved between modules.
+
+    Args:
+        old_name (str): Fully qualified legacy name shown in warnings and exposed as the wrapper's
+            name.
+        new_name (str): Fully qualified replacement name shown in warnings.
+        module_name (str): Import path containing the replacement callable.
+        attribute_name (str): Replacement callable's name within ``module_name``.
+
+    Returns:
+        Callable[..., Any]: A wrapper that warns, resolves the replacement, and forwards all
+            arguments when invoked.
+    """
 
     def wrapped(*args: Any, **kwargs: Any) -> Any:
         _warn(
@@ -251,7 +367,15 @@ def deprecated_lazy_alias(
 
 
 def legacy_epsilon_tree_bipartition(*args: Any, **kwargs: Any) -> Any:
-    """Compatibility entry point for the function moved out of ``gerrychain.tree``."""
+    """Compatibility entry point for the function moved out of ``gerrychain.tree``.
+
+    Args:
+        *args (Any): Positional arguments forwarded to the canonical function.
+        **kwargs (Any): Keyword arguments forwarded to the canonical function.
+
+    Returns:
+        Any: The canonical function's return value.
+    """
     _warn(
         "gerrychain.tree.epsilon_tree_bipartition is deprecated; import it from "
         "gerrychain.proposals.tree_proposals instead. The legacy import will be removed in "
@@ -263,7 +387,20 @@ def legacy_epsilon_tree_bipartition(*args: Any, **kwargs: Any) -> Any:
 
 
 def legacy_bipartition_tree_random(*args: Any, **kwargs: Any) -> Any:
-    """Compatibility wrapper for the renamed random bipartition function."""
+    """Compatibility wrapper for the renamed random bipartition function.
+
+    The canonical function returns ``(num_cuts, nodes)``. This wrapper warns and returns only the
+    selected nodes, or ``None`` when no cut was found, matching ``bipartition_tree_random``.
+
+    Args:
+        *args (Any): Positional arguments forwarded to
+            ``bipartition_tree_random_with_num_cuts``.
+        **kwargs (Any): Keyword arguments forwarded to
+            ``bipartition_tree_random_with_num_cuts``.
+
+    Returns:
+        Any: The selected node set when at least one cut was found; otherwise, ``None``.
+    """
     _warn(
         "gerrychain.tree.bipartition_tree_random is deprecated; use "
         "bipartition_tree_random_with_num_cuts instead. The legacy name will be removed in "
@@ -276,7 +413,15 @@ def legacy_bipartition_tree_random(*args: Any, **kwargs: Any) -> Any:
 
 
 def legacy_predecessors(graph: Any, root: Any) -> dict[Any, Any]:
-    """Compatibility wrapper for ``Graph.predecessors``."""
+    """Compatibility wrapper for ``Graph.predecessors``.
+
+    Args:
+        graph (Any): Graph providing a ``predecessors`` method.
+        root (Any): Root node passed to that method.
+
+    Returns:
+        dict[Any, Any]: Mapping from each reached node to its predecessor.
+    """
     _warn(
         "gerrychain.tree.predecessors is deprecated; use graph.predecessors instead. The legacy "
         "function will be removed in GerryChain 2.0."
@@ -285,7 +430,15 @@ def legacy_predecessors(graph: Any, root: Any) -> dict[Any, Any]:
 
 
 def legacy_successors(graph: Any, root: Any) -> dict[Any, list[Any]]:
-    """Compatibility wrapper for ``Graph.successors``."""
+    """Compatibility wrapper for ``Graph.successors``.
+
+    Args:
+        graph (Any): Graph providing a ``successors`` method.
+        root (Any): Root node passed to that method.
+
+    Returns:
+        dict[Any, list[Any]]: Mapping from each reached node to its successor nodes.
+    """
     _warn(
         "gerrychain.tree.successors is deprecated; use graph.successors instead. The legacy "
         "function will be removed in GerryChain 2.0."
@@ -294,7 +447,14 @@ def legacy_successors(graph: Any, root: Any) -> dict[Any, list[Any]]:
 
 
 def legacy_flips(partition: Any) -> Any:
-    """Compatibility updater returning ``Partition.flips``."""
+    """Compatibility updater returning ``Partition.flips``.
+
+    Args:
+        partition (Any): Partition whose flips should be returned.
+
+    Returns:
+        Any: The partition's flips mapping, or ``None`` when it has no flips.
+    """
     _warn(
         "gerrychain.updaters.flips is deprecated; use partition.flips directly. The legacy "
         "updater will be removed in GerryChain 2.0."
@@ -303,7 +463,16 @@ def legacy_flips(partition: Any) -> Any:
 
 
 def legacy_give_constant_attribute(graph: Any, attribute: Any, value: Any) -> None:
-    """Compatibility wrapper for the removed grid helper."""
+    """Compatibility wrapper for the removed grid helper.
+
+    This preserves the removed ``gerrychain.grid.give_constant_attribute`` helper while directing
+    callers to mutate node data explicitly.
+
+    Args:
+        graph (Any): Graph exposing ``node_indices`` and mutable ``node_data`` mappings.
+        attribute (Any): Node attribute key to set.
+        value (Any): Value assigned to every node.
+    """
     _warn(
         "gerrychain.grid.give_constant_attribute is deprecated; set node data directly instead. "
         "The helper will be removed in GerryChain 2.0."

--- a/gerrychain/accept.py
+++ b/gerrychain/accept.py
@@ -7,6 +7,7 @@ Last Updated: 11 Jan 2024
 import random
 from typing import Protocol
 
+from gerrychain._deprecated import allow_legacy_missing_rng
 from gerrychain.partition import Partition
 
 
@@ -16,6 +17,7 @@ class AcceptanceFn(Protocol):
     def __call__(self, partition: Partition, /, *, rng: random.Random) -> bool: ...
 
 
+@allow_legacy_missing_rng
 def always_accept(partition: Partition, *, rng: random.Random) -> bool:
     """Always accepts the a proposed next state.
 
@@ -29,6 +31,7 @@ def always_accept(partition: Partition, *, rng: random.Random) -> bool:
     return True
 
 
+@allow_legacy_missing_rng
 def cut_edge_accept(partition: Partition, *, rng: random.Random) -> bool:
     """Always accepts the flip if the number of cut_edges decreases Otherwise, uses the Metropolis.
 

--- a/gerrychain/chain.py
+++ b/gerrychain/chain.py
@@ -32,7 +32,11 @@ import numpy
 from collections.abc import Callable, Iterable, Iterator
 from typing import Any, cast
 
-from gerrychain._deprecated import adapt_legacy_callable, deprecated_parameters
+from gerrychain._deprecated import (
+    adapt_legacy_callable,
+    deprecated_parameters,
+    deprecated_property,
+)
 from gerrychain._rng import make_rng
 from gerrychain.accept import AcceptanceFn, always_accept
 from gerrychain.constraints import ConstraintFn, Validator
@@ -151,6 +155,13 @@ class MarkovChain:
         self.rng = make_rng(rng)
         # Last: the setter validates initial_partition against the constraints when both are given.
         self.constraints = constraints
+
+    proposal = deprecated_property("MarkovChain.proposal", "proposal_fn", writable=True)
+    accept = deprecated_property("MarkovChain.accept", "acceptance_fn", writable=True)
+    initial_state = deprecated_property(
+        "MarkovChain.initial_state", "initial_partition", writable=True
+    )
+    is_valid = deprecated_property("MarkovChain.is_valid", "constraints", writable=True)
 
     @property
     def constraints(self) -> Validator:

--- a/gerrychain/chain.py
+++ b/gerrychain/chain.py
@@ -32,6 +32,7 @@ import numpy
 from collections.abc import Callable, Iterable, Iterator
 from typing import Any, cast
 
+from gerrychain._deprecated import adapt_legacy_callable, deprecated_parameters
 from gerrychain._rng import make_rng
 from gerrychain.accept import AcceptanceFn, always_accept
 from gerrychain.constraints import ConstraintFn, Validator
@@ -95,6 +96,13 @@ class MarkovChain:
         "__locked",
     )
 
+    @deprecated_parameters(
+        renamed={
+            "proposal": "proposal_fn",
+            "accept": "acceptance_fn",
+            "initial_state": "initial_partition",
+        }
+    )
     def __init__(
         self,
         proposal_fn: ProposalFn | None = None,
@@ -372,14 +380,28 @@ class MarkovChain:
         self.check_valid()
 
         proposal_fn = self.proposal_fn
+        acceptance_fn = self.acceptance_fn
         total_steps = self.total_steps
         initial_partition = self.initial_partition
         assert proposal_fn is not None and total_steps is not None and initial_partition is not None
 
-        return self.__run(proposal_fn, total_steps, initial_partition)
+        proposal_fn = cast(
+            ProposalFn,
+            adapt_legacy_callable(proposal_fn, "Proposal function"),
+        )
+        acceptance_fn = cast(
+            AcceptanceFn,
+            adapt_legacy_callable(acceptance_fn, "Acceptance function"),
+        )
+
+        return self.__run(proposal_fn, acceptance_fn, total_steps, initial_partition)
 
     def __run(
-        self, proposal_fn: ProposalFn, total_steps: int, initial_partition: Partition
+        self,
+        proposal_fn: ProposalFn,
+        acceptance_fn: AcceptanceFn,
+        total_steps: int,
+        initial_partition: Partition,
     ) -> Iterator[Partition]:
         """Generator over one run: propose, validate, accept/reject, yield, for each step.
 
@@ -400,7 +422,7 @@ class MarkovChain:
                 state.parent = None
 
                 if self._validator(proposed_next_state):
-                    if self.acceptance_fn(proposed_next_state, rng=self.rng):
+                    if acceptance_fn(proposed_next_state, rng=self.rng):
                         state = proposed_next_state
                     self.state = state
                     self.counter += 1

--- a/gerrychain/constraints/__init__.py
+++ b/gerrychain/constraints/__init__.py
@@ -35,6 +35,7 @@ from .compactness import (
 )
 from .contiguity import (
     contiguous,
+    contiguous_bfs,
     no_more_discontiguous,
     single_flip_contiguous,
 )
@@ -63,6 +64,7 @@ __all__ = [
     "no_worse_L1_reciprocal_polsby_popper",
     "no_worse_L_minus_1_polsby_popper",
     "contiguous",
+    "contiguous_bfs",
     "no_more_discontiguous",
     "single_flip_contiguous",
     "Validator",

--- a/gerrychain/constraints/__init__.py
+++ b/gerrychain/constraints/__init__.py
@@ -27,10 +27,10 @@ from .bounds import (
 )
 from .compactness import (
     L2_polsby_popper,
-    L_1_polsby_popper,
-    L_1_reciprocal_polsby_popper,
+    L1_polsby_popper,
+    L1_reciprocal_polsby_popper,
     L_minus_1_polsby_popper,
-    no_worse_L_1_reciprocal_polsby_popper,
+    no_worse_L1_reciprocal_polsby_popper,
     no_worse_L_minus_1_polsby_popper,
 )
 from .contiguity import (
@@ -56,11 +56,11 @@ __all__ = [
     "SelfConfiguringUpperBound",
     "UpperBound",
     "WithinPercentRangeOfBounds",
-    "L_1_polsby_popper",
-    "L_1_reciprocal_polsby_popper",
+    "L1_polsby_popper",
+    "L1_reciprocal_polsby_popper",
     "L2_polsby_popper",
     "L_minus_1_polsby_popper",
-    "no_worse_L_1_reciprocal_polsby_popper",
+    "no_worse_L1_reciprocal_polsby_popper",
     "no_worse_L_minus_1_polsby_popper",
     "contiguous",
     "no_more_discontiguous",

--- a/gerrychain/constraints/bounds.py
+++ b/gerrychain/constraints/bounds.py
@@ -1,7 +1,7 @@
 from collections.abc import Callable, Iterable
 from typing import Generic, ParamSpec
 
-from .._deprecated import deprecated_parameters
+from .._deprecated import deprecated_parameters, deprecated_property
 from ..partition import Partition
 
 P = ParamSpec("P")
@@ -34,6 +34,8 @@ class Bounds(Generic[P]):
         """
         self.value_fn = value_fn
         self.bounds = bounds
+
+    func = deprecated_property("Bounds.func", "value_fn", writable=True)
 
     def __call__(self, *args: P.args, **kwargs: P.kwargs) -> bool:
         lower, upper = self.bounds
@@ -72,6 +74,8 @@ class UpperBound(Generic[P]):
         self.value_fn = value_fn
         self.bound = bound
 
+    func = deprecated_property("UpperBound.func", "value_fn", writable=True)
+
     def __call__(self, *args: P.args, **kwargs: P.kwargs) -> bool:
         return self.value_fn(*args, **kwargs) <= self.bound
 
@@ -106,6 +110,8 @@ class LowerBound(Generic[P]):
         """
         self.value_fn = value_fn
         self.bound = bound
+
+    func = deprecated_property("LowerBound.func", "value_fn", writable=True)
 
     def __call__(self, *args: P.args, **kwargs: P.kwargs) -> bool:
         return self.value_fn(*args, **kwargs) >= self.bound
@@ -143,6 +149,8 @@ class SelfConfiguringUpperBound:
         """
         self.value_fn = value_fn
         self.bound = None
+
+    func = deprecated_property("SelfConfiguringUpperBound.func", "value_fn", writable=True)
 
     def __call__(self, partition: Partition) -> bool:
         if not self.bound:
@@ -185,6 +193,8 @@ class SelfConfiguringLowerBound:
         self.value_fn = value_fn
         self.bound = None
         self.epsilon = epsilon
+
+    func = deprecated_property("SelfConfiguringLowerBound.func", "value_fn", writable=True)
 
     def __call__(self, partition: Partition) -> bool:
         if not self.bound:
@@ -230,6 +240,8 @@ class WithinPercentRangeOfBounds:
         self.percent = float(percent) / 100.0
         self.lbound = None
         self.ubound = None
+
+    func = deprecated_property("WithinPercentRangeOfBounds.func", "value_fn", writable=True)
 
     def __call__(self, partition: Partition) -> bool:
         if not (self.lbound and self.ubound):

--- a/gerrychain/constraints/bounds.py
+++ b/gerrychain/constraints/bounds.py
@@ -1,6 +1,7 @@
 from collections.abc import Callable, Iterable
 from typing import Generic, ParamSpec
 
+from .._deprecated import deprecated_parameters
 from ..partition import Partition
 
 P = ParamSpec("P")
@@ -20,6 +21,7 @@ class Bounds(Generic[P]):
 
     """
 
+    @deprecated_parameters(renamed={"func": "value_fn"})
     def __init__(self, value_fn: Callable[P, Iterable[float]], bounds: tuple[float, float]) -> None:
         """Initialize a Bounds instance.
 
@@ -55,6 +57,7 @@ class UpperBound(Generic[P]):
     and ``False`` otherwise.
     """
 
+    @deprecated_parameters(renamed={"func": "value_fn"})
     def __init__(self, value_fn: Callable[P, float], bound: float) -> None:
         """Initialize a UpperBound instance.
 
@@ -89,6 +92,7 @@ class LowerBound(Generic[P]):
     and ``False`` otherwise.
     """
 
+    @deprecated_parameters(renamed={"func": "value_fn"})
     def __init__(self, value_fn: Callable[P, float], bound: float) -> None:
         """Initialize a LowerBound instance.
 
@@ -126,6 +130,7 @@ class SelfConfiguringUpperBound:
     and ``False`` otherwise.
     """
 
+    @deprecated_parameters(renamed={"func": "value_fn"})
     def __init__(self, value_fn: Callable[[Partition], float]) -> None:
         """Initialize a SelfConfiguringUpperBound instance.
 
@@ -164,6 +169,7 @@ class SelfConfiguringLowerBound:
     and ``False`` otherwise.
     """
 
+    @deprecated_parameters(renamed={"func": "value_fn"})
     def __init__(self, value_fn: Callable[[Partition], float], epsilon: float = 0.05) -> None:
         """Initialize a SelfConfiguringLowerBound instance.
 
@@ -206,6 +212,7 @@ class WithinPercentRangeOfBounds:
     percentage range of the initial value, and ``False`` otherwise.
     """
 
+    @deprecated_parameters(renamed={"func": "value_fn"})
     def __init__(self, value_fn: Callable[[Partition], float], percent: float) -> None:
         """Initialize a WithinPercentRangeOfBounds instance.
 

--- a/gerrychain/constraints/compactness.py
+++ b/gerrychain/constraints/compactness.py
@@ -4,7 +4,7 @@ from ..partition import Partition
 from .bounds import SelfConfiguringLowerBound, SelfConfiguringUpperBound
 
 
-def L_1_reciprocal_polsby_popper(partition: Partition) -> float:
+def L1_reciprocal_polsby_popper(partition: Partition) -> float:
     """Returns the :math:`L^1` norm of the reciprocal Polsby-Popper scores for the given partition.
 
     Args:
@@ -16,7 +16,7 @@ def L_1_reciprocal_polsby_popper(partition: Partition) -> float:
     return sum(1 / value for value in partition["polsby_popper"].values())
 
 
-def L_1_polsby_popper(partition: Partition) -> float:
+def L1_polsby_popper(partition: Partition) -> float:
     """Returns the :math:`L^1` norm of the Polsby-Popper scores for the given partition.
 
     Args:
@@ -54,4 +54,4 @@ def L_minus_1_polsby_popper(partition: Partition) -> float:
 
 no_worse_L_minus_1_polsby_popper = SelfConfiguringLowerBound(L_minus_1_polsby_popper)
 
-no_worse_L_1_reciprocal_polsby_popper = SelfConfiguringUpperBound(L_1_reciprocal_polsby_popper)
+no_worse_L1_reciprocal_polsby_popper = SelfConfiguringUpperBound(L1_reciprocal_polsby_popper)

--- a/gerrychain/constraints/contiguity.py
+++ b/gerrychain/constraints/contiguity.py
@@ -1,6 +1,7 @@
 from collections import deque
 from collections.abc import Hashable, Iterable
 
+from .._deprecated import deprecated_alias
 from ..graph import FrozenGraph, Graph
 from ..partition import Partition
 from .bounds import SelfConfiguringLowerBound
@@ -185,3 +186,15 @@ def contiguous_components(partition: Partition) -> dict[Hashable, list[Graph]]:
         connected_components_in_each_partition[part] = subgraph.subgraphs_for_connected_components()
 
     return connected_components_in_each_partition
+
+
+affected_parts = deprecated_alias(
+    "gerrychain.constraints.contiguity.affected_parts",
+    "_affected_parts",
+    _affected_parts,
+)
+contiguous_bfs = deprecated_alias(
+    "gerrychain.constraints.contiguous_bfs",
+    "contiguous",
+    contiguous,
+)

--- a/gerrychain/grid.py
+++ b/gerrychain/grid.py
@@ -21,6 +21,7 @@ from typing import Any, cast
 import networkx
 from networkx.generators.lattice import grid_2d_graph
 
+from gerrychain._deprecated import deprecated_alias, legacy_give_constant_attribute
 from gerrychain.graph import Graph
 from gerrychain.metrics import polsby_popper
 from gerrychain.partition import Partition
@@ -166,6 +167,12 @@ class Grid(Partition):
         """
         m, n = self.dimensions
         return [[cast(int, self.assignment.mapping[(i, j)]) for i in range(m)] for j in range(n)]
+
+    as_list_of_lists = deprecated_alias(
+        "Grid.as_list_of_lists",
+        "Grid._as_list_of_lists",
+        _as_list_of_lists,
+    )
 
 
 def _create_grid_nx_graph(dimensions: tuple[int, ...], with_diagonals: bool) -> Graph:
@@ -315,3 +322,26 @@ def _color_quadrants(node: tuple[int, int], thresholds: tuple[int, int]) -> int:
     y_color = 0 if y < thresholds[1] else 2
 
     return x_color + y_color
+
+
+create_grid_graph = deprecated_alias(
+    "gerrychain.grid.create_grid_graph",
+    "_create_grid_nx_graph",
+    _create_grid_nx_graph,
+)
+give_constant_attribute = legacy_give_constant_attribute
+tag_boundary_nodes = deprecated_alias(
+    "gerrychain.grid.tag_boundary_nodes",
+    "_tag_boundary_nodes",
+    _tag_boundary_nodes,
+)
+get_boundary_perim = deprecated_alias(
+    "gerrychain.grid.get_boundary_perim",
+    "_get_boundary_perim",
+    _get_boundary_perim,
+)
+color_quadrants = deprecated_alias(
+    "gerrychain.grid.color_quadrants",
+    "_color_quadrants",
+    _color_quadrants,
+)

--- a/gerrychain/optimization/gingleator.py
+++ b/gerrychain/optimization/gingleator.py
@@ -6,6 +6,7 @@ from typing import Protocol
 
 import numpy as np
 
+from gerrychain._deprecated import deprecated_parameters
 from gerrychain.constraints import Validator, ConstraintFn
 from gerrychain.partition import Partition
 from gerrychain.proposals import ProposalFn
@@ -31,6 +32,12 @@ class Gingleator(SingleMetricOptimizer):
     Gingles districts is one of the litmus tests used in bringing forth a VRA case.
     """
 
+    @deprecated_parameters(
+        renamed={
+            "proposal": "proposal_fn",
+            "score_function": "score_fn",
+        }
+    )
     def __init__(
         self,
         proposal_fn: ProposalFn,

--- a/gerrychain/optimization/optimization.py
+++ b/gerrychain/optimization/optimization.py
@@ -4,6 +4,7 @@ from collections.abc import Callable, Generator, Iterable
 
 from tqdm import tqdm
 
+from .._deprecated import deprecated_parameters, deprecated_property
 from .._rng import make_rng
 from ..accept import AcceptanceFn, always_accept
 from ..chain import MarkovChain
@@ -35,6 +36,12 @@ class SingleMetricOptimizer:
     optimization run is invoked.
     """
 
+    @deprecated_parameters(
+        renamed={
+            "proposal": "proposal_fn",
+            "optimization_metric": "optimization_metric_fn",
+        }
+    )
     def __init__(
         self,
         proposal_fn: ProposalFn,
@@ -112,6 +119,8 @@ class SingleMetricOptimizer:
             Callable[[Partition], float]: The score function.
         """
         return self._score_fn
+
+    score = deprecated_property("SingleMetricOptimizer.score", "score_fn")
 
     def _is_improvement(self, new_score: float, old_score: float) -> bool:
         """Helper function to determine whether a new score is an improvement over an old score.
@@ -368,6 +377,7 @@ class SingleMetricOptimizer:
 
         return beta_function
 
+    @deprecated_parameters(renamed={"accept": "acceptance_fn"})
     def short_bursts(
         self,
         burst_length: int,
@@ -421,6 +431,7 @@ class SingleMetricOptimizer:
                     self._best_part = part
                     self._best_score = part_score
 
+    @deprecated_parameters(renamed={"beta_function": "beta_fn"})
     def simulated_annealing(
         self,
         num_steps: int,
@@ -496,6 +507,7 @@ class SingleMetricOptimizer:
             with_progress_bar=with_progress_bar,
         )
 
+    @deprecated_parameters(renamed={"accept": "acceptance_fn"})
     def variable_length_short_bursts(
         self,
         num_steps: int,

--- a/gerrychain/partition/assignment.py
+++ b/gerrychain/partition/assignment.py
@@ -7,6 +7,7 @@ from typing import TypeVar, cast
 import numpy
 import pandas
 
+from .._deprecated import deprecated_parameters
 from ..graph import FrozenGraph, Graph
 
 NodeT = TypeVar("NodeT", bound=Hashable)
@@ -173,6 +174,7 @@ class Assignment(Mapping[Hashable, Hashable]):
         return self.mapping
 
     @classmethod
+    @deprecated_parameters(renamed={"assignment": "nodes_to_parts"})
     def from_dict(cls, nodes_to_parts: Mapping[NodeT, PartT] | pandas.Series) -> Assignment:
         """Create an Assignment from a dictionary.
 
@@ -274,6 +276,7 @@ def get_assignment(
     raise TypeError("Assignment must be a mapping or a node attribute key")
 
 
+@deprecated_parameters(renamed={"container": "container_fn"})
 def level_sets(
     mapping: Mapping[NodeT, PartT],
     container_fn: Callable[[], set[NodeT]] = set,

--- a/gerrychain/partition/initial_partition_generators.py
+++ b/gerrychain/partition/initial_partition_generators.py
@@ -39,8 +39,9 @@ schema, it's a lot harder to make a snake-y patchwork of districts.
 import random
 from collections.abc import Hashable, Sequence
 from functools import partial
-from typing import Protocol
+from typing import Protocol, cast
 
+from .._deprecated import adapt_legacy_callable, deprecated_parameters
 from .._rng import make_rng
 
 # frm:  import the new Graph object which encapsulates NX and RX Graph...
@@ -67,6 +68,7 @@ class PartitionFn(Protocol):
     ) -> dict[Hashable, Hashable]: ...
 
 
+@deprecated_parameters(renamed={"method": "bipartition_tree_fn"})
 def recursive_tree_part(
     graph: Graph,
     parts: Sequence[Hashable],
@@ -106,6 +108,14 @@ def recursive_tree_part(
     """
 
     rng = make_rng(rng)
+    bipartition_tree_fn = cast(
+        BipartitionTreeFn,
+        adapt_legacy_callable(
+            bipartition_tree_fn,
+            "Bipartition function",
+            renamed={"single_district_cut": "one_sided_cut"},
+        ),
+    )
     flips = {}
     remaining_nodes = graph.node_indices
 
@@ -585,6 +595,7 @@ def _recursive_seed_part_inner(
     return translated_assignment
 
 
+@deprecated_parameters(renamed={"method": "bipartition_tree_fn"})
 def recursive_seed_part(
     graph: Graph,
     parts: Sequence[Hashable],
@@ -632,6 +643,14 @@ def recursive_seed_part(
     """
 
     rng = make_rng(rng)
+    bipartition_tree_fn = cast(
+        BipartitionTreeFn,
+        adapt_legacy_callable(
+            bipartition_tree_fn,
+            "Bipartition function",
+            renamed={"single_district_cut": "one_sided_cut"},
+        ),
+    )
 
     # Note: recursive_seed_part() is never used in the GerryCode codebase, but it is
     # part of the public API.

--- a/gerrychain/partition/partition.py
+++ b/gerrychain/partition/partition.py
@@ -92,6 +92,7 @@ import geopandas
 import networkx
 import numpy
 
+from gerrychain._deprecated import adapt_legacy_callable, deprecated_parameters
 from gerrychain.graph.graph import FrozenGraph, Graph
 
 from .._rng import make_rng
@@ -228,6 +229,12 @@ class Partition:
         self.subgraphs = SubgraphView(self.graph, self.parts)
 
     @classmethod
+    @deprecated_parameters(
+        renamed={"method": "partition_fn"},
+        ignored={
+            "flips": "This argument did not affect random-assignment generation in GerryChain 0.3.2."
+        },
+    )
     def from_random_assignment(
         cls,
         graph: Graph,
@@ -267,6 +274,10 @@ class Partition:
 
         total_pop = sum(graph.node_data(n)[pop_col] for n in graph)
         ideal_pop = total_pop / n_parts
+        partition_fn = cast(
+            PartitionFn,
+            adapt_legacy_callable(partition_fn, "Initial-partition function"),
+        )
 
         assignment = partition_fn(
             graph=graph,

--- a/gerrychain/proposals/spectral_proposals.py
+++ b/gerrychain/proposals/spectral_proposals.py
@@ -5,6 +5,7 @@ from typing import cast
 
 from numpy import linalg as LA
 
+from .._deprecated import deprecated_parameters
 from .._rng import make_rng
 from ..graph import FrozenGraph, Graph
 from ..partition import Partition
@@ -12,6 +13,7 @@ from ..proposals import ProposalFn
 
 
 # frm: only ever used in this file - but maybe it is used externally?
+@deprecated_parameters(renamed={"graph": "subgraph"})
 def spectral_cut(
     subgraph: Graph | FrozenGraph,
     part_labels: Sequence[Hashable],

--- a/gerrychain/proposals/tree_proposals.py
+++ b/gerrychain/proposals/tree_proposals.py
@@ -3,6 +3,11 @@ from collections.abc import Callable, Hashable, Iterable, Iterator, Sequence
 from functools import partial
 from typing import Literal, cast
 
+from gerrychain._deprecated import (
+    adapt_legacy_callable,
+    allow_legacy_missing_rng,
+    deprecated_parameters,
+)
 from gerrychain._rng import make_rng
 from gerrychain.partition import Partition
 
@@ -45,6 +50,8 @@ class ValueWarning(UserWarning):
     pass
 
 
+@deprecated_parameters(renamed={"method": "bipartition_tree_fn"})
+@allow_legacy_missing_rng
 def epsilon_tree_bipartition(
     subgraph_to_split: Graph | FrozenGraph,
     parts: Sequence[Hashable],
@@ -89,6 +96,14 @@ def epsilon_tree_bipartition(
     ub_pop = pop_target * (1 + epsilon)
     check_pop = lambda x: lb_pop <= x <= ub_pop
 
+    bipartition_tree_fn = cast(
+        BipartitionTreeFn,
+        adapt_legacy_callable(
+            bipartition_tree_fn,
+            "Bipartition function",
+            renamed={"single_district_cut": "one_sided_cut"},
+        ),
+    )
     nodes = bipartition_tree_fn(
         subgraph_to_split.subgraph(remaining_nodes),
         pop_col=pop_col,
@@ -189,6 +204,7 @@ def _candidate_district_pairs(
     return draw_without_replacement()
 
 
+@deprecated_parameters(renamed={"method": "bipartition_tree_fn"})
 def recom(
     partition: Partition,
     pop_col: str,
@@ -260,6 +276,15 @@ def recom(
     # Bind region_surcharge onto the bipartition_tree_fn. Other bipartition / spanning-tree options
     # (e.g. spanning_tree_fn_kwargs) are configured by passing a pre-bound bipartition_tree_fn, such
     # as partial(bipartition_tree, spanning_tree_fn_kwargs={...}).
+    bipartition_tree_fn = cast(
+        ReComBipartitionTreeFn,
+        adapt_legacy_callable(
+            bipartition_tree_fn,
+            "ReCom bipartition function",
+            renamed={"single_district_cut": "one_sided_cut"},
+            dropped={"region_surcharge"},
+        ),
+    )
     bipartition_tree_fn = cast(
         ReComBipartitionTreeFn,
         partial(bipartition_tree_fn, region_surcharge=region_surcharge),
@@ -347,6 +372,16 @@ def build_recom_proposal_fn(
     return cast(ProposalFn, proposal_fn)
 
 
+@deprecated_parameters(
+    renamed={
+        "balance_edge_fn": "find_balanced_edge_cuts_fn",
+        "M": "max_balanced_edge_cuts",
+    },
+    ignored={
+        "choice": "Cut selection now uses the proposal's rng.",
+    },
+    defaults={"max_balanced_edge_cuts": 1},
+)
 def reversible_recom(
     partition: Partition,
     pop_col: str,
@@ -385,6 +420,17 @@ def reversible_recom(
     """
 
     rng = make_rng(rng)
+    find_balanced_edge_cuts_fn = cast(
+        FindBalancedEdgeCutsFn,
+        adapt_legacy_callable(
+            find_balanced_edge_cuts_fn,
+            "Balanced-edge-cut function",
+            renamed={
+                "single_district_cut": "one_sided_cut",
+                "rootnode_choice_fn": "choice",
+            },
+        ),
+    )
 
     def dist_pair_edges(
         part: Partition, a: Hashable, b: Hashable

--- a/gerrychain/tree/__init__.py
+++ b/gerrychain/tree/__init__.py
@@ -23,6 +23,13 @@ There is additional documentation in each of these sub-modules.
 
 """
 
+from .._deprecated import (
+    deprecated_lazy_alias,
+    legacy_bipartition_tree_random,
+    legacy_epsilon_tree_bipartition,
+    legacy_predecessors,
+    legacy_successors,
+)
 from .bipartition_tree import (
     BalanceError,
     BipartitionTreeFn,
@@ -37,6 +44,29 @@ from .bipartition_tree import (
 )
 from .spanning_tree import random_spanning_tree, uniform_spanning_tree
 
+predecessors = legacy_predecessors
+successors = legacy_successors
+bipartition_tree_random = legacy_bipartition_tree_random
+epsilon_tree_bipartition = legacy_epsilon_tree_bipartition
+recursive_tree_part = deprecated_lazy_alias(
+    "gerrychain.tree.recursive_tree_part",
+    "gerrychain.partition.recursive_tree_part",
+    "gerrychain.partition.initial_partition_generators",
+    "recursive_tree_part",
+)
+recursive_seed_part = deprecated_lazy_alias(
+    "gerrychain.tree.recursive_seed_part",
+    "gerrychain.partition.recursive_seed_part",
+    "gerrychain.partition.initial_partition_generators",
+    "recursive_seed_part",
+)
+get_max_prime_factor_less_than = deprecated_lazy_alias(
+    "gerrychain.tree.get_max_prime_factor_less_than",
+    "gerrychain.partition.initial_partition_generators.get_max_prime_factor_less_than",
+    "gerrychain.partition.initial_partition_generators",
+    "get_max_prime_factor_less_than",
+)
+
 __all__ = [
     "bipartition_tree",
     "bipartition_tree_random_with_num_cuts",
@@ -50,4 +80,11 @@ __all__ = [
     "ReComBipartitionTreeFn",
     "uniform_spanning_tree",
     "random_spanning_tree",
+    "predecessors",
+    "successors",
+    "bipartition_tree_random",
+    "epsilon_tree_bipartition",
+    "recursive_tree_part",
+    "recursive_seed_part",
+    "get_max_prime_factor_less_than",
 ]

--- a/gerrychain/tree/bipartition_tree.py
+++ b/gerrychain/tree/bipartition_tree.py
@@ -34,6 +34,7 @@ from functools import partial
 from inspect import signature
 from typing import NamedTuple, Protocol, cast
 
+from .._deprecated import adapt_legacy_callable, adapt_legacy_cut_choice, deprecated_parameters
 from .._rng import make_rng
 from ..graph import FrozenGraph, Graph
 from .spanning_tree import random_spanning_tree
@@ -414,6 +415,12 @@ def _bfs_predecessors_and_successors_for_tree(
     return pred, succ
 
 
+@deprecated_parameters(
+    renamed={
+        "one_sided_cut": "single_district_cut",
+        "choice": "rootnode_choice_fn",
+    }
+)
 def find_balanced_edge_cuts_contraction(
     h: _PopulatedGraph,
     single_district_cut: bool = False,
@@ -601,6 +608,12 @@ def _nodes_in_subtree(start: Hashable, succ: dict[Hashable, list[Hashable]]) -> 
 
 
 # frm: used externally by tree_proposals.py
+@deprecated_parameters(
+    renamed={
+        "one_sided_cut": "single_district_cut",
+        "choice": "rootnode_choice_fn",
+    }
+)
 def find_balanced_edge_cuts_memoization(
     h: _PopulatedGraph,
     single_district_cut: bool = False,
@@ -991,6 +1004,27 @@ def _internal_bipartition_tree(
     if region_surcharge is None:
         region_surcharge = {}
 
+    spanning_tree_fn = adapt_legacy_callable(
+        spanning_tree_fn,
+        "Spanning-tree function",
+        dropped={"region_surcharge"},
+    )
+    find_balanced_edge_cuts_fn = cast(
+        FindBalancedEdgeCutsFn,
+        adapt_legacy_callable(
+            find_balanced_edge_cuts_fn,
+            "Balanced-edge-cut function",
+            renamed={
+                "single_district_cut": "one_sided_cut",
+                "rootnode_choice_fn": "choice",
+            },
+        ),
+    )
+    cut_choice_fn = cast(
+        CutChoiceFn | RegionAwareCutChoiceFn,
+        adapt_legacy_cut_choice(cut_choice_fn),
+    )
+
     if spanning_tree_fn_kwargs and "region_surcharge" in spanning_tree_fn_kwargs:
         raise ValueError(
             "Pass region_surcharge via the region_surcharge parameter, not inside "
@@ -1097,6 +1131,15 @@ def _internal_bipartition_tree(
             raise Exception("This should never happen...")
 
 
+@deprecated_parameters(
+    renamed={
+        "graph": "subgraph_to_split",
+        "balance_edge_fn": "find_balanced_edge_cuts_fn",
+        "one_sided_cut": "single_district_cut",
+        "choice": "rootnode_choice_fn",
+        "cut_choice": "cut_choice_fn",
+    }
+)
 def bipartition_tree(
     subgraph_to_split: GraphLike,
     pop_col: str,
@@ -1380,6 +1423,15 @@ def _get_possible_edge_cuts_and_populated_graph(
     raise RuntimeError(f"Could not find a possible cut after {max_attempts} attempts.")
 
 
+@deprecated_parameters(
+    renamed={
+        "graph": "subgraph_to_split",
+        "balance_edge_fn": "find_balanced_edge_cuts_fn",
+        "one_sided_cut": "single_district_cut",
+        "choice": "rootnode_choice_fn",
+        "cut_choice": "cut_choice_fn",
+    }
+)
 def bipartition_tree_random_with_num_cuts(
     subgraph_to_split: GraphLike,
     pop_col: str,

--- a/gerrychain/tree/spanning_tree.py
+++ b/gerrychain/tree/spanning_tree.py
@@ -74,6 +74,7 @@ from typing import cast
 
 import rustworkx
 
+from .._deprecated import deprecated_parameters
 from .._rng import make_rng
 from ..graph import FrozenGraph, Graph
 
@@ -273,6 +274,11 @@ def random_spanning_tree(
     return minimum_spanning_tree
 
 
+@deprecated_parameters(
+    ignored={
+        "choice": "Node selection now uses the function's rng.",
+    }
+)
 def uniform_spanning_tree(
     graph: Graph | FrozenGraph,
     region_surcharge: dict[str, float] | None = None,  # accepted but unused

--- a/gerrychain/updaters/__init__.py
+++ b/gerrychain/updaters/__init__.py
@@ -2,6 +2,7 @@ from .compactness import (
     boundary_nodes,
     exterior_boundaries,
     exterior_boundaries_as_a_set,
+    flips,
     interior_boundaries,
     perimeter,
 )
@@ -20,6 +21,7 @@ __all__ = [
     "Tally",
     "DataTally",
     "boundary_nodes",
+    "flips",
     "perimeter",
     "exterior_boundaries",
     "interior_boundaries",

--- a/gerrychain/updaters/compactness.py
+++ b/gerrychain/updaters/compactness.py
@@ -4,11 +4,14 @@ import collections
 from collections.abc import Hashable
 from typing import TYPE_CHECKING
 
+from .._deprecated import legacy_flips
 from .cut_edges import on_edge_flow
 from .flows import on_flow
 
 if TYPE_CHECKING:
     from ..partition.partition import Partition
+
+flips = legacy_flips
 
 
 def boundary_nodes(partition: Partition, alias: str = "boundary_nodes") -> set[Hashable]:

--- a/gerrychain/updaters/county_splits.py
+++ b/gerrychain/updaters/county_splits.py
@@ -4,6 +4,8 @@ from collections.abc import Callable, Hashable, Sequence
 from enum import Enum
 from typing import TYPE_CHECKING, NamedTuple
 
+from .._deprecated import deprecated_alias, deprecated_parameters
+
 if TYPE_CHECKING:
     from ..partition.partition import Partition
 
@@ -118,6 +120,7 @@ def compute_county_splits(
     return new_county_dict
 
 
+@deprecated_parameters(renamed={"reg_attr_lst": "region_attr_lst"})
 def tally_region_splits(region_attr_lst: Sequence[str]) -> Callable[[Partition], dict[str, int]]:
     """A naive updater for tallying the number of times a region attribute is split.
 
@@ -168,3 +171,10 @@ def total_region_splits(partition: Partition, region_attr: str) -> int:
             split[partition.graph.node_data(node2)[region_attr]] += 1
 
     return sum(1 for value in split.values() if value > 0)
+
+
+total_reg_splits = deprecated_alias(
+    "gerrychain.updaters.county_splits.total_reg_splits",
+    "total_region_splits",
+    total_region_splits,
+)

--- a/gerrychain/updaters/cut_edges.py
+++ b/gerrychain/updaters/cut_edges.py
@@ -4,6 +4,7 @@ import collections
 from collections.abc import Hashable, Iterable
 from typing import TYPE_CHECKING
 
+from .._deprecated import deprecated_alias
 from .flows import neighbor_flips, on_edge_flow
 
 if TYPE_CHECKING:
@@ -138,3 +139,20 @@ def cut_edges(partition: Partition) -> set[tuple[int, int]]:
     new, obsolete = _new_cuts(partition), _obsolete_cuts(partition)
 
     return (parent["cut_edges"] | new) - obsolete
+
+
+put_edges_into_parts = deprecated_alias(
+    "gerrychain.updaters.cut_edges.put_edges_into_parts",
+    "_put_edges_into_parts",
+    _put_edges_into_parts,
+)
+new_cuts = deprecated_alias(
+    "gerrychain.updaters.cut_edges.new_cuts",
+    "_new_cuts",
+    _new_cuts,
+)
+obsolete_cuts = deprecated_alias(
+    "gerrychain.updaters.cut_edges.obsolete_cuts",
+    "_obsolete_cuts",
+    _obsolete_cuts,
+)

--- a/gerrychain/updaters/election.py
+++ b/gerrychain/updaters/election.py
@@ -7,6 +7,8 @@ from typing import TYPE_CHECKING, cast
 import gerrychain.metrics.partisan as pm
 from gerrychain.updaters.tally import DataTally
 
+from .._deprecated import deprecated_parameters, deprecated_property
+
 if TYPE_CHECKING:
     from ..partition.partition import Partition
 
@@ -69,6 +71,7 @@ class Election:
             partition's dictionary of updaters.
     """
 
+    @deprecated_parameters(renamed={"parties_to_columns": "party_names_to_node_attribute_names"})
     def __init__(
         self,
         name: str,
@@ -136,6 +139,12 @@ class Election:
         }
 
         self.updater = ElectionUpdater(self)
+
+    columns = deprecated_property("Election.columns", "node_attribute_names")
+    parties_to_columns = deprecated_property(
+        "Election.parties_to_columns",
+        "party_names_to_node_attribute_names",
+    )
 
     def __str__(self) -> str:
         return (

--- a/gerrychain/updaters/flows.py
+++ b/gerrychain/updaters/flows.py
@@ -52,6 +52,8 @@ import functools
 from collections.abc import Callable, Hashable
 from typing import TYPE_CHECKING, Protocol, TypeVar, cast
 
+from .._deprecated import deprecated_parameters
+
 if TYPE_CHECKING:
     from ..partition.partition import Partition
 
@@ -145,6 +147,7 @@ def flows_from_changes(
     return flows
 
 
+@deprecated_parameters(renamed={"initializer": "initializer_fn"})
 def on_flow(
     initializer_fn: Callable[[Partition], dict[KeyT, ValueT]], alias: str
 ) -> Callable[[FlowUpdateFn[ValueT]], Callable[..., dict[KeyT, ValueT]]]:
@@ -316,6 +319,7 @@ def compute_edge_flows(
     return edge_flows
 
 
+@deprecated_parameters(renamed={"initializer": "initializer_fn"})
 def on_edge_flow(
     initializer_fn: Callable[[Partition], dict[KeyT, ValueT]], alias: str
 ) -> Callable[[EdgeFlowUpdateFn[ValueT]], Callable[[Partition], dict[KeyT, ValueT]]]:

--- a/gerrychain/updaters/tally.py
+++ b/gerrychain/updaters/tally.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, cast
 
 import pandas
 
+from .._deprecated import deprecated_parameters, deprecated_property
 from .flows import flows_from_changes, on_flow
 
 if TYPE_CHECKING:
@@ -130,6 +131,7 @@ class Tally:
 
     __slots__ = ["fields", "alias", "dtype_fn"]
 
+    @deprecated_parameters(renamed={"dtype": "dtype_fn"})
     def __init__(
         self,
         fields: str | list[str],
@@ -155,6 +157,8 @@ class Tally:
         self.fields = fields
         self.alias = alias
         self.dtype_fn = dtype_fn
+
+    dtype = deprecated_property("Tally.dtype", "dtype_fn")
 
     def __call__(self, partition: Partition) -> dict[Hashable, float]:
         if partition.parent is None:

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -1,0 +1,217 @@
+import inspect
+import random
+import warnings
+from collections.abc import Callable, Hashable, Sequence
+from typing import Any, cast
+
+import networkx
+import pytest
+
+from gerrychain import MarkovChain, Partition
+from gerrychain.accept import always_accept
+from gerrychain.constraints import (
+    Bounds,
+    L1_polsby_popper,
+    L1_reciprocal_polsby_popper,
+    no_worse_L1_reciprocal_polsby_popper,
+)
+from gerrychain.graph import Graph
+from gerrychain.partition.assignment import Assignment, level_sets
+from gerrychain.tree import bipartition_tree
+from gerrychain.tree.bipartition_tree import _Cut, _PopulatedGraph
+from gerrychain.updaters import Election, Tally
+
+
+class State:
+    parent: "State | None" = None
+
+
+def legacy_proposal(state: Partition) -> Partition:
+    return cast(Partition, State())
+
+
+def legacy_acceptance(state: Partition) -> bool:
+    return True
+
+
+def canonical_proposal(state: Partition, *, rng: random.Random) -> Partition:
+    return cast(Partition, State())
+
+
+def test_legacy_chain_keywords_and_callbacks_run() -> None:
+    with pytest.warns(DeprecationWarning) as caught:
+        chain = cast(Any, MarkovChain)(
+            proposal=legacy_proposal,
+            constraints=lambda state: True,
+            accept=legacy_acceptance,
+            initial_state=cast(Partition, State()),
+            total_steps=2,
+        )
+        assert len(list(chain)) == 2
+
+    messages = [str(warning.message) for warning in caught]
+    for old_name, new_name in (
+        ("proposal", "proposal_fn"),
+        ("accept", "acceptance_fn"),
+        ("initial_state", "initial_partition"),
+    ):
+        assert any(old_name in message and new_name in message for message in messages)
+    assert sum("pre-1.0 callback signature" in message for message in messages) == 2
+
+
+def test_canonical_chain_does_not_warn() -> None:
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always", DeprecationWarning)
+        chain = MarkovChain(
+            proposal_fn=canonical_proposal,
+            constraints=lambda state: True,
+            acceptance_fn=always_accept,
+            initial_partition=cast(Partition, State()),
+            total_steps=2,
+        )
+        assert len(list(chain)) == 2
+
+    assert caught == []
+
+
+def test_legacy_and_canonical_keyword_conflict() -> None:
+    with pytest.raises(TypeError, match="both 'proposal' and 'proposal_fn'"):
+        cast(Any, MarkovChain)(
+            proposal=legacy_proposal,
+            proposal_fn=canonical_proposal,
+            total_steps=1,
+        )
+
+
+def test_legacy_keywords_stay_out_of_canonical_signatures() -> None:
+    assert "proposal" not in inspect.signature(MarkovChain).parameters
+    assert "flips" not in inspect.signature(Partition.from_random_assignment).parameters
+    assert "dtype" not in inspect.signature(Tally).parameters
+
+
+def test_ignored_random_assignment_flips_warns(three_by_three_grid: Graph) -> None:
+    for node in three_by_three_grid.node_indices:
+        three_by_three_grid.node_data(node)["population"] = 1
+
+    def partition_fn(
+        *,
+        graph: Graph,
+        parts: Sequence[Hashable],
+        pop_target: float,
+        pop_col: str,
+        epsilon: float,
+        rng: random.Random,
+    ) -> dict[Hashable, Hashable]:
+        return {node: 0 for node in graph.node_indices}
+
+    with pytest.warns(DeprecationWarning, match="flips.*deprecated and ignored"):
+        partition = cast(Any, Partition.from_random_assignment)(
+            three_by_three_grid,
+            n_parts=1,
+            epsilon=0.01,
+            pop_col="population",
+            partition_fn=partition_fn,
+            flips={0: 1},
+        )
+
+    assert len(partition.parts) == 1
+
+
+@pytest.mark.parametrize(
+    ("call", "old_name", "new_name"),
+    [
+        (lambda: cast(Any, Bounds)(func=lambda: [1], bounds=(0, 2)), "func", "value_fn"),
+        (
+            lambda: cast(Any, Assignment.from_dict)(assignment={0: 1}),
+            "assignment",
+            "nodes_to_parts",
+        ),
+        (lambda: cast(Any, level_sets)({0: 1}, container=set), "container", "container_fn"),
+        (lambda: cast(Any, Tally)("population", dtype=float), "dtype", "dtype_fn"),
+        (
+            lambda: cast(Any, Election)("election", parties_to_columns={"A": "votes"}),
+            "parties_to_columns",
+            "party_names_to_node_attribute_names",
+        ),
+    ],
+)
+def test_representative_renamed_keywords_warn(
+    call: Callable[[], object],
+    old_name: str,
+    new_name: str,
+) -> None:
+    with pytest.warns(DeprecationWarning) as caught:
+        call()
+    message = str(caught[0].message)
+    assert old_name in message
+    assert new_name in message
+
+
+def test_l1_names_are_canonical() -> None:
+    from gerrychain import constraints
+
+    assert constraints.L1_polsby_popper is L1_polsby_popper
+    assert constraints.L1_reciprocal_polsby_popper is L1_reciprocal_polsby_popper
+    assert constraints.no_worse_L1_reciprocal_polsby_popper is no_worse_L1_reciprocal_polsby_popper
+    assert not hasattr(constraints, "L_1_polsby_popper")
+
+
+def test_legacy_callback_type_error_is_not_retried() -> None:
+    calls = 0
+
+    def broken_proposal(state: Partition) -> Partition:
+        nonlocal calls
+        calls += 1
+        raise TypeError("inside proposal")
+
+    with pytest.warns(DeprecationWarning, match="pre-1.0 callback signature"):
+        chain = MarkovChain(
+            proposal_fn=cast(Any, broken_proposal),
+            initial_partition=cast(Partition, State()),
+            total_steps=2,
+        )
+        iterator = iter(chain)
+
+    next(iterator)
+    with pytest.raises(TypeError, match="inside proposal"):
+        next(iterator)
+    assert calls == 1
+
+
+def test_legacy_tree_keywords_and_callbacks_run() -> None:
+    nx_graph = networkx.path_graph(4)
+    networkx.set_node_attributes(nx_graph, {node: 1 for node in nx_graph}, "population")
+    graph = Graph.from_networkx(nx_graph)
+
+    def spanning_tree_fn(graph: Graph) -> Graph:
+        return graph
+
+    def find_cuts(
+        populated_graph: _PopulatedGraph,
+        one_sided_cut: bool = False,
+        choice: Callable[[Sequence[Hashable]], Hashable] = random.choice,
+    ) -> list[_Cut]:
+        return [_Cut((1, 2), 1, frozenset({0, 1}))]
+
+    def cut_choice(cuts: list[_Cut]) -> _Cut:
+        return cuts[0]
+
+    with pytest.warns(DeprecationWarning) as caught:
+        nodes = cast(Any, bipartition_tree)(
+            graph=graph,
+            pop_col="population",
+            pop_target=2,
+            epsilon=0.01,
+            spanning_tree_fn=spanning_tree_fn,
+            balance_edge_fn=find_cuts,
+            one_sided_cut=False,
+            cut_choice=cut_choice,
+        )
+
+    assert nodes == frozenset({0, 1})
+    messages = [str(warning.message) for warning in caught]
+    assert any(
+        "balance_edge_fn" in message and "find_balanced_edge_cuts_fn" in message
+        for message in messages
+    )
+    assert any("pre-1.0 callback signature" in message for message in messages)

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -13,6 +13,11 @@ from gerrychain.constraints import (
     Bounds,
     L1_polsby_popper,
     L1_reciprocal_polsby_popper,
+    LowerBound,
+    SelfConfiguringLowerBound,
+    SelfConfiguringUpperBound,
+    UpperBound,
+    WithinPercentRangeOfBounds,
     no_worse_L1_reciprocal_polsby_popper,
 )
 from gerrychain.graph import Graph
@@ -72,6 +77,39 @@ def test_canonical_chain_does_not_warn() -> None:
         assert len(list(chain)) == 2
 
     assert caught == []
+
+
+@pytest.mark.parametrize(
+    ("old_name", "new_name"),
+    [
+        ("proposal", "proposal_fn"),
+        ("accept", "acceptance_fn"),
+        ("initial_state", "initial_partition"),
+        ("is_valid", "constraints"),
+    ],
+)
+def test_legacy_chain_attributes_are_read_write_aliases(
+    old_name: str,
+    new_name: str,
+) -> None:
+    chain = MarkovChain(total_steps=1)
+    if old_name == "initial_state":
+        value: object = cast(Partition, State())
+    elif old_name == "is_valid":
+        value = lambda state: True
+    else:
+        value = lambda state: state
+
+    with pytest.warns(DeprecationWarning, match=rf"{old_name}.*{new_name}"):
+        setattr(chain, old_name, value)
+    canonical_value = getattr(chain, new_name)
+    if old_name == "is_valid":
+        assert canonical_value(cast(Partition, State()))
+    else:
+        assert canonical_value is value
+
+    with pytest.warns(DeprecationWarning, match=rf"{old_name}.*{new_name}"):
+        assert getattr(chain, old_name) is canonical_value
 
 
 def test_legacy_and_canonical_keyword_conflict() -> None:
@@ -145,6 +183,28 @@ def test_representative_renamed_keywords_warn(
     message = str(caught[0].message)
     assert old_name in message
     assert new_name in message
+
+
+@pytest.mark.parametrize(
+    "bound",
+    [
+        Bounds(lambda value: [value], (0, 2)),
+        UpperBound(lambda value: value, 2),
+        LowerBound(lambda value: value, 0),
+        SelfConfiguringUpperBound(lambda partition: 1),
+        SelfConfiguringLowerBound(lambda partition: 1),
+        WithinPercentRangeOfBounds(lambda partition: 1, 5),
+    ],
+)
+def test_legacy_bounds_func_is_a_read_write_alias(bound: object) -> None:
+    replacement = lambda value: value
+
+    with pytest.warns(DeprecationWarning, match=r"\.func.*value_fn"):
+        setattr(bound, "func", replacement)
+    assert getattr(bound, "value_fn") is replacement
+
+    with pytest.warns(DeprecationWarning, match=r"\.func.*value_fn"):
+        assert getattr(bound, "func") is replacement
 
 
 def test_l1_names_are_canonical() -> None:


### PR DESCRIPTION
## Summary

This PR restores compatibility for many GerryChain 0.3.2 call patterns whose names or callback signatures changed during the 1.0 work. Legacy calls continue to run with actionable `DeprecationWarning` messages, while the canonical 1.0 signatures remain unchanged.

The warnings identify the replacement API and state that the compatibility path will be removed in GerryChain 2.0.

Not all pre-1.0 behavior is restored, but I made sure that workflows documented in readthedocs were covered.

## What changed

- Added shared compatibility helpers in `gerrychain._deprecated` for the following:
  - renamed and ignored parameters;
  - legacy defaults;
  - renamed public functions and properties;
  - moved functions that must be resolved lazily;
  - callbacks that do not yet accept the keyword-only `rng` argument; and
  - legacy tree callback parameter names and argument ordering.
- Restored renamed parameters across partitions, updaters, constraints, optimizers, proposals, tree algorithms, and assignment helpers.
- Kept removed parameters out of the canonical signatures. Calls using those parameters are handled by wrappers and receive a warning.
- Adapted pre-1.0 proposal, acceptance, bipartition, balanced-cut, spanning-tree, and cut-choice callbacks at their shared call sites.
- Restored moved or renamed public entry points in `gerrychain.tree`, `gerrychain.grid`, `gerrychain.updaters`, and `gerrychain.constraints`.
- Reverted to `L1` as the canonical spelling for the compactness helpers (in hindsight `L_1` was confusing when the proper symbol is $L^1$ and not $L_1$)
- Restored deprecated attribute access for:
  - `MarkovChain.proposal`, `.accept`, `.initial_state`, and `.is_valid`; and
  - `.func` on all Bounds classes.

## Compatibility behavior

- Supplying a legacy and canonical parameter name together raises a clear `TypeError`.
- Legacy callbacks are inspected and adapted once before use. Exceptions raised inside a callback are not caught and retried.
- Canonical 1.0 calls do not emit deprecation warnings.
- Deprecated calls identify the old name, its replacement, and the planned 2.0 removal.

## Tests

- Added focused tests for renamed parameters, aliases, ignored arguments, callback adaptation, warning messages, canonical signatures, and legacy read/write attributes.
- Full test suite: `533 passed, 9 skipped, 2 xfailed`.

## Exclusions

This PR did not restore:

- the pre-1.0 `Graph` API or other behavior made obsolete by the RustworkX migration;
- the old `ReCom` interface;
- old positional layouts where parameters were reordered or inserted; or
- global `random.seed(...)` control over the new explicit RNG streams;

## Reviewer Notes

- Thorough review not required. A quick sanity check to make sure I haven't missed anything substantial is appreciated.